### PR TITLE
Feature/scroll direction

### DIFF
--- a/packages/docs/services/scroll.md
+++ b/packages/docs/services/scroll.md
@@ -81,3 +81,10 @@ The scroll position on both axis mapped to a `0` to `1` range, based on the [max
 - Interface: `{ x: number, y: number }`
 
 The maximum value the scroll can reach.
+
+### `direction`
+
+- Type: `Object`
+- Interface `{ x: 'LEFT'|'RIGHT'|'NONE', y: 'UP'|'DOWN'|'NONE' }`
+
+The direction of the scroll.

--- a/packages/js-toolkit/services/scroll.js
+++ b/packages/js-toolkit/services/scroll.js
@@ -16,6 +16,7 @@ import nextFrame from '../utils/nextFrame.js';
  * @property {{ x: Number, y: Number }} delta
  * @property {{ x: Number, y: Number }} progress
  * @property {{ x: Number, y: Number }} max
+ * @property {{ x: 'LEFT'|'RIGHT'|'NONE', y: 'UP'|'DOWN'|'NONE' }} direction
  */
 
 /**
@@ -114,6 +115,12 @@ class Scroll extends Service {
       progress: {
         x: this.max.x === 0 ? 1 : this.x / this.max.x,
         y: this.max.y === 0 ? 1 : this.y / this.max.y,
+      },
+      direction: {
+        /* eslint-disable no-nested-ternary */
+        x: this.x > this.xLast ? 'RIGHT' : this.x < this.xLast ? 'LEFT' : 'NONE',
+        y: this.y > this.yLast ? 'DOWN' : this.y < this.yLast ? 'UP' : 'NONE',
+        /* eslint-enable no-nested-ternary */
       },
       max: this.max,
     };

--- a/packages/js-toolkit/services/scroll.js
+++ b/packages/js-toolkit/services/scroll.js
@@ -1,7 +1,5 @@
 import Service from '../abstracts/Service.js';
-import throttle from '../utils/throttle.js';
 import debounce from '../utils/debounce.js';
-import nextFrame from '../utils/nextFrame.js';
 
 /**
  * @typedef {import('./index').ServiceInterface} ServiceInterface
@@ -49,23 +47,38 @@ class Scroll extends Service {
    * @return {Scroll}
    */
   init() {
+    this.handler = this.handler.bind(this);
+    document.addEventListener('scroll', this.handler, { passive: true, capture: true });
+    return this;
+  }
+
+  /**
+   * Debounced handler.
+   *
+   * @return {() => void}
+   */
+  get debouncedHandler() {
     const debounced = debounce(() => {
       this.trigger(this.props);
-      nextFrame(() => {
-        this.trigger(this.props);
-      });
-    }, 50);
+    }, 0);
 
-    this.handler = throttle(() => {
-      this.trigger(this.props);
+    // Define property to avoid multiple call to the getter
+    Object.defineProperty(this, 'debouncedHandler', {
+      value: debounced,
+    });
 
-      // Reset changed flags at the end of the scroll event
-      debounced();
-    }, 32).bind(this);
+    return debounced;
+  }
 
-    // Fire the `scrolled` method on document scroll
-    document.addEventListener('scroll', this.handler, { passive: true });
-    return this;
+  /**
+   * Scroll event handler.
+   *
+   * @return {void}
+   */
+  handler() {
+    this.trigger(this.props);
+
+    this.debouncedHandler();
   }
 
   /**

--- a/packages/js-toolkit/utils/debounce.js
+++ b/packages/js-toolkit/utils/debounce.js
@@ -3,9 +3,9 @@
  * will not be triggered. The function will be called after it stops
  * being called for N milliseconds.
  *
- * @param {Function} fn The function to call.
+ * @param {(...args:any[]) => void} fn The function to call.
  * @param {Number=} [delay=300] The delay in ms to wait before calling the function.
- * @return {Function} The debounced function.
+ * @return {(...args:any[]) => void} The debounced function.
  */
 export default function debounce(fn, delay = 300) {
   let timeout;


### PR DESCRIPTION
Add a `direction` property to the scroll service with the following values: 

- `NONE` if the scroll has not changed
- `UP` if the user is scrolling up
- `DOWN` if the user is scrolling down

This PR also improve the scroll service performance by removing unnecessary throttling and debouncing.