### PR TITLE
[Feature] Freezed options

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "demo:dev": "npm run dev --workspace=@studiometa/js-toolkit-demo",
     "demo:build": "npm run build --workspace=@studiometa/js-toolkit-demo",
     "docs:dev": "npm run dev --workspace=@studiometa/js-toolkit-docs",
-    "docs:build": "cd packages/docs && npm install && rm -fr node_modules/.vite && npm run build",
+    "docs:build": "cd packages/docs && npm install && rm -rf node_modules/.vite && npm run build",
     "test": "npm run test --workspace=@studiometa/js-toolkit-tests",
     "lint": "npm run lint:eslint && npm run lint:types && npm run lint:docs",
     "lint:eslint": "eslint packages/js-toolkit",

--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -170,6 +170,7 @@ function getDecoratorsSidebar() {
     { text: 'withBreakpointObserver', link: '/api/decorators/withBreakpointObserver.html' },
     { text: 'withDrag', link: '/api/decorators/withDrag.html' },
     { text: 'withExtraConfig', link: '/api/decorators/withExtraConfig.html' },
+    { text: 'withFreezedOptions', link: '/api/decorators/withFreezedOptions.html' },
     { text: 'withIntersectionObserver', link: '/api/decorators/withIntersectionObserver.html' },
     { text: 'withMountWhenInView', link: '/api/decorators/withMountWhenInView.html' },
     { text: 'withScrolledInView', link: '/api/decorators/withScrolledInView.html' },

--- a/packages/docs/api/decorators/index.md
+++ b/packages/docs/api/decorators/index.md
@@ -6,6 +6,7 @@ Decorators are used to add extra functionalities to a Base class. The following 
 - [withBreakpointObserver](./withBreakpointObserver.html)
 - [withDrag](./withDrag.html)
 - [withExtraConfig](./withExtraConfig.html)
+- [withFreezedOptions](./withFreezedOptions.html)
 - [withIntersectionObserver](./withIntersectionObserver.html)
 - [withMountWhenInView](./withMountWhenInView.html)
 - [withVue2](./withVue2.html)

--- a/packages/docs/api/decorators/withFreezedOptions.md
+++ b/packages/docs/api/decorators/withFreezedOptions.md
@@ -1,0 +1,21 @@
+# withFreezedOptions
+
+Use this decorator to transfrom the `$options` property to be read only. This can help improve performance when accessing options in the [`ticked` service method](/api/methods-hooks-services.html#ticked).
+
+## Usage
+
+```js
+import { withFreezedOptions } from '@studiometa/js-toolkit';
+import Component from './Component.js';
+
+export default class ComponentWithFreezedOptions extends withFreezedOptions(Component);
+```
+
+### Parameters
+
+- `BaseClass` (`Base`): The class to use as parent.
+
+### Return value
+
+- `Base`: A child class of the given class with the `$options` property freezed.
+

--- a/packages/docs/api/decorators/withFreezedOptions.md
+++ b/packages/docs/api/decorators/withFreezedOptions.md
@@ -18,4 +18,3 @@ export default class ComponentWithFreezedOptions extends withFreezedOptions(Comp
 ### Return value
 
 - `Base`: A child class of the given class with the `$options` property freezed.
-

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,10 +7,10 @@
     "build": "vitepress build ."
   },
   "dependencies": {
-    "@bytebase/vue-kbar": "^0.1.5",
-    "@studiometa/tailwind-config": "^1.0.4",
-    "codemirror": "^5.65.0",
-    "tailwindcss": "^2.2.7",
-    "vitepress": "^0.20.0"
+    "@bytebase/vue-kbar": "^0.1.7",
+    "@studiometa/tailwind-config": "^1.1.0",
+    "codemirror": "^5.65.2",
+    "tailwindcss": "^2.2.19",
+    "vitepress": "^0.22.3"
   }
 }

--- a/packages/js-toolkit/decorators/index.js
+++ b/packages/js-toolkit/decorators/index.js
@@ -2,6 +2,7 @@ export { default as withBreakpointManager } from './withBreakpointManager.js';
 export { default as withBreakpointObserver } from './withBreakpointObserver.js';
 export { default as withDrag } from './withDrag.js';
 export { default as withExtraConfig } from './withExtraConfig.js';
+export { default as withFreezedOptions } from './withFreezedOptions.js';
 export { default as withIntersectionObserver } from './withIntersectionObserver.js';
 export { default as withMountWhenInView } from './withMountWhenInView.js';
 export { default as withScrolledInView } from './withScrolledInView.js';

--- a/packages/js-toolkit/decorators/withFreezedOptions.js
+++ b/packages/js-toolkit/decorators/withFreezedOptions.js
@@ -15,8 +15,10 @@ export default function withFreezedOptions(BaseClass) {
   return class extends BaseClass {
     /**
      * Lazyly freeze the `$options` property.
-     * @returns {Readonly<BaseOptions>}
+     * @returns {Readonly<{ name: string, debug: boolean, log: boolean, [key:string]: any }>}
      */
+    // @ts-ignore
+    // eslint-disable-next-line require-jsdoc
     get $options() {
       Object.defineProperty(this, '$options', {
         value: Object.freeze({ ...super.$options }),

--- a/packages/js-toolkit/decorators/withFreezedOptions.js
+++ b/packages/js-toolkit/decorators/withFreezedOptions.js
@@ -19,7 +19,7 @@ export default function withFreezedOptions(BaseClass) {
      */
     get $options() {
       Object.defineProperty(this, '$options', {
-        value: Object.freeze(super.$options),
+        value: Object.freeze({ ...super.$options }),
         enumerable: true,
       });
 

--- a/packages/js-toolkit/decorators/withFreezedOptions.js
+++ b/packages/js-toolkit/decorators/withFreezedOptions.js
@@ -1,0 +1,29 @@
+/**
+ * @typedef {import('../Base').BaseOptions} BaseOptions
+ * @typedef {import('../Base').BaseConstructor} BaseConstructor
+ */
+
+/**
+ * Freeze the `$options` property to improve performance.
+ *
+ * @template {BaseConstructor} T
+ * @param {T} BaseClass The Base class to extend.
+ * @return {T}
+ */
+export default function withFreezedOptions(BaseClass) {
+  // @ts-ignore
+  return class extends BaseClass {
+    /**
+     * Lazyly freeze the `$options` property.
+     * @returns {Readonly<BaseOptions>}
+     */
+    get $options() {
+      Object.defineProperty(this, '$options', {
+        value: Object.freeze(super.$options),
+        enumerable: true,
+      });
+
+      return this.$options;
+    }
+  };
+}

--- a/packages/tests/__snapshots__/index.spec.js.snap
+++ b/packages/tests/__snapshots__/index.spec.js.snap
@@ -18,6 +18,7 @@ Array [
   "withBreakpointObserver",
   "withDrag",
   "withExtraConfig",
+  "withFreezedOptions",
   "withIntersectionObserver",
   "withMountWhenInView",
   "withScrolledInView",

--- a/packages/tests/decorators/withFreezedOptions.spec.js
+++ b/packages/tests/decorators/withFreezedOptions.spec.js
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+import { Base, withFreezedOptions } from '@studiometa/js-toolkit';
+
+describe('The `withFreezedOptions` decorator', () => {
+  class Foo extends withFreezedOptions(Base) {
+    static config = {
+      name: 'Foo',
+      options: {
+        bool: Boolean,
+      },
+    };
+  }
+
+  it('should transform the `$options` property to be read-only', () => {
+    const foo = new Foo(document.createElement('div'));
+    expect(foo.$options.bool).toBe(false);
+    expect(() => {
+      foo.$options.bool = true;
+    }).toThrow();
+    expect(foo.$options.bool).toBe(false);
+  });
+
+  it('should not break a component lifecycle', () => {
+    const foo = new Foo(document.createElement('div'));
+    foo.$mount();
+    expect(foo.$isMounted).toBe(true);
+    foo.$update();
+    expect(foo.$isMounted).toBe(true);
+    foo.$destroy();
+    expect(foo.$isMounted).toBe(false);
+    foo.$terminate();
+    expect(foo.$el.__base__.get(Foo)).toBe('terminated');
+  });
+});


### PR DESCRIPTION
Add a `withFreezedOptions` decorator to make the `$options` property read-only. This can help improve performance when working with the `ticked` service hook.