### PR TITLE
Feature/decorator mount when in view

### DIFF
--- a/demo/src/js/components/Skew.js
+++ b/demo/src/js/components/Skew.js
@@ -1,7 +1,7 @@
 import Base from '../../../../src';
 import { matrix } from '../../../../src/utils/css';
 import { damp } from '../../../../src/utils/math';
-import { withIntersectionObserver } from '../../../../src/decorators';
+import { withMountWhenInView } from '../../../../src/decorators';
 
 function clamp(value, min, max) {
   /* eslint-disable no-nested-ternary */
@@ -19,7 +19,7 @@ function clamp(value, min, max) {
   /* eslint-enable no-nested-ternary */
 }
 
-export default class Skew extends withIntersectionObserver(Base) {
+export default class Skew extends withMountWhenInView(Base) {
   static config = {
     name: 'Skew',
   };
@@ -28,22 +28,20 @@ export default class Skew extends withIntersectionObserver(Base) {
 
   dampedSkewY = 0;
 
-  intersected([entry]) {
-    if (entry.intersectionRatio > 0) {
-      this.$services.enable('scrolled');
+  scrolled({ delta, changed }) {
+    if (changed.y && !this.$services.has('ticked')) {
       this.$services.enable('ticked');
-    } else {
-      this.$services.disable('scrolled');
-      this.$services.disable('ticked');
     }
-  }
 
-  scrolled({ delta }) {
     this.skewY = clamp(delta.y * -0.005, -0.1, 0.1);
   }
 
   ticked() {
     this.dampedSkewY = damp(this.skewY, this.dampedSkewY, 0.1);
     this.$el.style.transform = matrix({ skewY: this.dampedSkewY });
+
+    if (Math.abs(this.dampedSkewY - this.skewY) < 0.01) {
+      this.$services.disable('ticked');
+    }
   }
 }

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -16,6 +16,7 @@ module.exports = {
           { text: 'withBreakpointManager', link: '/decorators/withBreakpointManager.html' },
           { text: 'withBreakpointObserver', link: '/decorators/withBreakpointObserver.html' },
           { text: 'withIntersectionObserver', link: '/decorators/withIntersectionObserver.html' },
+          { text: 'withMountWhenInView', link: '/decorators/withMountWhenInView.html' },
         ],
       },
       {

--- a/docs/components/readme.md
+++ b/docs/components/readme.md
@@ -1,6 +1,6 @@
 ---
 sidebar: auto
-prev: /utils/
+prev: /decorators/
 next: /components/Accordion.md
 ---
 

--- a/docs/decorators/withIntersectionObserver.md
+++ b/docs/decorators/withIntersectionObserver.md
@@ -2,7 +2,7 @@
 sidebar: auto
 sidebarDepth: 5
 prev: /decorators/withBreakpointObserver.html
-next: /components/
+next: /decorators/withMountWhenInView.html
 ---
 
 # withIntersectionObserver

--- a/docs/decorators/withMountWhenInView.md
+++ b/docs/decorators/withMountWhenInView.md
@@ -1,0 +1,75 @@
+---
+sidebar: auto
+sidebarDepth: 5
+prev: /decorators/withIntersectionObserver.html
+next: /components/
+---
+
+# withMountWhenInView
+
+Use this decorator to create a component which will mount and destroy itself based on its visibility in the viewport.
+
+## Examples
+
+### Simple usage
+
+```js
+import Base from '@studiometa/js-toolkit';
+import withMountWhenInView from '@studiometa/js-toolkit/decorators/withMountWhenInView';
+
+export default class Component extends withMountWhenInView(Base) {
+  static config = {
+    name: 'Component',
+    log: true,
+  };
+
+  mounted() {
+    this.$log('I am visible!')
+  }
+
+  destroyed() {
+    this.$log('I am no longer visible.');
+  }
+}
+```
+
+### With custom options
+
+You can pass custom options for the `IntersectionObserver` instance by passing a second parameter to the `withMountWhenInView` function:
+
+```js{4-6}
+import Base from '@studiometa/js-toolkit';
+import withMountWhenInView from '@studiometa/js-toolkit/decorators/withMountWhenInView';
+
+export default class Component extends withMountWhenInView(Base, {
+  threshold: 0.5,
+}) {
+  static config = {
+    name: "Component",
+  };
+
+  mounted() {
+    this.$log('I am visible!')
+  }
+
+  destroyed() {
+    this.$log('I am no longer visible.');
+  }
+}
+```
+
+Or at the instance level in the `data-option-intersection-observer` attribute of the rool element:
+
+```html{3-5}
+<div
+  data-component="Component"
+  data-option-intersection-observer='{
+    "threshold": 0.5
+  }'>
+  ...
+</div>
+```
+
+## API
+
+This decorator does not expose a specific API.

--- a/src/abstracts/Base/classes/Services.js
+++ b/src/abstracts/Base/classes/Services.js
@@ -64,7 +64,7 @@ export default class Services {
       return this.disable.bind(this, service);
     }
 
-    if (!hasMethod(this.#base, service) && !SERVICES_MAP[service]) {
+    if (!hasMethod(this.#base, service) || !SERVICES_MAP[service]) {
       return function noop() {};
     }
 

--- a/src/decorators/index.js
+++ b/src/decorators/index.js
@@ -1,5 +1,11 @@
 import withBreakpointManager from './withBreakpointManager';
 import withBreakpointObserver from './withBreakpointObserver';
 import withIntersectionObserver from './withIntersectionObserver';
+import withMountWhenInView from './withMountWhenInView';
 
-export { withBreakpointManager, withBreakpointObserver, withIntersectionObserver };
+export {
+  withBreakpointManager,
+  withBreakpointObserver,
+  withIntersectionObserver,
+  withMountWhenInView,
+};

--- a/src/decorators/withMountWhenInView.js
+++ b/src/decorators/withMountWhenInView.js
@@ -1,0 +1,96 @@
+/**
+ * @typedef {import('../abstracts/Base').default} Base
+ * @typedef {import('../abstracts/Base').BaseOptions} BaseOptions
+ * @typedef {import('../abstracts/Base').BaseComponent} BaseComponent
+ */
+
+/**
+ * @typedef {Object} WithMountWhenInViewOptions
+ * @property {Object} intersectionObserver
+ */
+
+/**
+ * @typedef {Object} WithMountWhenInViewInterface
+ * @property {() => void} terminated
+ * @property {WithMountWhenInViewOptions & BaseOptions} $options
+ */
+
+/**
+ * IntersectionObserver decoration.
+ * @param {BaseComponent} BaseClass The Base class to extend.
+ * @param {Object} [defaultOptions] The options for the IntersectionObserver instance.
+ * @return {BaseComponent}
+ */
+export default (BaseClass, defaultOptions = { threshold: [0, 1] }) =>
+  class extends BaseClass {
+    /**
+     * Class config.
+     * @type {Object}
+     */
+    static config = {
+      ...(BaseClass.config || {}),
+      name: `${BaseClass?.config?.name ?? ''}WithMountWhenInView`,
+      options: {
+        ...(BaseClass?.config?.options || {}),
+        intersectionObserver: Object,
+      },
+    };
+
+    /**
+     * Is the component visible?
+     * @type {Boolean}
+     */
+    #isVisible = false;
+
+    /**
+     * The component's observer.
+     * @type {IntersectionObserver}
+     */
+    #observer;
+
+    /**
+     * Create an observer when the class in instantiated.
+     *
+     * @param {HTMLElement} element The component's root element.
+     */
+    constructor(element) {
+      super(element);
+
+      this.#observer = new IntersectionObserver(
+        (entries) => {
+          const isVisible = entries.reduce((acc, entry) => acc || entry.isIntersecting, false);
+          if (this.#isVisible !== isVisible) {
+            this.#isVisible = isVisible;
+
+            const method = isVisible ? '$mount' : '$destroy';
+            this[method]();
+          }
+        },
+        { ...defaultOptions, ...this.$options.intersectionObserver }
+      );
+
+      this.#observer.observe(this.$el);
+
+      return this;
+    }
+
+    /**
+     * Override the mounting of the component.
+     *
+     * @return {this}
+     */
+    $mount() {
+      if (this.#isVisible) {
+        super.$mount();
+      }
+
+      return this;
+    }
+
+    /**
+     * Disconnect the observer when the component is terminated.
+     */
+    terminated() {
+      this.#observer.disconnect();
+    }
+  };

--- a/tests/decorators/withMountWhenInView.spec.js
+++ b/tests/decorators/withMountWhenInView.spec.js
@@ -1,0 +1,53 @@
+import Base from '~/abstracts/Base';
+import withMountWhenInView from '~/decorators/withMountWhenInView';
+import {
+  beforeAllCallback,
+  afterEachCallback,
+  mockIsIntersecting,
+  intersectionMockInstance,
+} from '../__setup__/mockIntersectionObserver';
+
+beforeAll(() => beforeAllCallback());
+
+let div;
+let instance;
+
+class Foo extends withMountWhenInView(Base) {
+  static config = {
+    name: 'Foo',
+  };
+}
+
+beforeEach(() => {
+  div = document.createElement('div');
+  instance = new Foo(div);
+  instance.$mount();
+});
+
+afterEach(() => afterEachCallback());
+
+describe('The withMountWhenInView decorator', () => {
+  it('should mount the component when in view', () => {
+    mockIsIntersecting(div, true);
+    expect(instance.$isMounted).toBe(true);
+  });
+
+  it('should not mount the component when not in view', () => {
+    mockIsIntersecting(div, false);
+    expect(instance.$isMounted).toBe(false);
+  });
+
+  it('should destroy the component when not in view', () => {
+    mockIsIntersecting(div, true);
+    expect(instance.$isMounted).toBe(true);
+    mockIsIntersecting(div, false);
+    expect(instance.$isMounted).toBe(false);
+  });
+
+  it('should disconnect the observer when terminated', () => {
+    const observer = intersectionMockInstance(div);
+    const disconnect = jest.spyOn(observer, 'disconnect');
+    instance.$terminate();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This PR adds a new decorator to mount and destroy components based on their visibility. 
This can be useful for performance greedy components for example.

```js
import Base from '@studiometa/js-toolkit';
import withMountWhenInView from '@studiometa/js-toolkit/decorators/withMountWhenInView';

export default class Component extends withMountWhenInView(Base) {
  static config = {
    name: 'Component',
    log: true,
  };

  mounted() {
    this.$log('I am visible!')
  }

  destroyed() {
    this.$log('I am no longer visible.');
  }
}
```