### PR TITLE
Bugfix/component complex selector

### DIFF
--- a/src/abstracts/Base/children.js
+++ b/src/abstracts/Base/children.js
@@ -42,7 +42,12 @@ function getChild(el, ComponentClass, parent) {
  */
 export function getComponentElements(nameOrSelector, element = document) {
   const selector = `[data-component="${nameOrSelector}"]`;
-  let elements = Array.from(element.querySelectorAll(selector));
+  let elements = [];
+
+  try {
+    elements = Array.from(element.querySelectorAll(selector));
+    // eslint-disable-next-line no-empty
+  } catch {}
 
   // If no child component found with the default selector, try a classic DOM selector
   if (elements.length === 0) {

--- a/tests/abstracts/Base/children.spec.js
+++ b/tests/abstracts/Base/children.spec.js
@@ -1,0 +1,41 @@
+import { getComponentElements } from '~/abstracts/Base/children';
+
+describe('The component resolution', () => {
+  it('should resolve components by name', () => {
+    const component1 = document.createElement('div');
+    component1.setAttribute('data-component', 'Component');
+    const component2 = document.createElement('div');
+    component2.setAttribute('data-component', 'OtherComponent');
+    document.body.appendChild(component1);
+    document.body.appendChild(component2);
+    expect(getComponentElements('Component')).toEqual([component1]);
+  });
+
+  it('should resolve components by CSS selector', () => {
+    const component1 = document.createElement('div');
+    component1.classList.add('component');
+    const component2 = document.createElement('div');
+    component2.setAttribute('data-component', 'component');
+    document.body.appendChild(component1);
+    document.body.appendChild(component2);
+    expect(getComponentElements('.component')).toEqual([component1]);
+  });
+
+  it('should resolve components by complex selector', () => {
+    const link1 = document.createElement('a');
+    link1.href = 'https://www.studiometa.fr';
+    const link2 = document.createElement('a');
+    link2.href = '#anchor';
+    document.body.appendChild(link1);
+    document.body.appendChild(link2);
+    expect(getComponentElements('a[href^="#"]')).toEqual([link2]);
+  });
+
+  it('should resolve components from a custom root element', () => {
+    const root = document.createElement('div');
+    const component = document.createElement('div');
+    component.setAttribute('data-component', 'Component');
+    root.appendChild(component);
+    expect(getComponentElements('Component', root)).toEqual([component]);
+  });
+});

--- a/tests/abstracts/Base/index.spec.js
+++ b/tests/abstracts/Base/index.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-new, require-jsdoc, max-classes-per-file */
-import Base from '../../src/abstracts/Base';
-import wait from '../__utils__/wait';
+import Base from '~/abstracts/Base';
+import wait from '../../__utils__/wait';
 
 describe('The abstract Base class', () => {
   it('must be extended', () => {

--- a/tests/abstracts/EventManager.spec.js
+++ b/tests/abstracts/EventManager.spec.js
@@ -1,5 +1,5 @@
 /* eslint no-underscore-dangle: ["error", { "allow": ["_events"] }] */
-import EventManager from '../../src/abstracts/EventManager';
+import EventManager from '~/abstracts/EventManager';
 
 describe('EventManager class', () => {
   it('can register callbacks to events', () => {

--- a/tests/abstracts/Service.spec.js
+++ b/tests/abstracts/Service.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-new, require-jsdoc, max-classes-per-file */
-import Service from '../../src/abstracts/Service';
+import Service from '~/abstracts/Service';
 
 describe('The abstract Service class', () => {
   it('should be implemented with the `init` and `kill` methods', () => {


### PR DESCRIPTION
This PR fixes the resolution of components by complex selector.

Attribute selectors containing quotes were throwing an error when trying to get the `[data-component="${nameOrSelector}"]` elements as they were multiple quotes in the selector, i.e. `[data-component="a[href^="#"]"]`.

This bugfix adds a simple try/catch combo to avoid throwing an error.