### PR TITLE
Bugfix/reset accordion on destroy

### DIFF
--- a/src/components/Accordion/AccordionItem.js
+++ b/src/components/Accordion/AccordionItem.js
@@ -106,6 +106,14 @@ export default class AccordionItem extends Base {
   }
 
   /**
+   * Remove styles on destroy.
+   * @this {AccordionItem & AccordionItemInterface}
+   */
+  destroyed() {
+    styles.remove(this.$refs.container, { visibility: '', height: '' });
+  }
+
+  /**
    * Handler for the click event on the `btn` ref.
    * @this {AccordionItem & AccordionItemInterface}
    */

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -55,14 +55,11 @@ export default class Accordion extends Base {
    * @return {Promise<void>}
    */
   async mounted() {
-    // /** @type {AccordionItem[]} */
-    // const items = await Promise.all(
-    //   this.$children.AccordionItem.map((item) =>
-    //     item instanceof Promise ? item : Promise.resolve(item)
-    //   )
-    // );
-
     this.unbindMethods = this.$children.AccordionItem.map((item, index) => {
+      if (item instanceof Promise) {
+        throw new Error('The AccordionItem component can not be used asynchronously.');
+      }
+
       const unbindOpen = item.$on('open', () => {
         this.$emit('open', item, index);
         if (this.$options.autoclose) {

--- a/tests/components/Accordion/AccordionItem.spec.js
+++ b/tests/components/Accordion/AccordionItem.spec.js
@@ -98,4 +98,10 @@ describe('AccordionItem component', () => {
     await item.open();
     expect(fn).toHaveBeenCalledTimes(3);
   });
+
+  it('should remove styles when destroyed', () => {
+    item.$destroy();
+    expect(item.$refs.container.style.visibility).toBe('');
+    expect(item.$refs.container.style.height).toBe('');
+  });
 });


### PR DESCRIPTION
Remove styles from the AccordionItem component when it is destroyed.

Fixes #42.