### PR TITLE
Add a decorator to add extra configuration to a class

### DIFF
--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -20,6 +20,7 @@ module.exports = {
         items: [
           { text: 'withBreakpointManager', link: '/decorators/withBreakpointManager.html' },
           { text: 'withBreakpointObserver', link: '/decorators/withBreakpointObserver.html' },
+          { text: 'withExtraConfig', link: '/decorators/withExtraConfig.html' },
           { text: 'withIntersectionObserver', link: '/decorators/withIntersectionObserver.html' },
           { text: 'withMountWhenInView', link: '/decorators/withMountWhenInView.html' },
         ],

--- a/packages/docs/decorators/withBreakpointObserver.md
+++ b/packages/docs/decorators/withBreakpointObserver.md
@@ -2,7 +2,7 @@
 sidebar: auto
 sidebarDepth: 5
 prev: /decorators/withBreakpointManager.html
-next: /decorators/withIntersectionObserver.html
+next: /decorators/withExtraConfig.html
 ---
 
 # withBreakpointObserver

--- a/packages/docs/decorators/withExtraConfig.md
+++ b/packages/docs/decorators/withExtraConfig.md
@@ -1,0 +1,78 @@
+---
+sidebar: auto
+sidebarDepth: 5
+prev: /decorators/withBreakpointObserver.html
+next: /decorators/withIntersectionObserver.html
+---
+
+# withExtraConfig
+
+Use this decorator to quickly create variants of an existing class.
+
+## Examples
+
+### Add new refs
+
+This decorator can be used to easily add a new ref to an existing component.
+
+```js
+import Modal from '@studiometa/js-toolkit/components/Modal';
+import withExtraConfig from '@studiometa/js-toolkit/decorators/withExtraConfig';
+
+export default withExtraConfig(Modal, { refs: ['toggle'] });
+```
+
+### Change default options
+
+Components can define default values for their options, this decorator can be used to change them without the hassle of re-writing the whole configuration.
+
+```js
+import Modal from '@studiometa/js-toolkit/components/Modal';
+import withExtraConfig from '@studiometa/js-toolkit/decorators/withExtraConfig';
+
+export default withExtraConfig(Modal, {
+  options: {
+    styles: {
+      default: () => ({ /* ... */ }),
+    },
+  },
+});
+```
+
+### Enable debug or log easily
+
+This decorator can be used to quickly enable debug for an external component.
+
+```js{9}
+import Base from '@studiometa/js-toolkit';
+import Modal from '@studiometa/js-toolkit/components/Modal';
+import withExtraConfig from '@studiometa/js-toolkit/decorators/withExtraConfig';
+
+class App extends Base {
+  static config = {
+    name: 'App',
+    components: {
+      Modal: withExtraConfig(Modal, { debug: true }),
+    },
+  };
+}
+```
+
+### Pass option to the merge function
+
+This decorator uses [`deepmerge`](https://github.com/TehShrike/deepmerge) to merge the `config` properties, you can pass [options](https://github.com/TehShrike/deepmerge#options) to it with the third parameter:
+
+```js{7}
+import Modal from '@studiometa/js-toolkit/components/Modal';
+import withExtraConfig from '@studiometa/js-toolkit/decorators/withExtraConfig';
+
+export default withExtraConfig(Modal, {
+  refs: ['toggle']
+}, {
+  arrayMerge(target, source, options) { /* ... */ }
+})
+```
+
+## API
+
+This decorator does not expose a specific API.

--- a/packages/docs/decorators/withIntersectionObserver.md
+++ b/packages/docs/decorators/withIntersectionObserver.md
@@ -1,7 +1,7 @@
 ---
 sidebar: auto
 sidebarDepth: 5
-prev: /decorators/withBreakpointObserver.html
+prev: /decorators/withExtraConfig.html
 next: /decorators/withMountWhenInView.html
 ---
 

--- a/packages/js-toolkit/decorators/withExtraConfig.js
+++ b/packages/js-toolkit/decorators/withExtraConfig.js
@@ -1,18 +1,21 @@
 import merge from 'deepmerge';
 
 /**
+ * @typedef {import('deepmerge').Options} DeepmergeOptions
  * @typedef {import('../abstracts/Base').BaseConfig} BaseConfig
  * @typedef {import('../abstracts/Base').BaseComponent} BaseComponent
  */
 
 /**
- * IntersectionObserver decoration.
+ * Extends the configuration of an existing class.
+ *
  * @param {BaseComponent} BaseClass The Base class to extend.
  * @param {Partial<BaseConfig>} config Extra configuration to merge.
+ * @param {DeepmergeOptions} options Options for the `deepmerge` function. {@link https://github.com/TehShrike/deepmerge#options}
  * @return {BaseComponent}
  */
-export default (BaseClass, config = {}) => {
-  const newConfig = merge(BaseClass.config, config);
+export default (BaseClass, config = {}, options = {}) => {
+  const newConfig = merge(BaseClass.config, config, options);
 
   if (newConfig.name === BaseClass.config.name) {
     newConfig.name = `${BaseClass.config.name}WithExtraConfig`;

--- a/packages/js-toolkit/decorators/withExtraConfig.js
+++ b/packages/js-toolkit/decorators/withExtraConfig.js
@@ -1,0 +1,28 @@
+import merge from 'deepmerge';
+
+/**
+ * @typedef {import('../abstracts/Base').BaseConfig} BaseConfig
+ * @typedef {import('../abstracts/Base').BaseComponent} BaseComponent
+ */
+
+/**
+ * IntersectionObserver decoration.
+ * @param {BaseComponent} BaseClass The Base class to extend.
+ * @param {Partial<BaseConfig>} config Extra configuration to merge.
+ * @return {BaseComponent}
+ */
+export default (BaseClass, config = {}) => {
+  const newConfig = merge(BaseClass.config, config);
+
+  if (newConfig.name === BaseClass.config.name) {
+    newConfig.name = `${BaseClass.config.name}WithExtraConfig`;
+  }
+
+  return class extends BaseClass {
+    /**
+     * Class config.
+     * @type {BaseConfig}
+     */
+    static config = newConfig;
+  };
+};

--- a/packages/js-toolkit/decorators/withExtraConfig.js
+++ b/packages/js-toolkit/decorators/withExtraConfig.js
@@ -14,7 +14,7 @@ import merge from 'deepmerge';
  * @param {DeepmergeOptions} options Options for the `deepmerge` function. {@link https://github.com/TehShrike/deepmerge#options}
  * @return {BaseComponent}
  */
-export default (BaseClass, config = {}, options = {}) => {
+export default (BaseClass, config, options = {}) => {
   const newConfig = merge(BaseClass.config, config, options);
 
   if (newConfig.name === BaseClass.config.name) {

--- a/packages/tests/decorators/withExtraConfig.spec.js
+++ b/packages/tests/decorators/withExtraConfig.spec.js
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+import Base from '@studiometa/js-toolkit/abstracts/Base';
+import withExtraConfig from '@studiometa/js-toolkit/decorators/withExtraConfig';
+
+describe('The `withExtraConfig` decorator', () => {
+  it('should merge config of a given class', () => {
+    class Foo extends Base {
+      static config = {
+        name: 'Foo',
+        log: true,
+        debug: false,
+      }
+    }
+
+    const Bar = withExtraConfig(Foo, { log: false, debug: true });
+
+    expect(Bar.config.log).toBe(false)
+    expect(Bar.config.debug).toBe(true);
+    expect(Bar.config.name).toBe('FooWithExtraConfig');
+    expect(withExtraConfig(Foo, { name: 'OtherName' }).config.name).toBe('OtherName');
+  })
+
+  it('should use deepmerge options', () => {
+    class Foo extends Base {
+      static config = {
+        name: 'Foo',
+      }
+    }
+
+    const fn = jest.fn();
+    const Bar = withExtraConfig(Foo, { refs: ['one'] }, { arrayMerge: fn })
+    expect(fn).toHaveBeenCalledTimes(1);
+  })
+})


### PR DESCRIPTION
This PR introduces a new `withExtraConfig(class, config)` decorator which should help to quickly create variants of an existing class.

## Examples

**Add a new `toggle` ref to the modal component**
```js
import Modal from '@studiometa/js-toolkit/components/Modal';
import withExtraConfig from '@studiometa/js-toolkit/decorators/withExtraConfig';

export default withExtraConfig(Modal, { refs: ['toggle'] });
```

**Set the default styles of the modal component**

```js
import Modal from '@studiometa/js-toolkit/components/Modal';
import withExtraConfig from '@studiometa/js-toolkit/decorators/withExtraConfig';

export default withExtraConfig(Modal, {
  options: {
    styles: {
      default: () => ({ /* ... */ }),
    },
  },
});
```

## Todo

- [x] Add tests
- [x] Add doc