### PR TITLE
Add first draft of the documentation for the breakpoint abstract classes

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,6 +9,14 @@ module.exports = {
       { text: 'Guide', link: '/guide/' },
       { text: 'API', link: '/api/' },
       {
+        text: 'Abstracts',
+        link: '/abstracts/',
+        items: [
+          { text: 'BreakpointManager', link: '/abstracts/BreakpointManager.html' },
+          { text: 'BreakpointObserver', link: '/abstracts/BreakpointObserver.html' },
+        ],
+      },
+      {
         text: 'Components',
         link: '/components/',
         items: [

--- a/docs/abstracts/BreakpointManager.md
+++ b/docs/abstracts/BreakpointManager.md
@@ -1,0 +1,40 @@
+---
+sidebar: auto
+sidebarDepth: 5
+prev: /abstracts/
+next: /abstracts/BreakpointObserver.html
+---
+
+# BreakpointManager
+
+A component based on this class will have the capacity to switch components between different breakpoints.
+
+## Examples
+
+### Switch between component classes
+
+In the following example, the `MenuMobile` class will be mounted along the `Menu` class on small devices and destroyed on large devices. The `MenuDesktop` class will be mounted on large devices and destroyed on small ones.
+
+The root element `this.$el` of each classes will be the same.
+
+```js{9-12}
+import { BreakpointManager } from '@studiometa/js-toolkit/abstracts';
+import MenuMobile from './MenuMobile';
+import MenuDesktop from './MenuDesktop';
+
+export default class Menu extends BreakpointManager {
+  get config() {
+    return {
+      name: 'Menu',
+      breakpoints: [
+        ['xxs xs s', MenuMobile],
+        ['m l xl xxl', MenuDesktop],
+      ],
+    };
+  }
+}
+```
+
+:::tip
+See the [`resize` service documentation on breakpoints](/services/resize.html#breakpoint) for a more comprehensive view of the potential values of the `activeBreakpoint` property.
+:::

--- a/docs/abstracts/BreakpointObserver.md
+++ b/docs/abstracts/BreakpointObserver.md
@@ -1,0 +1,50 @@
+---
+sidebar: auto
+sidebarDepth: 5
+prev: /abstracts/BreakpointManager.html
+next: /components/
+---
+
+# BreakpointObserver
+
+A component based on this class will have the capacity to be mounted or destroyed when the current breakpoint changes.
+
+## Examples
+
+### Enable for the given breakpoints
+
+In the following example, the `MobileComponent` class will self mount on devices matching any of the breakpoint defined in the `activeBreakpoint` property, and self destroy on all others:
+
+```js{7}
+import { BreakpointObserver } from '@studiometa/js-toolkit/abstracts';
+
+export default class MobileComponent extends BreakpointObserver {
+  get config() {
+    return {
+      name: 'MobileComponent',
+      activeBreakpoints: 'xxs xs s'
+    };
+  }
+}
+```
+
+### Disable for the given breakpoints
+
+The same behaviour as before can be achieved by specifying all the other breakpoints in the `inactiveBreakpoints` property instead:
+
+```js{7}
+import { BreakpointObserver } from '@studiometa/js-toolkit/abstracts';
+
+export default class MobileComponent extends BreakpointObserver {
+  get config() {
+    return {
+      name: 'MobileComponent',
+      inactiveBreakpoints: 'm l xl xxl',
+    };
+  }
+}
+```
+
+:::tip
+See the [`resize` service documentation on breakpoints](/services/resize.html#breakpoint) for a more comprehensive view of the potential values of the `activeBreakpoint` property.
+:::

--- a/docs/abstracts/readme.md
+++ b/docs/abstracts/readme.md
@@ -1,0 +1,12 @@
+---
+sidebar: auto
+prev: /api/
+next: /components/
+---
+
+# Abstracts
+
+- EventManager
+- Base
+- [BreakpointManager](./BreakpointManager.md)
+- [BreakpointObserver](./BreakpointObserver.md)

--- a/docs/services/resize.md
+++ b/docs/services/resize.md
@@ -71,7 +71,7 @@ This prop will not be available if no `[data-breakpoint]` element was found in t
 :::
 
 ::: tip
-This prop and the following one will work smoothly with the [breakpoint plugin](https://tailwind-config.meta.fr/plugins/breakpoint.html) of our [Tailwind configuration](https://tailwind-config.meta.fr/).
+This prop and the following one will work smoothly with the [breakpoint plugin](https://tailwind-config.meta.fr/plugins/breakpoint.html) of our [Tailwind configuration](https://tailwind-config.meta.fr/) and will use its [defined screens](https://tailwind-config.meta.fr/configuration/#screens) as breakpoints.
 :::
 
 ### `breakpoints`


### PR DESCRIPTION
This PR introduces mechanisms to easily work with breakpoints when creating components:

- The `BreakpointObserver` abstract class allows a component to self mount/destroy by breakpoint
- The `BreakpointManager` abstract class allows a component to switch between different component classes by breakpoint