### PR TITLE
Use Github Actions to publish to NPM on each release 

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,34 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run deploy
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "demo:dev": "parcel demo/index.html --out-dir demo/dist",
     "demo:build": "parcel build demo/index.html --out-dir demo/dist",
     "build": "rm -rf dist/ && babel --source-maps --out-dir dist/ src/",
-    "deploy": "npm run build && cp package.json dist/ && cd dist/ && npm publish --access public --tag alpha && rm package.json"
+    "deploy": "npm run build && cp package.json dist/ && cd dist/ && npm publish --tag alpha && rm package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a Github action to publish the package to NPM on each release.