### PR TITLE
[Feature] Get a service props

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
           PRERELEASE=false
           # Check release type
-          if [[ $VERSION =~ 'alpha' || $VERSION =~ 'beta' ]]; then
+          if [[ $VERSION =~ 'alpha' || $VERSION =~ 'beta' || $VERSION =~ 'rc' ]]; then
             echo "This is a prerelease."
             PRERELEASE=true
           fi

--- a/packages/docs/api/instance-properties.md
+++ b/packages/docs/api/instance-properties.md
@@ -65,6 +65,7 @@ The following methods are available:
 - `enable(service: string): () => void`: enable the given service if the current component instance has the service method defined, returns a function to disable the service
 - `disable(service: string): void`: disable the given service
 - `toggle(service: string, force?: boolean): void`: toggle the given service
+- `get(service: string): any`: get the props of the given service
 - `enableAll(): Array<() => void>`: enable all services which are defined
 - `disableAll(): void`: disable all services
 
@@ -78,7 +79,7 @@ class Component extends Base {
   };
 
   onBtnClick() {
-    if (this.$services.has('ticked')) {
+    if (!this.$services.has('ticked')) {
       this.$services.enable('ticked');
     } else {
       this.$services.disable('ticked');

--- a/packages/js-toolkit/Base/managers/ServicesManager.js
+++ b/packages/js-toolkit/Base/managers/ServicesManager.js
@@ -92,6 +92,15 @@ export default class ServicesManager {
   }
 
   /**
+   * Get a service props by name.
+   * @param   {ServiceName} service The name of the service.
+   * @returns {ServiceInterface}
+   */
+  get(service) {
+    return this.__services[service]().props();
+  }
+
+  /**
    * Init the given service and bind it to the given instance.
    *
    * @param  {ServiceName} service The name of the service.

--- a/packages/js-toolkit/Base/managers/ServicesManager.js
+++ b/packages/js-toolkit/Base/managers/ServicesManager.js
@@ -94,7 +94,7 @@ export default class ServicesManager {
   /**
    * Get a service props by name.
    * @param   {ServiceName} service The name of the service.
-   * @returns {ServiceInterface}
+   * @returns {ReturnType<ServiceInterface['props']>}
    */
   get(service) {
     return this.__services[service]().props();

--- a/packages/tests/Base/managers/ServicesManager.spec.js
+++ b/packages/tests/Base/managers/ServicesManager.spec.js
@@ -114,4 +114,8 @@ describe('The ServicesManager', () => {
     expect(service.remove).toHaveBeenCalledTimes(1);
     app.$services.unregister('customService');
   });
+
+  it('should expose each services props', () => {
+    expect(app.$services.get('ticked')).toHaveProperty('time');
+  });
 });


### PR DESCRIPTION
Add support for accessing a registered service props easily from within a component:  

```js
import { Base,  } from '@studiometa/js-toolkit';

class Btn extends Base {
  static config = {
    name: 'Btn',
  };

  onClick() {
    if (this.$services.get('resized').breakpoint === 'xxs') {
      // Do something on small screens...
    }
  }
}
```