### PR TITLE
Add unit tests for the EventManager class

### DIFF
--- a/src/abstracts/EventManager.js
+++ b/src/abstracts/EventManager.js
@@ -36,15 +36,11 @@ export default class EventManager {
    * @return {EventManager}          The current instance.
    */
   $off(event, listener) {
-    if (!Array.isArray(this.events[event])) {
-      return this;
-    }
     // If no event specified, we remove them all.
     if (!event) {
       this.events = {};
       return this;
     }
-
     // If no listener have been specified, we remove all
     // the listeners for the given event.
     if (!listener) {

--- a/tests/EventManager.spec.js
+++ b/tests/EventManager.spec.js
@@ -1,0 +1,102 @@
+import EventManager from '../src/abstracts/EventManager';
+
+describe('EventManager class', () => {
+  it('can register callbacks to events', () => {
+    const eventManager = new EventManager();
+    const foo = jest.fn();
+    eventManager.$on('foo', foo);
+    expect(eventManager.events.foo[0]).toEqual(foo);
+
+    eventManager.$emit('foo');
+    eventManager.$emit('foo', 'bar', 'baz');
+
+    expect(foo).toHaveBeenCalledTimes(2);
+    expect(foo).toHaveBeenCalledWith('bar', 'baz');
+  });
+
+  it('returns a method to unbind the binded function', () => {
+    const eventManager = new EventManager();
+    const foo = jest.fn();
+    const unbind = eventManager.$on('foo', foo);
+
+    eventManager.$emit('foo');
+    unbind();
+    eventManager.$emit('foo');
+
+    expect(foo).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails silently when trying to unbind an unbounded method', () => {
+    const eventManager = new EventManager();
+    const foo = jest.fn();
+    const bar = jest.fn();
+
+    eventManager.$on('foo', foo);
+    eventManager.$emit('foo');
+    eventManager.$off('foo', bar);
+
+    expect(eventManager.events.foo).toHaveLength(1);
+    expect(eventManager.events.foo[0]).toBe(foo);
+  });
+
+  it('can unregister a specific callback from an event', () => {
+    const eventManager = new EventManager();
+    const foo = jest.fn();
+    eventManager.$on('foo', foo);
+    eventManager.$emit('foo');
+    eventManager.$off('foo', foo);
+    expect(eventManager.events.foo).toHaveLength(0);
+    eventManager.$emit('foo');
+    expect(foo).toHaveBeenCalledTimes(1);
+  });
+
+  it('can unregister all callbacks from an event', () => {
+    const eventManager = new EventManager();
+    const foo = jest.fn();
+    const bar = jest.fn();
+    eventManager.$on('foo', () => foo());
+    eventManager.$on('foo', () => bar());
+
+    expect(eventManager.events.foo).toHaveLength(2);
+
+    eventManager.$emit('foo');
+    eventManager.$off('foo');
+
+    expect(foo).toHaveBeenCalledTimes(1);
+    expect(bar).toHaveBeenCalledTimes(1);
+    expect(eventManager.events.foo).toHaveLength(0);
+  });
+
+  it('can disable all events from itself', () => {
+    const eventManager = new EventManager();
+    const foo = jest.fn();
+    const bar = jest.fn();
+    eventManager.$on('foo', () => foo());
+    eventManager.$on('bar', () => bar());
+
+    expect(eventManager.events.foo).toHaveLength(1);
+    expect(eventManager.events.bar).toHaveLength(1);
+
+    eventManager.$off();
+
+    expect(eventManager.events.foo).toBeUndefined();
+    expect(eventManager.events.bar).toBeUndefined();
+
+    eventManager.$emit('foo');
+    eventManager.$emit('bar');
+
+    expect(foo).toHaveBeenCalledTimes(0);
+    expect(bar).toHaveBeenCalledTimes(0);
+  });
+
+  it('can listen to an event only once', () => {
+    const eventManager = new EventManager();
+    const foo = jest.fn();
+    eventManager.$once('foo', foo);
+    eventManager.$emit('foo');
+    eventManager.$emit('foo');
+
+    expect(foo).toHaveBeenCalledTimes(1);
+    expect(eventManager.events.foo).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
This PR adds unit tests with Jest for the `EventManager` class. 

@studiometa/js would be interested in a live code review on how these tests were written ? 