### PR TITLE
Improve the performance of the refs resolution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     '<rootDir>/tests/__setup__/requestAnimationFrame.js',
     '<rootDir>/tests/__setup__/mockBreakpoints.js',
     '<rootDir>/tests/__setup__/ResizeObserver.js',
+    '<rootDir>/tests/__setup__/mockQuerySelectorAllWithScope.js',
   ],
   moduleNameMapper: {
     '~(.*)$': '<rootDir>/src/$1',

--- a/src/abstracts/Base/refs.js
+++ b/src/abstracts/Base/refs.js
@@ -6,16 +6,24 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/:scope
  * @see https://github.com/jonathantneal/element-qsa-scope
  *
- * @param {HTMLElement} element  The element from which the scope is taken.
- * @param {String}      selector The children selector.
- * @param {String}      uniqId   A uniq ID to prefix the selector with.
+ * @param  {HTMLElement} element  The element from which the scope is taken.
+ * @param  {String}      selector The children selector.
+ * @param  {String}      uniqId   A uniq ID to prefix the selector with.
+ * @return {Array}                A list of elements.
  */
 export function scopeSelectorPonyfill(element, selector, uniqId) {
-  const attr = `data-uniq-id`;
-  const scopedSelector = `[${attr}="${uniqId}"] ${selector}`;
-  element.setAttribute(attr, uniqId);
-  const list = Array.from(element.querySelectorAll(scopedSelector));
-  element.removeAttribute(attr);
+  let list = [];
+
+  try {
+    list = Array.from(element.querySelectorAll(`:scope ${selector}`));
+  } catch (err) {
+    const attr = `data-uniq-id`;
+    const scopedSelector = `[${attr}="${uniqId}"] ${selector}`;
+    element.setAttribute(attr, uniqId);
+    list = Array.from(element.querySelectorAll(scopedSelector));
+    element.removeAttribute(attr);
+  }
+
   return list;
 }
 

--- a/tests/__setup__/mockQuerySelectorAllWithScope.js
+++ b/tests/__setup__/mockQuerySelectorAllWithScope.js
@@ -1,0 +1,33 @@
+import nanoid from 'nanoid/non-secure';
+
+export default function mockSelectorWithScope(prototype, methodName) {
+  const originalMethod = prototype[methodName];
+  const spy = jest.spyOn(prototype, methodName);
+
+  spy.mockImplementation(function mockQuerySelectorAllWithScope(selectors) {
+    if (/:scope/i.test(selectors) && this !== document) {
+      // Mock IE11 which does not support the `:scope` selector and throws a syntax error.
+      // eslint-disable-next-line no-underscore-dangle
+      if (global.__SCOPE_PSEUDO_CLASS_SHOULD_FAIL__) {
+        throw new Error('Syntax error');
+      }
+
+      const attr = `data-uniq-id`;
+      const uniqId = nanoid();
+      const scopedSelector = selectors.replace(':scope', `[${attr}="${uniqId}"]`);
+      this.setAttribute(attr, uniqId);
+      const list = originalMethod.call(this, scopedSelector);
+      this.removeAttribute(attr);
+      return list;
+    }
+
+    return originalMethod.call(this, selectors);
+  });
+
+  return spy;
+}
+
+export const spies = [
+  mockSelectorWithScope(Element.prototype, 'querySelectorAll'),
+  mockSelectorWithScope(Document.prototype, 'querySelectorAll'),
+];

--- a/tests/abstracts/Base/refs.spec.js
+++ b/tests/abstracts/Base/refs.spec.js
@@ -82,12 +82,33 @@ describe('The refs resolution', () => {
   it('should not resolve child components refs', () => {
     const div = document.createElement('div');
     div.innerHTML = `
-      <div data-ref="foo"></div>
-      <div data-component="Child">
-        <div data-ref="bar"></div>
+      <div>
+        <div data-ref="foo"></div>
+        <div data-component="Child">
+          <div data-ref="bar"></div>
+        </div>
       </div>
     `;
     const app = new App(div);
     expect(Object.keys(app.$refs)).not.toEqual(['foo', 'bar']);
+  });
+
+  it('should resolve child components refs when the :scope pseudo-class is not supported', () => {
+    // eslint-disable-next-line no-underscore-dangle
+    global.__SCOPE_PSEUDO_CLASS_SHOULD_FAIL__ = true;
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <div>
+        <div data-ref="foo"></div>
+        <div data-component="Child">
+          <div data-ref="bar"></div>
+        </div>
+      </div>
+    `;
+    const app = new App(div);
+    expect(Object.keys(app.$refs)).toEqual(['foo']);
+    expect(Object.keys(app.$refs)).not.toEqual(['foo', 'bar']);
+    // eslint-disable-next-line no-underscore-dangle
+    global.__SCOPE_PSEUDO_CLASS_SHOULD_FAIL__ = false;
   });
 });


### PR DESCRIPTION
The current version ([v1.0.0-beta.3](https://github.com/studiometa/js-toolkit/releases/tag/1.0.0-beta.3)) introduced a ponyfill to resolve the refs following the `:scope` pseudo-class logic in light of some IE11 issue. The introduced ponyfill might have a negative impact on performance, so we use the `:scope` pseudo-class selector where it is available and fallback to the ponyfill version otherwise.

Ping @notjb as you found the bug 😉 