### PR TITLE
[Feature] Allow usage of `withIntersectionObserver` with events only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20578,7 +20578,6 @@
       "version": "2.0.0-beta.14",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
         "deepmerge": "^4.2.2"
       }
     },
@@ -22599,7 +22598,6 @@
     "@studiometa/js-toolkit": {
       "version": "file:packages/js-toolkit",
       "requires": {
-        "@babel/runtime": "^7.15.4",
         "deepmerge": "^4.2.2"
       }
     },

--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -5,9 +5,7 @@ module.exports = defineConfig({
   lang: 'en-US',
   title: 'JS Toolkit',
   description: 'A set of useful little bits of JavaScript to boost your project! 🚀',
-  head: [
-    ['link', { rel: 'icon', type: 'image/x-icon', href: '/logo.png' }],
-  ],
+  head: [['link', { rel: 'icon', type: 'image/x-icon', href: '/logo.png' }]],
   themeConfig: {
     version: pkg.version,
     repo: 'studiometa/js-toolkit',

--- a/packages/js-toolkit/decorators/withBreakpointObserver.js
+++ b/packages/js-toolkit/decorators/withBreakpointObserver.js
@@ -97,10 +97,10 @@ export default function withBreakpointObserver(BaseClass) {
   // @ts-ignore
   return class extends BaseClass {
     static config = {
-      ...(BaseClass.config || {}),
-      name: `${BaseClass?.config?.name ?? ''}WithBreakpointObserver`,
+      ...BaseClass.config,
+      name: `${BaseClass.config.name}WithBreakpointObserver`,
       options: {
-        ...(BaseClass?.config?.options || {}),
+        ...(BaseClass.config?.options || {}),
         activeBreakpoints: String,
         inactiveBreakpoints: String,
       },

--- a/packages/js-toolkit/decorators/withIntersectionObserver.js
+++ b/packages/js-toolkit/decorators/withIntersectionObserver.js
@@ -52,14 +52,10 @@ export default function withIntersectionObserver(
      * Create an observer when the class in instantiated.
      *
      * @this {Base & WithIntersectionObserverInterface}
-     * @param  {HTMLElement} element The component's root element.
+     * @param {HTMLElement} element The component's root element.
      */
     constructor(element) {
       super(element);
-
-      if (!this.intersected || typeof this.intersected !== 'function') {
-        throw new Error('[withIntersectionObserver] The `intersected` method must be defined.');
-      }
 
       this.$observer = new IntersectionObserver(
         (entries) => {

--- a/packages/js-toolkit/decorators/withIntersectionObserver.js
+++ b/packages/js-toolkit/decorators/withIntersectionObserver.js
@@ -39,10 +39,10 @@ export default function withIntersectionObserver(
   // @ts-ignore
   return class extends BaseClass {
     static config = {
-      ...(BaseClass.config || {}),
-      name: `${BaseClass?.config?.name ?? ''}WithIntersectionObserver`,
+      ...BaseClass.config,
+      name: `${BaseClass.config.name}WithIntersectionObserver`,
       options: {
-        ...(BaseClass?.config?.options || {}),
+        ...(BaseClass.config?.options || {}),
         intersectionObserver: Object,
       },
       emits: ['intersected'],
@@ -62,7 +62,10 @@ export default function withIntersectionObserver(
           // @ts-ignore
           this.__callMethod('intersected', entries);
         },
-        { ...defaultOptions, ...(this.$options.intersectionObserver || {}) }
+        {
+          ...defaultOptions,
+          ...this.$options.intersectionObserver,
+        }
       );
 
       this.$on('mounted', () => {

--- a/packages/js-toolkit/decorators/withMountWhenInView.js
+++ b/packages/js-toolkit/decorators/withMountWhenInView.js
@@ -31,10 +31,10 @@ export default function withMountWhenInView(BaseClass, defaultOptions = { thresh
      * @type {Object}
      */
     static config = {
-      ...(BaseClass.config || {}),
-      name: `${BaseClass?.config?.name ?? ''}WithMountWhenInView`,
+      ...BaseClass.config,
+      name: `${BaseClass.config.name}WithMountWhenInView`,
       options: {
-        ...(BaseClass?.config?.options || {}),
+        ...(BaseClass.config?.options || {}),
         intersectionObserver: Object,
       },
     };

--- a/packages/js-toolkit/decorators/withVue2.js
+++ b/packages/js-toolkit/decorators/withVue2.js
@@ -20,9 +20,9 @@ export default (BaseClass, Vue) => {
   // @ts-ignore
   return class WithVue2 extends BaseClass {
     static config = {
-      ...(BaseClass.config || {}),
-      name: `${BaseClass?.config?.name ?? ''}WithVue`,
-      refs: [...(BaseClass?.config?.refs ?? []), 'vue'],
+      ...BaseClass.config,
+      name: `${BaseClass.config.name}WithVue`,
+      refs: [...(BaseClass.config?.refs ?? []), 'vue'],
     };
 
     /**

--- a/packages/js-toolkit/package.json
+++ b/packages/js-toolkit/package.json
@@ -39,7 +39,6 @@
     "toolkit"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.15.4",
     "deepmerge": "^4.2.2"
   }
 }

--- a/packages/tests/decorators/withIntersectionObserver.spec.js
+++ b/packages/tests/decorators/withIntersectionObserver.spec.js
@@ -38,16 +38,27 @@ describe('The withIntersectionObserver decorator', () => {
     expect(observer.observe).toHaveBeenCalledTimes(2);
   });
 
-  it('should not instantiate without `intersected` method', () => {
-    class Foo extends withIntersectionObserver(Base) {
+  it('should be able to be used without the `intersected` method', () => {
+    const fn = jest.fn();
+    class Foo extends Base {
       static config = {
         name: 'Foo',
+        components: {
+          Detector: withIntersectionObserver(Base),
+        },
       };
+
+      onDetectorIntersected(entries) {
+        fn(entries);
+      }
     }
+
     const div = document.createElement('div');
-    expect(() => {
-      // eslint-disable-next-line no-unused-vars
-      const foo = new Foo(div);
-    }).toThrow(/withIntersectionObserver/);
+    div.innerHTML = '<div data-component="Detector"></div>';
+    new Foo(div).$mount();
+    mockIsIntersecting(div.firstElementChild, true);
+    expect(fn).toHaveBeenCalledTimes(1);
+    mockIsIntersecting(div.firstElementChild, true);
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -12,6 +12,7 @@ const defaultOptions = {
   entryPoints,
   write: true,
   outdir,
+  target: 'es2019',
 };
 
 /**


### PR DESCRIPTION
The `withIntersectionObserver` decorator was throwing an error when the `intersected` method was not defined on the instance. This prevented us from using the decorator by only listening to its events, for example:

```js
import { Base, withIntersectionObserver } from '@studiometa/js-toolkit';

export default class Component extends Base {
  static config = {
    name: 'Component',
    components: {
      IntersectionDetector: withIntersectionObserver(Base),
    },
  };

  onIntersectionDetectorIntersected(entries) {
    // Do something with the `entries`
  }
}
```

---

## Changled

### Changed 
- Allow usage of the `withIntersectionObserver` decorator without defining the `intersected` method (#197)

### Fixed
- Remove the obsolete `@babel/runtime` dependency (d814c38)
- Lower the build target to `es2019` (4032a5e)
