### PR TITLE
[Feature] Add support for `onDocument<Event>` and `onWindow<Event>` hook methods

### DIFF
--- a/packages/demo/src/js/app.ts
+++ b/packages/demo/src/js/app.ts
@@ -26,7 +26,7 @@ class App extends Base {
   static config = {
     name: 'App',
     refs: ['modal'],
-    log: false,
+    log: true,
     components: {
       ParentNativeEvent,
       AnimateTest,
@@ -128,6 +128,14 @@ class App extends Base {
 
   resized(props) {
     this.$log('resized', props);
+  }
+
+  onDocumentClick(event) {
+    console.log('onDocumentClick', event);
+  }
+
+  onWindowResize(event) {
+    console.log('onWindowResize', event);
   }
 }
 

--- a/packages/docs/.vitepress/theme/components/Search.vue
+++ b/packages/docs/.vitepress/theme/components/Search.vue
@@ -128,7 +128,9 @@
       .map((link) =>
         defineAction({
           id: link.link,
-          name: [link?.keywords ?? '', link.text, link.parent?.text ?? '', link.root?.text ?? ''].flat().join(' '),
+          name: [link?.keywords ?? '', link.text, link.parent?.text ?? '', link.root?.text ?? '']
+            .flat()
+            .join(' '),
           link,
           section: link.parent
             ? link.root

--- a/packages/docs/api/methods-hooks-events.md
+++ b/packages/docs/api/methods-hooks-events.md
@@ -104,6 +104,7 @@ Native DOM events registered on a child component will be binded to the child ro
 Methods following this pattern will be triggered when the `event` event is dispatched on the `document`.
 
 **Arguments**
+
 - `event` (`Event`): The event object
 
 **Examples**
@@ -135,6 +136,7 @@ class Dropdown extends Base {
 Methods following this pattern will be triggered when the `event` event is dispatched on the `window`.
 
 **Arguments**
+
 - `event` (`Event`): The event object
 
 **Examples**

--- a/packages/docs/api/methods-hooks-events.md
+++ b/packages/docs/api/methods-hooks-events.md
@@ -98,3 +98,59 @@ Native DOM events registered on a child component will be binded to the child ro
   new Foo(document.querySelector('[data-component="Foo"]'));
 </script>
 ```
+
+## `onDocument<Event>`
+
+Methods following this pattern will be triggered when the `event` event is dispatched on the `document`.
+
+**Arguments**
+- `event` (`Event`): The event object
+
+**Examples**
+
+Implement a click-outside behaviour:
+
+```js {14-16}
+import { Base } from '@studiometa/js-toolkit';
+
+class Dropdown extends Base {
+  static config = {
+    name: 'Dropdown',
+    refs: ['btn'],
+  };
+
+  onBtnClick(event) {
+    event.stopPropagation();
+    this.open();
+  }
+
+  onDocumentClick() {
+    this.close();
+  }
+}
+```
+
+## `onWindow<Event>`
+
+Methods following this pattern will be triggered when the `event` event is dispatched on the `window`.
+
+**Arguments**
+- `event` (`Event`): The event object
+
+**Examples**
+
+Watch the page hash:
+
+```js {8-10}
+import { Base } from '@studiometa/js-toolkit';
+
+class Component extends Base {
+  static config = {
+    name: 'Component',
+  };
+
+  onWindowHashchange(event) {
+    // do something with the new hash...
+  }
+}
+```

--- a/packages/docs/guide/going-further/typing-components.md
+++ b/packages/docs/guide/going-further/typing-components.md
@@ -12,9 +12,9 @@ interface BaseProps {
   $options: Record<string, any>;
   $refs: Record<string, HTMLElement | HTMLElement[]>;
   $children: Record<string, Base | Promise<Base>>;
-};
+}
 
-declare class Base<T extends BaseProps = BaseProps> {};
+declare class Base<T extends BaseProps = BaseProps> {}
 ```
 
 See below for an example of how to define the type parameter in JSDoc or in TypeScript.
@@ -89,7 +89,6 @@ export default class Component extends Base {
   resized(props) {
     this.$log(props.orientation); // 'square' | 'portrait' | 'landscape'
   }
-
 }
 ```
 
@@ -115,7 +114,7 @@ interface ComponentProps extends BaseProps {
     Figure: Figure;
     LazyComponent: Promise<LazyComponent>;
   };
-};
+}
 
 export default class Component extends Base<ComponentProps> {
   static config: BaseConfig = {
@@ -141,7 +140,7 @@ export default class Component extends Base<ComponentProps> {
     this.$children.LazyComponent; // Promise<LazyComponent>[]
   }
 
-  resized(props:ResizeServiceProps) {
+  resized(props: ResizeServiceProps) {
     this.$log(props.orientation); // 'square' | 'portrait' | 'landscape'
   }
 }
@@ -211,7 +210,7 @@ With TypeScript, you can directly use the type parameter on the returned value o
 
 ```ts
 import { Base, withIntersectionObserver } from '@studiometa/js-toolkit';
-import type { BaseProps } from '@studiometa/js-toolkit'
+import type { BaseProps } from '@studiometa/js-toolkit';
 import Component from './Component.js';
 
 export interface ChildComponentProps extends BaseProps {
@@ -220,7 +219,9 @@ export interface ChildComponentProps extends BaseProps {
   };
 }
 
-export class ChildComponent<T extends BaseProps = BaseProps> extends withIntersectionObserver<Component>(Component)<T & ChildComponentProps> {
+export class ChildComponent<
+  T extends BaseProps = BaseProps,
+> extends withIntersectionObserver<Component>(Component)<T & ChildComponentProps> {
   mounted() {
     this.$log(this.$observer); // IntersectionObserver
     this.$log(this.$options.intersectionObserver); // IntersectionObserverInit
@@ -293,9 +294,7 @@ export interface ComponentProps extends BaseProps {
   // ...
 }
 
-export class Component<T extends BaseProps = BaseProps> extends Base<
-  T & ComponentProps
-> {
+export class Component<T extends BaseProps = BaseProps> extends Base<T & ComponentProps> {
   static config: BaseConfig = {
     name: 'Component',
   };

--- a/packages/docs/guide/introduction/working-with-events.md
+++ b/packages/docs/guide/introduction/working-with-events.md
@@ -24,3 +24,8 @@ Handlers can be unbounded from an event with the [`$off(event, handler)`](/api/i
 ### on\<Refname>\<Event>
 
 ### on\<Childname>\<Event>
+
+### onDocument\<Event>
+
+### onWindow\<Event>
+

--- a/packages/docs/guide/introduction/working-with-events.md
+++ b/packages/docs/guide/introduction/working-with-events.md
@@ -28,4 +28,3 @@ Handlers can be unbounded from an event with the [`$off(event, handler)`](/api/i
 ### onDocument\<Event>
 
 ### onWindow\<Event>
-

--- a/packages/js-toolkit/Base/managers/EventsManager.ts
+++ b/packages/js-toolkit/Base/managers/EventsManager.ts
@@ -6,6 +6,9 @@ import AbstractManager from './AbstractManager.js';
 import { normalizeRefName } from './RefsManager.js';
 
 const names = new Map();
+const normalizeRegex1 = /[A-Z]([A-Z].*)/g;
+const normalizeRegex2 = /[^a-zA-Z\d\s:]/g;
+const normalizeRegex3 = /(^\w|\s+\w)/g;
 
 /**
  * Normalize the given name to PascalCase, such as:
@@ -32,10 +35,10 @@ export function normalizeName(name: string): string {
     names.set(
       name,
       name
-        .replace(/[A-Z]([A-Z].*)/g, (c) => c.toLowerCase())
-        .replace(/[^a-zA-Z\d\s:]/g, ' ')
-        .replace(/(^\w|\s+\w)/g, (c) => c.trim().toUpperCase())
-        .trim(),
+        .replace(normalizeRegex1, (c) => c.toLowerCase())
+        .replace(normalizeRegex2, ' ')
+        .replace(normalizeRegex3, (c) => c.trim().toUpperCase())
+        .trim()
     );
   }
 
@@ -44,6 +47,8 @@ export function normalizeName(name: string): string {
 
 const eventNames = new Map();
 
+const normalizeEventRegex1 = /[A-Z]/g;
+const normalizeEventRegex2 = /^-/;
 /**
  * Normalize the event names from PascalCase to kebab-case.
  *
@@ -52,7 +57,12 @@ const eventNames = new Map();
  */
 export function normalizeEventName(name: string): string {
   if (!eventNames.has(name)) {
-    eventNames.set(name, name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`).replace(/^-/, ''));
+    eventNames.set(
+      name,
+      name
+        .replace(normalizeEventRegex1, (c) => `-${c.toLowerCase()}`)
+        .replace(normalizeEventRegex2, '')
+    );
   }
 
   return eventNames.get(name);

--- a/packages/js-toolkit/Base/managers/EventsManager.ts
+++ b/packages/js-toolkit/Base/managers/EventsManager.ts
@@ -215,7 +215,6 @@ function manageRootElement(that:EventsManager, mode:'add' | 'remove' = 'add') {
     } else if (methodIsGlobal(method)) {
       event = getEventNameByMethod(method, methodIsDocument(method) ? 'document' : 'window');
       const target = getGlobalEventTarget(method);
-      console.log('method is global', { method, event, target });
       target[modeMethod](
         event,
         methodIsDocument(method) ? that.__documentHandler : that.__windowHandler

--- a/packages/js-toolkit/Base/managers/EventsManager.ts
+++ b/packages/js-toolkit/Base/managers/EventsManager.ts
@@ -38,7 +38,7 @@ export function normalizeName(name: string): string {
         .replace(normalizeRegex1, (c) => c.toLowerCase())
         .replace(normalizeRegex2, ' ')
         .replace(normalizeRegex3, (c) => c.trim().toUpperCase())
-        .trim()
+        .trim(),
     );
   }
 
@@ -61,7 +61,7 @@ export function normalizeEventName(name: string): string {
       name,
       name
         .replace(normalizeEventRegex1, (c) => `-${c.toLowerCase()}`)
-        .replace(normalizeEventRegex2, '')
+        .replace(normalizeEventRegex2, ''),
     );
   }
 
@@ -200,7 +200,7 @@ const getGlobalEventTarget = (method) => (methodIsDocument(method) ? document : 
  * @private
  */
 // eslint-disable-next-line no-use-before-define
-function manageRootElement(that:EventsManager, mode:'add' | 'remove' = 'add') {
+function manageRootElement(that: EventsManager, mode: 'add' | 'remove' = 'add') {
   const modeMethod = `${mode}EventListener`;
   const methods = getEventMethodsByName(that);
 
@@ -217,7 +217,7 @@ function manageRootElement(that:EventsManager, mode:'add' | 'remove' = 'add') {
       const target = getGlobalEventTarget(method);
       target[modeMethod](
         event,
-        methodIsDocument(method) ? that.__documentHandler : that.__windowHandler
+        methodIsDocument(method) ? that.__documentHandler : that.__windowHandler,
       );
     }
   });
@@ -229,13 +229,13 @@ function manageRootElement(that:EventsManager, mode:'add' | 'remove' = 'add') {
  * @todo Use event delegation?
  */
 export default class EventsManager extends AbstractManager {
-  __methodsCache:Map<string, string[]> = new Map();
+  __methodsCache: Map<string, string[]> = new Map();
 
   /**
    * Event listener object for the root element.
    */
-  __rootElementHandler:EventListenerObject = {
-    handleEvent: (event:Event | CustomEvent) => {
+  __rootElementHandler: EventListenerObject = {
+    handleEvent: (event: Event | CustomEvent) => {
       const normalizedEventName = normalizeName(event.type);
       const method = `on${normalizedEventName}`;
 
@@ -286,7 +286,7 @@ export default class EventsManager extends AbstractManager {
   /**
    * Event listener object for the refs.
    */
-  __refsHandler:EventListenerObject = {
+  __refsHandler: EventListenerObject = {
     handleEvent: (event) => {
       const ref = event.currentTarget as HTMLElement;
       const refName = normalizeRefName(ref.dataset.ref);
@@ -307,8 +307,8 @@ export default class EventsManager extends AbstractManager {
   /**
    * Event listener object for the children.
    */
-  __childrenHandler:EventListenerObject = {
-    handleEvent: (event:CustomEvent) => {
+  __childrenHandler: EventListenerObject = {
+    handleEvent: (event: CustomEvent) => {
       const childrenManager = this.__base.$children;
 
       // @todo handle async child components
@@ -336,7 +336,7 @@ export default class EventsManager extends AbstractManager {
   /**
    * Class constructor.
    */
-  constructor(base:Base) {
+  constructor(base: Base) {
     super(base);
 
     this.__hideProperties([
@@ -344,6 +344,8 @@ export default class EventsManager extends AbstractManager {
       '__rootElementHandler',
       '__refsHandler',
       '__childrenHandler',
+      '__documentHandler',
+      '__windowHandler',
     ]);
   }
 
@@ -356,7 +358,7 @@ export default class EventsManager extends AbstractManager {
    *   The elements of the ref.
    * @returns {void}
    */
-  bindRef(name:string, elements:HTMLElement[]) {
+  bindRef(name: string, elements: HTMLElement[]) {
     manageRef(this, name, elements);
   }
 
@@ -369,7 +371,7 @@ export default class EventsManager extends AbstractManager {
    *   The elements of the ref.
    * @returns {void}
    */
-  unbindRef(name:string, elements:HTMLElement[]) {
+  unbindRef(name: string, elements: HTMLElement[]) {
     manageRef(this, name, elements, 'remove');
   }
 
@@ -382,7 +384,7 @@ export default class EventsManager extends AbstractManager {
    *   A base instance.
    * @returns {void}
    */
-  bindChild(name:string, instance:Base) {
+  bindChild(name: string, instance: Base) {
     manageChild(this, name, instance);
   }
 
@@ -395,7 +397,7 @@ export default class EventsManager extends AbstractManager {
    *   A base instance.
    * @returns {void}
    */
-  unbindChild(name:string, instance:Base) {
+  unbindChild(name: string, instance: Base) {
     manageChild(this, name, instance, 'remove');
   }
 

--- a/packages/tests/Base/managers/EventsManager.spec.js
+++ b/packages/tests/Base/managers/EventsManager.spec.js
@@ -9,6 +9,8 @@ import wait from '../../__utils__/wait';
 
 describe('The EventsManager class', () => {
   const rootElementFn = jest.fn();
+  const documentFn = jest.fn();
+  const windowFn = jest.fn();
   const singleRefFn = jest.fn();
   const multipleRefFn = jest.fn();
   const componentFn = jest.fn();
@@ -45,6 +47,14 @@ describe('The EventsManager class', () => {
 
     onClick(...args) {
       rootElementFn(...args);
+    }
+
+    onDocumentClick(...args) {
+      documentFn(...args);
+    }
+
+    onWindowClick(...args) {
+      windowFn(...args);
     }
 
     onSingleClick(...args) {
@@ -94,12 +104,16 @@ describe('The EventsManager class', () => {
 
   const app = new App(tpl);
 
+  const clickEvent = new Event('click');
+
   beforeEach(() => {
     rootElementFn.mockClear();
     singleRefFn.mockClear();
     multipleRefFn.mockClear();
     componentFn.mockClear();
     asyncComponentFn.mockClear();
+    documentFn.mockClear();
+    windowFn.mockClear();
   });
 
   it('can bind event methods to the root element', () => {
@@ -114,6 +128,34 @@ describe('The EventsManager class', () => {
     app.$destroy();
     tpl.click();
     expect(rootElementFn).not.toHaveBeenCalled();
+  });
+
+  it('can bind event methods to the document', () => {
+    document.dispatchEvent(clickEvent);
+    expect(documentFn).not.toHaveBeenCalled();
+    app.$mount();
+    document.dispatchEvent(clickEvent);
+    expect(documentFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('can unbind event methods from the document', () => {
+    app.$destroy();
+    document.dispatchEvent(clickEvent);
+    expect(documentFn).not.toHaveBeenCalled();
+  });
+
+  it('can bind event methods to the window', () => {
+    window.dispatchEvent(clickEvent);
+    expect(windowFn).not.toHaveBeenCalled();
+    app.$mount();
+    window.dispatchEvent(clickEvent);
+    expect(windowFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('can unbind event methods from the window', () => {
+    app.$destroy();
+    window.dispatchEvent(clickEvent);
+    expect(windowFn).not.toHaveBeenCalled();
   });
 
   it('can bind event methods to single refs', () => {
@@ -158,20 +200,20 @@ describe('The EventsManager class', () => {
       1,
       2,
       0,
-      expect.objectContaining({ type: 'custom-event', detail: [1, 2] })
+      expect.objectContaining({ type: 'custom-event', detail: [1, 2] }),
     );
     expect(componentInnerFn).toHaveBeenLastCalledWith(
       1,
       2,
-      expect.objectContaining({ type: 'custom-event', detail: [1, 2] })
+      expect.objectContaining({ type: 'custom-event', detail: [1, 2] }),
     );
     app.$children.Component[0].dispatchEvent(new CustomEvent('custom-event'));
     expect(componentFn).toHaveBeenLastCalledWith(
       0,
-      expect.objectContaining({ type: 'custom-event', detail: null })
+      expect.objectContaining({ type: 'custom-event', detail: null }),
     );
     expect(componentInnerFn).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: 'custom-event', detail: null })
+      expect.objectContaining({ type: 'custom-event', detail: null }),
     );
     app.$children.Component[0].$el.click();
     expect(componentFn).toHaveBeenLastCalledWith(0, expect.objectContaining({ type: 'click' }));
@@ -189,12 +231,12 @@ describe('The EventsManager class', () => {
       1,
       2,
       0,
-      expect.objectContaining({ type: 'custom-event', detail: [1, 2] })
+      expect.objectContaining({ type: 'custom-event', detail: [1, 2] }),
     );
     expect(componentInnerFn).toHaveBeenLastCalledWith(
       1,
       2,
-      expect.objectContaining({ type: 'custom-event', detail: [1, 2] })
+      expect.objectContaining({ type: 'custom-event', detail: [1, 2] }),
     );
     app.$destroy();
   });


### PR DESCRIPTION
This PR introduces 2 new patterns for methods hooks, allowing to attach event listener to the `document` or the `window` object. This can be useful when needing to implement a "click outside" behavior.

## Changelog

### Added
- Add support for `onDocument…` and `onWindow…` hook methods (d0051fc)

### Changed
- Improve regex performances in `EventsManager` (d06d9a6)

## To-do

- [x] Update doc
- [x] Wait for @studiometa/core feedback
- [x] Add tests