### PR TITLE
Add a `time` property to the `raf` service props

### DIFF
--- a/src/services/raf.js
+++ b/src/services/raf.js
@@ -22,7 +22,6 @@ class Raf extends Service {
    */
   init() {
     const loop = () => {
-      // todo: add params to the trigger
       this.trigger(this.props);
 
       if (!this.isTicking) {
@@ -52,7 +51,9 @@ class Raf extends Service {
    * @type {Object}
    */
   get props() {
-    return {};
+    return {
+      time: window.performance.now(),
+    };
   }
 }
 


### PR DESCRIPTION
This PR adds a `time` property to the props of the `raf` service.

Usage in a component:

```js
class MyComponent extends Base {
  ticked({ time }) {
    console.log(time);
  }
}
```

Usage with the `raf` service : 

```js
import { useRaf } from '@studiometa/js-toolkit/services';

const { add, remove } = useRaf();

add('id', ({ time }) => {
  console.log(time);

  if (time > 1000) {
    remove('id');
  }
});