### PR TITLE
[Feature] Add a `getDirectChildren` helper

### DIFF
--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -198,10 +198,12 @@ function getDecoratorsSidebar() {
 function getHelpersSidebar() {
   return [
     { text: 'createApp', link: '/api/helpers/createApp.html' },
+    { text: 'getDirectChildren', link: '/api/helpers/getDirectChildren.html' },
     { text: 'getInstanceFromElement', link: '/api/helpers/getInstanceFromElement.html' },
     { text: 'importOnInteraction', link: '/api/helpers/importOnInteraction.html' },
     { text: 'importWhenIdle', link: '/api/helpers/importWhenIdle.html' },
     { text: 'importWhenVisible', link: '/api/helpers/importWhenVisible.html' },
+    { text: 'isDirectChild', link: '/api/helpers/isDirectChild.html' },
   ];
 }
 

--- a/packages/docs/api/helpers/getDirectChildren.md
+++ b/packages/docs/api/helpers/getDirectChildren.md
@@ -1,0 +1,43 @@
+# getDirectChildren
+
+Use the `getDirectChildren` function to get a list components which are direct descendants of the given parent instance. This function is helpful when working with nested components which declare themselves as children.
+
+:::tip
+If you need to only check if an instance is a direct descendant of another instance, prefer the [`isDirectChild` helper function](/api/helpers/isDirectChild.md) which will return a `boolean` directly.
+:::
+
+## Usage
+
+```js {1,9,16}
+import { Base, getDirectChildren } from '@studiometa/js-toolkit';
+import Child from './Child.js';
+
+class Parent extends Base {
+  static config = {
+    name: 'Parent',
+    components: {
+      Child,
+      Parent, // Useful for recursive components only
+    },
+  };
+
+  onChildClick(index, event) {
+    const childInstance = this.$children.Child[index];
+    const directChildren = getDirectChildren(this, 'Parent', 'Child');
+
+    if (directChildren.includes(childInstance)) {
+      event.preventDefault();
+    }
+  }
+}
+```
+
+**Parameters**
+
+- `parentInstance` (`Base`): the target element
+- `parentName` (`string`): the name of the recursive parent as specified in the `config.components` object.
+- `childrenName` (`string`): the name of the children components as specified in the `config.components` object.
+
+**Return value**
+
+- `Base[]`: a list of the direct child components corresponding to the given `childrenName`

--- a/packages/docs/api/helpers/getInstanceFromElement.md
+++ b/packages/docs/api/helpers/getInstanceFromElement.md
@@ -14,7 +14,7 @@ const componentInstance = getInstanceFromElement(document.body, Component);
 **Parameters**
 
 - `element` (`HTMLElement`): the target element
-- `BaseConstructor`: (`BaseConstructor`): the class (constructor) of the component to look for
+- `BaseConstructor` (`BaseConstructor`): the class (constructor) of the component to look for
 
 **Return value**
 

--- a/packages/docs/api/helpers/isDirectChild.md
+++ b/packages/docs/api/helpers/isDirectChild.md
@@ -1,0 +1,39 @@
+# isDirectChild
+
+Use the `isDirectChild` function to test if a child component instance is a direct descendant of the given parent instance. This function is helpful when working with nested components which declare themselves as children.
+
+## Usage
+
+```js {1,9,16}
+import { Base, isDirectChild } from '@studiometa/js-toolkit';
+import Child from './Child.js';
+
+class Parent extends Base {
+  static config = {
+    name: 'Parent',
+    components: {
+      Child,
+      Parent, // Useful for recursive components only
+    },
+  };
+
+  onChildClick(index, event) {
+    const childInstance = this.$children.Child[index];
+
+    if (isDirectChild(this, 'Parent', childInstance, 'Child')) {
+      event.preventDefault();
+    }
+  }
+}
+```
+
+**Parameters**
+
+- `parentInstance` (`Base`): the parent instance.
+- `parentName` (`string`): the name of the recursive parent as specified in the `config.components` object.
+- `childInstance` (`Base`): the child instance.
+- `childName` (`string`): the name of the child component as specified in the `config.components` object.
+
+**Return value**
+
+- `boolean`: `true` if the given child instance is a direct descendant of the given parent instance.

--- a/packages/docs/api/helpers/isDirectChild.md
+++ b/packages/docs/api/helpers/isDirectChild.md
@@ -20,7 +20,7 @@ class Parent extends Base {
   onChildClick(index, event) {
     const childInstance = this.$children.Child[index];
 
-    if (isDirectChild(this, 'Parent', childInstance, 'Child')) {
+    if (isDirectChild(this, 'Parent', 'Child', childInstance)) {
       event.preventDefault();
     }
   }
@@ -31,8 +31,8 @@ class Parent extends Base {
 
 - `parentInstance` (`Base`): the parent instance.
 - `parentName` (`string`): the name of the recursive parent as specified in the `config.components` object.
-- `childInstance` (`Base`): the child instance.
 - `childName` (`string`): the name of the child component as specified in the `config.components` object.
+- `childInstance` (`Base`): the child instance.
 
 **Return value**
 

--- a/packages/js-toolkit/helpers/getDirectChildren.js
+++ b/packages/js-toolkit/helpers/getDirectChildren.js
@@ -39,10 +39,10 @@ export function getDirectChildren(parentInstance, parentName, childrenName) {
  *
  * @param   {Base}    parentInstance
  * @param   {string}  parentName
- * @param   {Base}    childInstance
  * @param   {string}  childrenName
+ * @param   {Base}    childInstance
  * @returns {boolean}
  */
-export function isDirectChild(parentInstance, parentName, childInstance, childrenName) {
+export function isDirectChild(parentInstance, parentName, childrenName, childInstance) {
   return getDirectChildren(parentInstance, parentName, childrenName).includes(childInstance);
 }

--- a/packages/js-toolkit/helpers/getDirectChildren.js
+++ b/packages/js-toolkit/helpers/getDirectChildren.js
@@ -1,0 +1,26 @@
+/**
+ * Get direct children from a parent when working with nested components.
+ *
+ * @template {Base} T
+ * @param   {Base} parentInstance
+ * @param   {string} parentName
+ * @param   {string} childrenName
+ * @returns {Array<T>}
+ */
+export default function getDirectChildren(parentInstance, parentName, childrenName) {
+  if (!parentInstance.$children[childrenName]) {
+    return [];
+  }
+
+  if (!parentInstance.$children[parentName]) {
+    return parentInstance.$children[childrenName];
+  }
+
+  return parentInstance.$children[childrenName].filter((child) =>
+    parentInstance.$children[parentName].every((nestedParent) =>
+      nestedParent.$children[childrenName]
+        ? !nestedParent.$children[childrenName].includes(child)
+        : true
+    )
+  );
+}

--- a/packages/js-toolkit/helpers/getDirectChildren.js
+++ b/packages/js-toolkit/helpers/getDirectChildren.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('../Base/index.js').default} Base
+ */
+
+/**
  * Get direct children from a parent when working with nested components.
  *
  * @template {Base} T
@@ -7,7 +11,7 @@
  * @param   {string} childrenName
  * @returns {Array<T>}
  */
-export default function getDirectChildren(parentInstance, parentName, childrenName) {
+export function getDirectChildren(parentInstance, parentName, childrenName) {
   if (!parentInstance.$children[childrenName]) {
     return [];
   }
@@ -23,4 +27,17 @@ export default function getDirectChildren(parentInstance, parentName, childrenNa
         : true
     )
   );
+}
+
+/**
+ * Test if a component instance is a direct child from the given component.
+ *
+ * @param   {Base}    parentInstance
+ * @param   {string}  parentName
+ * @param   {Base}    childInstance
+ * @param   {string}  childrenName
+ * @returns {boolean}
+ */
+export function isDirectChild(parentInstance, parentName, childInstance, childrenName) {
+  return getDirectChildren(parentInstance, parentName, childrenName).includes(childInstance);
 }

--- a/packages/js-toolkit/helpers/getDirectChildren.js
+++ b/packages/js-toolkit/helpers/getDirectChildren.js
@@ -1,3 +1,5 @@
+import { isArray } from '../utils/index.js';
+
 /**
  * @typedef {import('../Base/index.js').default} Base
  */
@@ -12,21 +14,24 @@
  * @returns {Array<T>}
  */
 export function getDirectChildren(parentInstance, parentName, childrenName) {
-  if (!parentInstance.$children[childrenName]) {
+  const children = parentInstance.$children[childrenName];
+  const nestedParents = parentInstance.$children[parentName];
+
+  if (!isArray(children)) {
     return [];
   }
 
-  if (!parentInstance.$children[parentName]) {
-    return parentInstance.$children[childrenName];
+  if (!isArray(nestedParents) || nestedParents.length <= 0) {
+    return children;
   }
 
-  return parentInstance.$children[childrenName].filter((child) =>
-    parentInstance.$children[parentName].every((nestedParent) =>
-      nestedParent.$children[childrenName]
-        ? !nestedParent.$children[childrenName].includes(child)
-        : true
-    )
-  );
+  return children.filter((child) => {
+    return nestedParents.every((nestedParent) => {
+      const nestedChildren = nestedParent.$children[childrenName];
+      /* istanbul ignore next */
+      return isArray(nestedChildren) ? !nestedChildren.includes(child) : true;
+    });
+  });
 }
 
 /**

--- a/packages/js-toolkit/helpers/index.js
+++ b/packages/js-toolkit/helpers/index.js
@@ -1,5 +1,5 @@
 export { default as createApp } from './createApp.js';
-export { default as getDirectChildren } from './getDirectChildren.js';
+export * from './getDirectChildren.js';
 export { default as getInstanceFromElement } from './getInstanceFromElement.js';
 export { default as importOnInteraction } from './importOnInteraction.js';
 export { default as importWhenIdle } from './importWhenIdle.js';

--- a/packages/js-toolkit/helpers/index.js
+++ b/packages/js-toolkit/helpers/index.js
@@ -1,4 +1,5 @@
 export { default as createApp } from './createApp.js';
+export { default as getDirectChildren } from './getDirectChildren.js';
 export { default as getInstanceFromElement } from './getInstanceFromElement.js';
 export { default as importOnInteraction } from './importOnInteraction.js';
 export { default as importWhenIdle } from './importWhenIdle.js';

--- a/packages/tests/__snapshots__/index.spec.js.snap
+++ b/packages/tests/__snapshots__/index.spec.js.snap
@@ -4,10 +4,12 @@ exports[`The package exports should export helpers and the Base class 1`] = `
 Array [
   "Base",
   "createApp",
+  "getDirectChildren",
   "getInstanceFromElement",
   "importOnInteraction",
   "importWhenIdle",
   "importWhenVisible",
+  "isDirectChild",
   "useDrag",
   "useKey",
   "useLoad",

--- a/packages/tests/helpers/__snapshots__/index.spec.js.snap
+++ b/packages/tests/helpers/__snapshots__/index.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`helpers exports 1`] = `
+Array [
+  "createApp",
+  "getDirectChildren",
+  "getInstanceFromElement",
+  "importOnInteraction",
+  "importWhenIdle",
+  "importWhenVisible",
+  "isDirectChild",
+]
+`;

--- a/packages/tests/helpers/getDirectChildren.spec.js
+++ b/packages/tests/helpers/getDirectChildren.spec.js
@@ -1,39 +1,44 @@
-import { Base, getDirectChildren, getInstanceFromElement } from '@studiometa/js-toolkit';
+import {
+  Base,
+  getDirectChildren,
+  getInstanceFromElement,
+  isDirectChild,
+} from '@studiometa/js-toolkit';
+
+class Child extends Base {
+  static config = {
+    name: 'Child',
+  };
+}
+
+class Parent extends Base {
+  static config = {
+    name: 'Parent',
+    components: {
+      Child,
+      Parent,
+    },
+  };
+}
+
+const div = document.createElement('div');
+div.innerHTML = `
+  <div data-component="Parent">
+    <div data-component="Child" id="first-child"></div>
+    <div data-component="Parent">
+      <div data-component="Child" id="grand-child"></div>
+    </div>
+  </div>
+`;
+const firstChild = div.querySelector('#first-child');
+const grandChild = div.querySelector('#grand-child');
+
+const parent = new Parent(div.firstElementChild);
+parent.$mount();
+
+const directChildren = getDirectChildren(parent, 'Parent', 'Child');
 
 describe('The `getDirectChildren` helper function', () => {
-  class Child extends Base {
-    static config = {
-      name: 'Child',
-    };
-  }
-
-  class Parent extends Base {
-    static config = {
-      name: 'Parent',
-      components: {
-        Child,
-        Parent,
-      },
-    };
-  }
-
-  const div = document.createElement('div');
-  div.innerHTML = `
-    <div data-component="Parent">
-      <div data-component="Child" id="first-child"></div>
-      <div data-component="Parent">
-        <div data-component="Child" id="grand-child"></div>
-      </div>
-    </div>
-  `;
-  const firstChild = div.querySelector('#first-child');
-  const grandChild = div.querySelector('#grand-child');
-
-  const parent = new Parent(div.firstElementChild);
-  parent.$mount();
-
-  const directChildren = getDirectChildren(parent, 'Parent', 'Child');
-
   it('should return first-child components', () => {
     expect(directChildren).toHaveLength(1);
     expect(directChildren).toEqual([getInstanceFromElement(firstChild, Child)]);
@@ -41,5 +46,19 @@ describe('The `getDirectChildren` helper function', () => {
 
   it('should not return grand-child components', () => {
     expect(getDirectChildren(parent, 'Parent', 'Child')).not.toContain(grandChild);
+  });
+});
+
+describe('The `isDirectChild` helper function', () => {
+  it('should return true when a component is a direct child', () => {
+    expect(
+      isDirectChild(parent, 'Parent', getInstanceFromElement(firstChild, Child), 'Child')
+    ).toBe(true);
+  });
+
+  it('should return false when a component is a grand child', () => {
+    expect(
+      isDirectChild(parent, 'Parent', getInstanceFromElement(grandChild, Child), 'Child')
+    ).toBe(false);
   });
 });

--- a/packages/tests/helpers/getDirectChildren.spec.js
+++ b/packages/tests/helpers/getDirectChildren.spec.js
@@ -71,13 +71,13 @@ describe('The `getDirectChildren` helper function', () => {
 describe('The `isDirectChild` helper function', () => {
   it('should return true when a component is a direct child', () => {
     expect(
-      isDirectChild(parent, 'Parent', getInstanceFromElement(firstChild, Child), 'Child')
+      isDirectChild(parent, 'Parent', 'Child', getInstanceFromElement(firstChild, Child))
     ).toBe(true);
   });
 
   it('should return false when a component is a grand child', () => {
     expect(
-      isDirectChild(parent, 'Parent', getInstanceFromElement(grandChild, Child), 'Child')
+      isDirectChild(parent, 'Parent', 'Child', getInstanceFromElement(grandChild, Child))
     ).toBe(false);
   });
 });

--- a/packages/tests/helpers/getDirectChildren.spec.js
+++ b/packages/tests/helpers/getDirectChildren.spec.js
@@ -16,6 +16,7 @@ class Parent extends Base {
     name: 'Parent',
     components: {
       Child,
+      OtherChild: Child,
       Parent,
     },
   };
@@ -39,6 +40,11 @@ parent.$mount();
 const directChildren = getDirectChildren(parent, 'Parent', 'Child');
 
 describe('The `getDirectChildren` helper function', () => {
+  it('should return an empty array if no children components where found', () => {
+    expect(getDirectChildren(parent, 'Parent', 'OtherChild')).toEqual([]);
+    expect(getDirectChildren(parent, 'Parent', 'UndefinedChild')).toEqual([]);
+  });
+
   it('should return first-child components', () => {
     expect(directChildren).toHaveLength(1);
     expect(directChildren).toEqual([getInstanceFromElement(firstChild, Child)]);
@@ -46,6 +52,19 @@ describe('The `getDirectChildren` helper function', () => {
 
   it('should not return grand-child components', () => {
     expect(getDirectChildren(parent, 'Parent', 'Child')).not.toContain(grandChild);
+  });
+
+  it('should return all children if there is no nested parent', () => {
+    const el = document.createElement('div');
+    el.innerHTML = `
+      <div data-component="Parent">
+        <div data-component="Child"></div>
+        <div data-component="Child"></div>
+      </div>
+    `;
+    const instance = new Parent(el.firstElementChild);
+    instance.$mount();
+    expect(getDirectChildren(instance, 'Parent', 'Child')).toHaveLength(2);
   });
 });
 

--- a/packages/tests/helpers/getDirectChildren.spec.js
+++ b/packages/tests/helpers/getDirectChildren.spec.js
@@ -1,0 +1,45 @@
+import { Base, getDirectChildren, getInstanceFromElement } from '@studiometa/js-toolkit';
+
+describe('The `getDirectChildren` helper function', () => {
+  class Child extends Base {
+    static config = {
+      name: 'Child',
+    };
+  }
+
+  class Parent extends Base {
+    static config = {
+      name: 'Parent',
+      components: {
+        Child,
+        Parent,
+      },
+    };
+  }
+
+  const div = document.createElement('div');
+  div.innerHTML = `
+    <div data-component="Parent">
+      <div data-component="Child" id="first-child"></div>
+      <div data-component="Parent">
+        <div data-component="Child" id="grand-child"></div>
+      </div>
+    </div>
+  `;
+  const firstChild = div.querySelector('#first-child');
+  const grandChild = div.querySelector('#grand-child');
+
+  const parent = new Parent(div.firstElementChild);
+  parent.$mount();
+
+  const directChildren = getDirectChildren(parent, 'Parent', 'Child');
+
+  it('should return first-child components', () => {
+    expect(directChildren).toHaveLength(1);
+    expect(directChildren).toEqual([getInstanceFromElement(firstChild, Child)]);
+  });
+
+  it('should not return grand-child components', () => {
+    expect(getDirectChildren(parent, 'Parent', 'Child')).not.toContain(grandChild);
+  });
+});

--- a/packages/tests/helpers/index.spec.js
+++ b/packages/tests/helpers/index.spec.js
@@ -1,7 +1,5 @@
 import * as helpers from '@studiometa/js-toolkit/helpers';
-import getFilenamesInFolder from '../__utils__/getFilenamesInFolder.js';
 
 test('helpers exports', () => {
-  const names = getFilenamesInFolder('../../js-toolkit/helpers/', import.meta.url).filter(key => key !== 'utils');
-  expect(Object.keys(helpers)).toEqual(names);
+  expect(Object.keys(helpers)).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR introduces a new helper `getDirectChildren` which should be used when working with nested components to easily filter direct children from nested ones. 

Example usage:

```js
import { Base, getDirectChildren, isDirectChild } from '@studiometa/js-toolkit';
import Child from './Child.js';

class Parent extends Base {
  static config = {
    name: 'Parent',
    components: {
      Parent, // The parent component is recursive
      Child,
    },
  };

  onChildClick(index) {
    if (getDirectChildren(this, 'Parent', 'Child').includes(this.$children.Child[index]) {
      // Do something when only the `#first-child` component is clicked
    }

    if (isDirectChild(this, 'Parent', this.$children.Child[index], 'Child')) {
      // Do something when only the `#first-child` component is clicked
    }
  }
}
```

```html
<div data-component="Parent">
  <div data-component="Child" id="first-child"></div>
  <div data-component="Parent">
    <div data-component="Child"></div>
  </div>
</div>
```

## Changelog

### Added
- Add a `getDirectChildren(parentInstance, parentName, childrenName)` helper function (#253, c89e123)
- Add a `isDirectChild(parentInstance, parentName, childInstance, childName)` helper function (#253, 04693b0)

## To do
- [x] Add tests
- [x] Add doc