### PR TITLE
Bugfix/pointer service capture

### DIFF
--- a/packages/js-toolkit/services/pointer.js
+++ b/packages/js-toolkit/services/pointer.js
@@ -61,6 +61,18 @@ class Pointer extends Service {
   event;
 
   /**
+   * Whether or not the raf service is running.
+   * @type {Boolean}
+   */
+  hasRaf = false;
+
+  /**
+   * The service handler.
+   * @type {Function}
+   */
+  handler;
+
+  /**
    * Bind the handler to the mousemove and touchmove events.
    * Bind the up and down handler to the mousedown, mouseup, touchstart and touchend events.
    *
@@ -92,13 +104,19 @@ class Pointer extends Service {
     this.downHandler = this.downHandler.bind(this);
     this.upHandler = this.upHandler.bind(this);
 
-    document.documentElement.addEventListener('mouseenter', this.handler, { once: true });
-    document.addEventListener('mousemove', this.handler, { passive: true });
-    document.addEventListener('touchmove', this.handler, { passive: true });
-    document.addEventListener('mousedown', this.downHandler, { passive: true });
-    document.addEventListener('touchstart', this.downHandler, { passive: true });
-    document.addEventListener('mouseup', this.upHandler, { passive: true });
-    document.addEventListener('touchend', this.upHandler, { passive: true });
+    document.documentElement.addEventListener('mouseenter', this.handler, {
+      once: true,
+      capture: true,
+    });
+
+    const options = { passive: true, capture: true };
+
+    document.addEventListener('mousemove', this.handler, options);
+    document.addEventListener('touchmove', this.handler, options);
+    document.addEventListener('mousedown', this.downHandler, options);
+    document.addEventListener('touchstart', this.downHandler, options);
+    document.addEventListener('mouseup', this.upHandler, options);
+    document.addEventListener('touchend', this.upHandler, options);
     return this;
   }
 

--- a/packages/js-toolkit/services/pointer.js
+++ b/packages/js-toolkit/services/pointer.js
@@ -68,7 +68,7 @@ class Pointer extends Service {
 
   /**
    * The service handler.
-   * @type {Function}
+   * @type {(this:Document, event:MouseEvent) => any}
    */
   handler;
 

--- a/packages/tests/services/pointer.spec.js
+++ b/packages/tests/services/pointer.spec.js
@@ -4,28 +4,17 @@ import nextFrame from '@studiometa/js-toolkit/utils/nextFrame';
 import resizeWindow from '../__utils__/resizeWindow';
 import wait from '../__utils__/wait';
 
-/**
- * Dispatch an event on the document and wait for 100ms.
- *
- * @param  {Event}   event The event to dispatch.
- * @return {Promise}       A promise resolving after 100ms.
- */
-async function dispatchEvent(event) {
-  document.dispatchEvent(event);
-  return wait(100);
-}
-
 describe('usePointer', () => {
   const { add, remove, props } = usePointer();
   let pointerProps;
-  let fn;
+  const fn = jest.fn((p) => {
+    pointerProps = p;
+  });
+
+  add('usePointer', fn);
 
   beforeEach(() => {
-    remove('usePointer');
-    fn = jest.fn((p) => {
-      pointerProps = p;
-    });
-    add('usePointer', fn);
+    fn.mockClear();
   });
 
   it('should export the `add`, `remove` and `props` methods', () => {
@@ -34,148 +23,185 @@ describe('usePointer', () => {
     expect(typeof props).toBe('function');
   });
 
-  it('should trigger the callbacks on mousedown and mouseup', async () => {
-    await dispatchEvent(new MouseEvent('mousedown'));
+  it('should trigger the callbacks on mousedown and mouseup', () => {
+    document.dispatchEvent(new MouseEvent('mousedown'));
     expect(fn).toHaveBeenCalledTimes(1);
     expect(pointerProps.isDown).toBe(true);
-    await dispatchEvent(new MouseEvent('mouseup'));
+    document.dispatchEvent(new MouseEvent('mouseup'));
     expect(fn).toHaveBeenCalledTimes(2);
     expect(pointerProps.isDown).toBe(false);
   });
 
-  it('should trigger the callbacks on touchstart and touchend', async () => {
-    await dispatchEvent(new TouchEvent('touchstart'));
+  it('should trigger the callbacks on touchstart and touchend', () => {
+    document.dispatchEvent(new TouchEvent('touchstart'));
     expect(fn).toHaveBeenCalledTimes(1);
     expect(pointerProps.isDown).toBe(true);
-    await dispatchEvent(new TouchEvent('touchend'));
+    document.dispatchEvent(new TouchEvent('touchend'));
     expect(fn).toHaveBeenCalledTimes(2);
     expect(pointerProps.isDown).toBe(false);
   });
 
-  it('should trigger multiple callbacks', async () => {
+  it('should trigger multiple callbacks', () => {
     const otherFn = jest.fn();
     add('otherUsePointer', otherFn);
-    await dispatchEvent(new MouseEvent('mouseup'));
+    document.dispatchEvent(new MouseEvent('mouseup'));
     expect(fn).toHaveBeenCalledTimes(1);
     expect(otherFn).toHaveBeenCalledTimes(1);
   });
 
-  it('should not trigger callbacks after removal', async () => {
+  it('should not trigger callbacks after removal', () => {
     remove('usePointer');
-    await dispatchEvent(new MouseEvent('mouseup'));
-    await dispatchEvent(new MouseEvent('mousedown'));
-    await dispatchEvent(new MouseEvent('mousemove'));
-    await dispatchEvent(new TouchEvent('touchstart'));
-    await dispatchEvent(new TouchEvent('touchend'));
-    await dispatchEvent(new TouchEvent('touchmove'));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    document.dispatchEvent(new MouseEvent('mousedown'));
+    document.dispatchEvent(new MouseEvent('mousemove'));
+    document.dispatchEvent(new TouchEvent('touchstart'));
+    document.dispatchEvent(new TouchEvent('touchend'));
+    document.dispatchEvent(new TouchEvent('touchmove'));
     expect(fn).toHaveBeenCalledTimes(0);
+    add('usePointer', fn);
   });
 
   it('should trigger the callbacks on mousemove', async () => {
     await resizeWindow({ width: 1000, height: 1000 });
-    await dispatchEvent(new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
-    const event = new MouseEvent('mousemove', { clientX: 10, clientY: 10 });
-    await dispatchEvent(event);
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
+    await wait(50);
 
-    expect(fn).toHaveBeenCalled();
+    const progress = 0.1;
+    const x = Math.round(window.innerWidth * progress);
+    const y = Math.round(window.innerHeight * progress);
 
-    expect(pointerProps).toEqual({
+    const event = new MouseEvent('mousemove', {  clientX: x, clientY: y });
+    document.dispatchEvent(event);
+    await wait(50);
+    expect(fn).toHaveBeenLastCalledWith({
       event,
       isDown: false,
-      x: 10,
-      y: 10,
+      x,
+      y,
       changed: {
         x: false,
         y: false,
       },
       last: {
-        x: 10,
-        y: 10,
+        x,
+        y,
       },
       delta: {
         x: 0,
         y: 0,
       },
       progress: {
-        x: 0.01,
-        y: 0.01,
+        x: progress,
+        y: progress,
       },
       max: {
-        x: 1000,
-        y: 1000,
+        x: window.innerWidth,
+        y: window.innerHeight,
       },
     });
 
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 11, clientY: 10 }));
+    const newX = x + 10;
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: newX, clientY: y }));
     await nextFrame();
-    expect(pointerProps.changed.x).toBe(true);
-    expect(pointerProps.changed.y).toBe(false);
-    expect(pointerProps.progress.x).toBe(0.011);
-    await wait(100);
-  });
-
-  it('should trigger the callbacks on touchmove', async () => {
-    await resizeWindow({ width: 1000, height: 1000 });
-    await dispatchEvent(new TouchEvent('touchmove', { touches: [{ clientX: 0, clientY: 0 }] }));
-    const event = new TouchEvent('touchmove', { touches: [{ clientX: 10, clientY: 10 }] });
-    await dispatchEvent(event);
-
-    expect(fn).toHaveBeenCalled();
-
-    expect(pointerProps).toEqual({
+    expect(fn).toHaveBeenLastCalledWith({
       event,
       isDown: false,
-      x: 10,
-      y: 10,
-      changed: {
-        x: false,
-        y: false,
-      },
-      last: {
-        x: 10,
-        y: 10,
-      },
-      delta: {
-        x: 0,
-        y: 0,
-      },
-      progress: {
-        x: 0.01,
-        y: 0.01,
-      },
-      max: {
-        x: 1000,
-        y: 1000,
-      },
-    });
-
-    const otherEvent = new TouchEvent('touchmove', { touches: [{ clientX: 11, clientY: 10 }] });
-    document.dispatchEvent(otherEvent);
-    await nextFrame();
-    expect(pointerProps).toEqual({
-      event: otherEvent,
-      isDown: false,
-      x: 11,
-      y: 10,
+      x: newX,
+      y,
       changed: {
         x: true,
         y: false,
       },
       last: {
-        x: 10,
-        y: 10,
+        x,
+        y,
       },
       delta: {
-        x: 1,
+        x: newX - x,
         y: 0,
       },
       progress: {
-        x: 0.011,
-        y: 0.01,
+        x: newX / window.innerWidth,
+        y: progress,
       },
       max: {
-        x: 1000,
-        y: 1000,
+        x: window.innerWidth,
+        y: window.innerHeight,
+      },
+    });
+    await wait(100);
+  });
+
+  it('should trigger the callbacks on touchmove', async () => {
+    await resizeWindow({ width: 1000, height: 1000 });
+    document.dispatchEvent(new TouchEvent('touchmove', { touches: [{ clientX: 0, clientY: 0 }] }));
+    await wait(50);
+
+    const progress = 0.1;
+    const x = Math.round(window.innerWidth * progress);
+    const y = Math.round(window.innerHeight * progress);
+
+    const event = new TouchEvent('touchmove', { touches: [{ clientX: x, clientY: y }] });
+    document.dispatchEvent(event);
+
+    await wait(50);
+    expect(fn).toHaveBeenLastCalledWith({
+      event,
+      isDown: false,
+      x,
+      y,
+      changed: {
+        x: false,
+        y: false,
+      },
+      last: {
+        x,
+        y,
+      },
+      delta: {
+        x: 0,
+        y: 0,
+      },
+      progress: {
+        x: progress,
+        y: progress,
+      },
+      max: {
+        x: window.innerWidth,
+        y: window.innerHeight,
+      },
+    });
+
+    await wait(50);
+
+    const newX = x + 10;
+    const otherEvent = new TouchEvent('touchmove', { touches: [{ clientX: newX, clientY: y }] });
+    document.dispatchEvent(otherEvent);
+    await nextFrame();
+    expect(fn).toHaveBeenLastCalledWith({
+      event: otherEvent,
+      isDown: false,
+      x: newX,
+      y,
+      changed: {
+        x: true,
+        y: false,
+      },
+      last: {
+        x,
+        y,
+      },
+      delta: {
+        x: newX - x,
+        y: 0,
+      },
+      progress: {
+        x: newX / window.innerWidth,
+        y: progress,
+      },
+      max: {
+        x: window.innerWidth,
+        y: window.innerHeight,
       },
     });
   });


### PR DESCRIPTION
Fix a bug where the pointer service and the `moved` hook props would not have the correct value for `props.isDown` as the first  `downHandler` would not fire.