### PR TITLE
[Feature] Negated boolean option

### DIFF
--- a/packages/docs/api/index.md
+++ b/packages/docs/api/index.md
@@ -101,7 +101,7 @@ class Component extends Base {
 - Type: `Object`
 - Default: `{}`
 
-Define configurable values for the component.
+Define values configurable with `data-option-...` attributes for the component.
 
 ```js
 class Component extends Base {
@@ -365,6 +365,10 @@ An object containing the full options of the instance as defined in the [`config
 - `$options.debug` Wether the debug is active on this instance or not
 
 The values for the `$options` object are read from and written to the `data-option-<option-name>` attribute of the root element.
+
+:::tip
+Boolean options with `true` as a default value can be negated with a `data-option-no-<option-name>` attribute.
+:::
 
 ### `$refs`
 

--- a/packages/js-toolkit/abstracts/Base/classes/Options.js
+++ b/packages/js-toolkit/abstracts/Base/classes/Options.js
@@ -80,7 +80,7 @@ export default class Options {
           return this.get(name, type, defaultValue);
         },
         set(value) {
-          this.set(name, type, value);
+          this.set(name, type, value, defaultValue);
         },
         enumerable: true,
       });
@@ -101,9 +101,13 @@ export default class Options {
     const hasAttribute = this.#element.hasAttribute(attributeName);
 
     if (type === Boolean) {
-      if (!hasAttribute && defaultValue) {
-        this.#element.setAttribute(attributeName, '');
+      if (defaultValue) {
+        const negatedAttributeName = memoizedGetAttributeName(`no-${name}`);
+        const hasNegatedAttribute = this.#element.hasAttribute(negatedAttributeName);
+
+        return !hasNegatedAttribute;
       }
+
       return hasAttribute || defaultValue;
     }
 
@@ -145,7 +149,7 @@ export default class Options {
    * @param {ArrayConstructor|ObjectConstructor|StringConstructor|NumberConstructor|BooleanConstructor} type The option data's type.
    * @param {any} value The new value for this option.
    */
-  set(name, type, value) {
+  set(name, type, value, defaultValue) {
     const attributeName = memoizedGetAttributeName(name);
 
     if (value.constructor.name !== type.name) {
@@ -157,7 +161,15 @@ export default class Options {
 
     switch (type) {
       case Boolean:
-        if (value) {
+        if (defaultValue) {
+          const negatedAttributeName = memoizedGetAttributeName(`no-${name}`);
+
+          if (value) {
+            this.#element.removeAttribute(negatedAttributeName);
+          } else {
+            this.#element.setAttribute(negatedAttributeName, '');
+          }
+        } else if (value) {
           this.#element.setAttribute(attributeName, '');
         } else {
           this.#element.removeAttribute(attributeName);

--- a/packages/tests/abstracts/Base/classes/Options.spec.js
+++ b/packages/tests/abstracts/Base/classes/Options.spec.js
@@ -96,6 +96,8 @@ describe('The Options class', () => {
     expect(options.foo).toBe(true);
     expect(div.hasAttribute('data-option-foo')).toBe(false);
     expect(div.hasAttribute('data-option-no-foo')).toBe(false);
+    options.foo = false;
+    expect(div.hasAttribute('data-option-no-foo')).toBe(true);
   });
 
   it('should get and set array options', () => {
@@ -165,10 +167,10 @@ describe('The Options class', () => {
     expect(
       () =>
         new Options(html`<div />`, {
-          array: [Array, [1, 2, 3]],
+          array: { type: Array, default: [1, 2, 3] },
         })
     ).toThrow(
-      'The "array" option has an invalid type. The allowed types are: String, Number, Boolean, Array and Object.'
+      'The default value for options of type \"Array\" must be returned by a function.'
     );
   });
 

--- a/packages/tests/abstracts/Base/classes/Options.spec.js
+++ b/packages/tests/abstracts/Base/classes/Options.spec.js
@@ -83,6 +83,21 @@ describe('The Options class', () => {
     expect(options.foo).toBe(true);
   });
 
+  it('should get falsy boolean options', () => {
+    const div = html`<div data-option-no-foo></div>`;
+    const options = new Options(div, {
+      foo: { type: Boolean, default: true },
+    });
+
+    expect(options.foo).toBe(false);
+    expect(div.hasAttribute('data-option-foo')).toBe(false);
+    expect(div.hasAttribute('data-option-no-foo')).toBe(true);
+    options.foo = true;
+    expect(options.foo).toBe(true);
+    expect(div.hasAttribute('data-option-foo')).toBe(false);
+    expect(div.hasAttribute('data-option-no-foo')).toBe(false);
+  });
+
   it('should get and set array options', () => {
     const div = html`<div data-option-foo="[1, 2]"></div>`;
     const options = new Options(div, {
@@ -141,7 +156,7 @@ describe('The Options class', () => {
     expect(options.stringWithDefault).toBe('foo');
     expect(options.numberWithDefault).toBe(10);
     expect(options.booleanWithDefault).toBe(true);
-    expect(div.hasAttribute('data-option-boolean-with-default')).toBe(true);
+    expect(div.hasAttribute('data-option-boolean-with-default')).toBe(false);
     expect(options.arrayWithDefault).toEqual([1, 2, 3]);
     expect(options.objectWithDefault).toEqual({ foo: 'foo' });
   });


### PR DESCRIPTION
Add support for negated boolean option from the DOM when the default value of a boolean option is `true`.

**HTML**
```html
<div data-component="Component" data-option-no-boolean></div>
```

**JS**
```js
import Base from '@studiometa/js-toolkit';

class Component extends Base {
  static config = {
    name: 'Component',
    options: {
      boolean: {
        type: Boolean,
        default: true,
      },
    },
  };

  mounted() {
    this.$options.boolean; // false
  }
}
```