### PR TITLE
[Feature] Add a utility to get the sizes of an element without its transform

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,3 +58,13 @@ jobs:
         fail_ci_if_error: false
         path_to_write_report: ./codecov_report.txt
         verbose: true
+
+  Export-Size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: antfu/export-size-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          build_script: npm run build
+          paths: dist

--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -227,6 +227,7 @@ function getUtilsSidebar() {
       children: [
         { text: 'addClass', link: '/utils/css/addClass.html' },
         { text: 'addStyle', link: '/utils/css/addStyle.html' },
+        { text: 'getOffsetSizes', link: '/utils/css/getOffsetSizes.html' },
         { text: 'matrix', link: '/utils/css/matrix.html' },
         { text: 'removeClass', link: '/utils/css/removeClass.html' },
         { text: 'removeStyle', link: '/utils/css/removeStyle.html' },

--- a/packages/docs/api/decorators/withScrolledInView.md
+++ b/packages/docs/api/decorators/withScrolledInView.md
@@ -25,7 +25,9 @@ This decorator uses the [`withMountWhenInView`](./withMountWhenInView.html) deco
 ### Parameters
 
 - `Base` (`BaseConstructor`): The `Base` class or a class extending it.
-- `options` (`IntersectionObserverInit`): Options for the `IntersectionObserver` used by the `withMountWhenInView` decorator
+- `options` (`IntersectionObserverInit & { useOffsetSizes?: boolean }`):
+  - `options[key:string]`: Options for the `IntersectionObserver` used by the `withMountWhenInView` decorator
+  - `options.useOffsetSizes` (`boolean`): when `true`, uses the [`getOffsetSizes(el)` function](/utils/css/getOffsetSizes.html) instead of the `el.getBoundingClientRect()` to get the element sizes
 
 ### Return value
 

--- a/packages/docs/utils/css/getOffsetSizes.md
+++ b/packages/docs/utils/css/getOffsetSizes.md
@@ -1,0 +1,32 @@
+# getOffsetSizes
+
+This function will return a `DOMRect` like object representing the position of the given element without its CSS transforms.
+
+## Usage
+
+```js
+import { getOffsetSizes } from '@studiometa/js-toolkit/utils';
+
+const sizes = getOffsetSizes(document.body);
+```
+
+### Parameters
+
+- `element` (`HTMLElement`): the scale on the x axis
+
+### Return value
+
+An object with the same properties as a `DOMRect`:
+
+```ts
+{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  top: number;
+  right number;
+  bottom: number;
+  left: number;
+}
+```

--- a/packages/js-toolkit/decorators/withScrolledInView.js
+++ b/packages/js-toolkit/decorators/withScrolledInView.js
@@ -12,10 +12,10 @@ import { damp, clamp, clamp01, getOffsetSizes } from '../utils/index.js';
  *
  * @template {BaseConstructor} T
  * @param {T} BaseClass
- * @param {IntersectionObserverInit} options
+ * @param {IntersectionObserverInit & { useOffsetSizes?: boolean }} options
  * @returns {T}
  */
-export default function withScrolledInView(BaseClass, options) {
+export default function withScrolledInView(BaseClass, options = {}) {
   // @ts-ignore
   return class extends withMountWhenInView(BaseClass, options) {
     /**
@@ -141,7 +141,9 @@ export default function withScrolledInView(BaseClass, options) {
      * @returns {void}
      */
     __setProps() {
-      const sizes = getOffsetSizes(this.$el);
+      const sizes = options.useOffsetSizes
+        ? getOffsetSizes(this.$el)
+        : this.$el.getBoundingClientRect();
 
       // Y axis
       const yEnd = sizes.y + window.pageYOffset + sizes.height;

--- a/packages/js-toolkit/decorators/withScrolledInView.js
+++ b/packages/js-toolkit/decorators/withScrolledInView.js
@@ -1,5 +1,5 @@
 import withMountWhenInView from './withMountWhenInView.js';
-import { damp, clamp, clamp01 } from '../utils/index.js';
+import { damp, clamp, clamp01, getOffsetSizes } from '../utils/index.js';
 
 /**
  * @typedef {import('../Base').default} Base
@@ -141,16 +141,16 @@ export default function withScrolledInView(BaseClass, options) {
      * @returns {void}
      */
     __setProps() {
-      const sizes = this.$el.getBoundingClientRect();
+      const sizes = getOffsetSizes(this.$el);
 
       // Y axis
-      const yEnd = sizes.top + window.pageYOffset + sizes.height;
+      const yEnd = sizes.y + window.pageYOffset + sizes.height;
       const yStart = yEnd - window.innerHeight - sizes.height;
       const yCurrent = clamp(window.pageYOffset, yStart, yEnd);
       const yProgress = clamp01((yCurrent - yStart) / (yEnd - yStart));
 
       // X axis
-      const xEnd = sizes.left + window.pageXOffset + sizes.width;
+      const xEnd = sizes.x + window.pageXOffset + sizes.width;
       const xStart = xEnd - window.innerWidth - sizes.width;
       const xCurrent = clamp(window.pageXOffset, xStart, xEnd);
       const xProgress = clamp01((xCurrent - xStart) / (xEnd - xStart));

--- a/packages/js-toolkit/utils/css/getOffsetSizes.js
+++ b/packages/js-toolkit/utils/css/getOffsetSizes.js
@@ -1,0 +1,31 @@
+/**
+ * Get a `DOMRect` like `Object` for an element, without its transforms.
+ * @param   {HTMLElement} element
+ * @returns {{ x: number, y: number, width: number, height: number, top: number, right: number, bottom: number, left: number }}
+ */
+export default function getOffsetSizes(element) {
+  let parent = element;
+  let x = 0;
+  let y = 0;
+
+  while (parent) {
+    x += parent.offsetLeft;
+    y += parent.offsetTop;
+    // @ts-ignore
+    parent = parent.offsetParent;
+  }
+
+  const width = element.offsetWidth;
+  const height = element.offsetWidth;
+
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    right: width + x,
+    bottom: height + y,
+    left: x,
+  };
+}

--- a/packages/js-toolkit/utils/css/getOffsetSizes.js
+++ b/packages/js-toolkit/utils/css/getOffsetSizes.js
@@ -5,8 +5,8 @@
  */
 export default function getOffsetSizes(element) {
   let parent = element;
-  let x = 0;
-  let y = 0;
+  let x = -window.pageXOffset;
+  let y = -window.pageYOffset;
 
   while (parent) {
     x += parent.offsetLeft;

--- a/packages/js-toolkit/utils/css/index.js
+++ b/packages/js-toolkit/utils/css/index.js
@@ -1,4 +1,5 @@
 export { add as addClass, remove as removeClass, toggle as toggleClass } from './classes.js';
 export { add as addStyle, remove as removeStyle } from './styles.js';
+export { default as getOffsetSizes } from './getOffsetSizes.js';
 export { default as matrix } from './matrix.js';
 export { default as transition } from './transition.js';

--- a/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
+++ b/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
@@ -4,24 +4,51 @@ exports[`The withScrolledInView decorator should trigger the \`scrolledInView\` 
 Array [
   Object {
     "current": Object {
-      "x": 0,
-      "y": 0,
+      "x": 600,
+      "y": 600,
     },
     "dampedProgress": Object {
-      "x": 0.6355000000000001,
-      "y": 0.6355000000000001,
+      "x": 0.44092704626334517,
+      "y": 0.3835414746543779,
     },
     "end": Object {
-      "x": 0,
-      "y": 0,
+      "x": 600,
+      "y": 600,
     },
     "progress": Object {
       "x": 1,
       "y": 1,
     },
     "start": Object {
-      "x": -1024,
-      "y": -768,
+      "x": -524,
+      "y": -268,
+    },
+  },
+]
+`;
+
+exports[`The withScrolledInView decorator should trigger the \`scrolledInView\` hook when in view with the \`useOffsetSizes\` option 1`] = `
+Array [
+  Object {
+    "current": Object {
+      "x": 600,
+      "y": 600,
+    },
+    "dampedProgress": Object {
+      "x": 0.44092704626334517,
+      "y": 0.3835414746543779,
+    },
+    "end": Object {
+      "x": 600,
+      "y": 600,
+    },
+    "progress": Object {
+      "x": 1,
+      "y": 1,
+    },
+    "start": Object {
+      "x": -524,
+      "y": -268,
     },
   },
 ]

--- a/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
+++ b/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
@@ -4,24 +4,24 @@ exports[`The withScrolledInView decorator should trigger the \`scrolledInView\` 
 Array [
   Object {
     "current": Object {
-      "x": 600,
-      "y": 600,
+      "x": 0,
+      "y": 0,
     },
     "dampedProgress": Object {
-      "x": 0.44092704626334517,
-      "y": 0.3835414746543779,
+      "x": 0.6355000000000001,
+      "y": 0.6355000000000001,
     },
     "end": Object {
-      "x": 600,
-      "y": 600,
+      "x": 0,
+      "y": 0,
     },
     "progress": Object {
       "x": 1,
       "y": 1,
     },
     "start": Object {
-      "x": -524,
-      "y": -268,
+      "x": -1024,
+      "y": -768,
     },
   },
 ]

--- a/packages/tests/decorators/withScrolledInView.spec.js
+++ b/packages/tests/decorators/withScrolledInView.spec.js
@@ -10,40 +10,107 @@ import wait from '../__utils__/wait.js';
 beforeAll(() => beforeAllCallback());
 
 let div;
-let instance;
 let divRectSpy;
+let offsetTopSpy;
+let offsetLeftSpy;
+let offsetWidthSpy;
+let offsetHeightSpy;
 const fn = jest.fn();
-
-class Foo extends withScrolledInView(Base) {
-  static config = {
-    name: 'Foo',
-  };
-
-  scrolledInView(props) {
-    fn(props);
-  }
-}
 
 beforeEach(() => {
   fn.mockClear();
+  window.pageYOffset = 0;
+  window.pageXOffset = 0;
   div = document.createElement('div');
+  offsetTopSpy = jest.spyOn(div, 'offsetTop', 'get').mockImplementation(() =>  500);
+  offsetLeftSpy = jest.spyOn(div, 'offsetLeft', 'get').mockImplementation(() =>  500);
+  offsetWidthSpy = jest.spyOn(div, 'offsetWidth', 'get').mockImplementation(() =>  100);
+  offsetHeightSpy = jest.spyOn(div, 'offsetHeight', 'get').mockImplementation(() =>  100);
   divRectSpy = jest.spyOn(div, 'getBoundingClientRect');
   divRectSpy.mockImplementation(() => ({
     height: 100,
     width: 100,
     top: 500,
+    y: 500,
     left: 500,
+    x: 500,
   }));
-  instance = new Foo(div);
 });
 
 afterEach(() => {
   afterEachCallback();
   divRectSpy.mockRestore();
+  offsetTopSpy.mockRestore();
+  offsetLeftSpy.mockRestore();
+  offsetWidthSpy.mockRestore();
+  offsetHeightSpy.mockRestore();
 });
 
 describe('The withScrolledInView decorator', () => {
   it('should trigger the `scrolledInView` hook when in view', async () => {
+    class Foo extends withScrolledInView(Base) {
+      static config = {
+        name: 'Foo',
+      };
+
+      scrolledInView(props) {
+        fn(props);
+      }
+    }
+    new Foo(div);
+
+    mockIsIntersecting(div, true);
+    const scrollHeightSpy = jest.spyOn(document.body, 'scrollHeight', 'get');
+    scrollHeightSpy.mockImplementation(() => window.innerHeight * 2);
+    const scrollWidthSpy = jest.spyOn(document.body, 'scrollWidth', 'get');
+    scrollWidthSpy.mockImplementation(() => window.innerWidth * 2);
+
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset = 10;
+    window.pageXOffset = 10;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+    document.dispatchEvent(new Event('scroll'));
+    window.pageYOffset *= 2;
+    window.pageXOffset *= 2;
+
+    await wait(50);
+    expect(fn.mock.calls.pop()).toMatchSnapshot();
+    scrollHeightSpy.mockRestore();
+    scrollWidthSpy.mockRestore();
+  });
+
+  it('should trigger the `scrolledInView` hook when in view with the `useOffsetSizes` option' , async () => {
+    class Foo extends withScrolledInView(Base, { useOffsetSizes: true }) {
+      static config = {
+        name: 'Foo',
+      };
+
+      scrolledInView(props) {
+        fn(props);
+      }
+    }
+    new Foo(div);
+
     mockIsIntersecting(div, true);
     const scrollHeightSpy = jest.spyOn(document.body, 'scrollHeight', 'get');
     scrollHeightSpy.mockImplementation(() => window.innerHeight * 2);

--- a/packages/tests/utils/__snapshots__/index.spec.js.snap
+++ b/packages/tests/utils/__snapshots__/index.spec.js.snap
@@ -38,6 +38,7 @@ Array [
   "easeOutQuint",
   "easeOutSine",
   "focusTrap",
+  "getOffsetSizes",
   "historyPush",
   "historyReplace",
   "inertiaFinalValue",

--- a/packages/tests/utils/css/__snapshots__/getOffsetSizes.spec.js.snap
+++ b/packages/tests/utils/css/__snapshots__/getOffsetSizes.spec.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The \`getOffsetSizes\` method should return a DOMRect like Object 1`] = `
+Object {
+  "bottom": 0,
+  "height": 0,
+  "left": 0,
+  "right": 0,
+  "top": 0,
+  "width": 0,
+  "x": 0,
+  "y": 0,
+}
+`;
+
+exports[`The \`getOffsetSizes\` method should return a DOMRect like object without transforms 1`] = `
+Object {
+  "bottom": 0,
+  "height": 0,
+  "left": 0,
+  "right": 0,
+  "top": 0,
+  "width": 0,
+  "x": 0,
+  "y": 0,
+}
+`;

--- a/packages/tests/utils/css/__snapshots__/index.spec.js.snap
+++ b/packages/tests/utils/css/__snapshots__/index.spec.js.snap
@@ -4,6 +4,7 @@ exports[`@studiometa/js-toolkit/utils/css exports should export all scripts 1`] 
 Array [
   "addClass",
   "addStyle",
+  "getOffsetSizes",
   "matrix",
   "removeClass",
   "removeStyle",

--- a/packages/tests/utils/css/getOffsetSizes.spec.js
+++ b/packages/tests/utils/css/getOffsetSizes.spec.js
@@ -1,0 +1,14 @@
+import { getOffsetSizes } from '@studiometa/js-toolkit/utils';
+
+describe('The `getOffsetSizes` method', () => {
+  it('should return a DOMRect like Object', () => {
+    expect(getOffsetSizes(document.body)).toMatchSnapshot();
+  });
+
+  it('should return a DOMRect like object without transforms', () => {
+    const div = document.createElement('div');
+    div.style.transform = 'translateX(10px) rotate(45deg) scale(0.5)';
+    div.style.marginLeft = '10px';
+    expect(getOffsetSizes(div)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Changelog

### Added
- Add a `getOffsetSizes` function to get the sizes of an element without its transform (#226) 

### Fixed
- Fix usage of nested components using the `withScrolledInView` decorator (6b77517, #226) 