### PR TITLE
[Release] 2.0.0-beta.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/js-toolkit-workspace",
-      "version": "2.0.0-beta.14",
+      "version": "2.0.0-beta.15",
       "workspaces": [
         "packages/*"
       ],
@@ -20507,7 +20507,7 @@
     },
     "packages/demo": {
       "name": "@studiometa/js-toolkit-demo",
-      "version": "2.0.0-beta.14",
+      "version": "2.0.0-beta.15",
       "dependencies": {
         "@studiometa/eslint-config": "^2.1.3",
         "@studiometa/stylelint-config": "^2.0.0",
@@ -20525,7 +20525,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/js-toolkit-docs",
-      "version": "2.0.0-beta.14",
+      "version": "2.0.0-beta.15",
       "dependencies": {
         "@bytebase/vue-kbar": "^0.1.5",
         "@studiometa/tailwind-config": "^1.0.4",
@@ -20575,7 +20575,7 @@
     },
     "packages/js-toolkit": {
       "name": "@studiometa/js-toolkit",
-      "version": "2.0.0-beta.14",
+      "version": "2.0.0-beta.15",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2"
@@ -20583,7 +20583,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/js-toolkit-tests",
-      "version": "2.0.0-beta.14",
+      "version": "2.0.0-beta.15",
       "dependencies": {
         "@jest/globals": "^27.1.0",
         "babel-jest": "^27.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-demo",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-docs",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "private": true,
   "scripts": {
     "dev": "vitepress dev .",

--- a/packages/js-toolkit/package.json
+++ b/packages/js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "A set of useful little bits of JavaScript to boost your project! 🚀",
   "publishConfig": {
     "access": "public"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-tests",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Changelog

### Changed 
- Allow usage of the `withIntersectionObserver` decorator without defining the `intersected` method (#197)

### Fixed
- Remove the obsolete `@babel/runtime` dependency (d814c38)
- Lower the build target to `es2019` (4032a5e)
