### PR TITLE
[Bugfix] Fix the `withScrolledInView` deactivation

### DIFF
--- a/packages/docs/api/decorators/withScrolledInView.md
+++ b/packages/docs/api/decorators/withScrolledInView.md
@@ -87,6 +87,7 @@ The `scrolledInView` class method will be triggered for each frame of the compon
   - `props.start` (`{ x: number, y: number }`): The scroll position were the element starts to be visible.
   - `props.end` (`{ x: number, y: number }`): The scroll position were the element is not visible anymore.
   - `props.current` (`{ x: number, y: number }`): The current scroll position, clamped in the `props.start` and `props.end` range.
+  - `props.dampedCurrent` (`{ x: number, y: number }`): The current values smoothed with the [`damp` function](/utils/math/damp.md)
   - `props.progress` (`{ x: number, y: number }`): The progress of the element between `props.start` and `props.end` mapped to a `0–1` range.
   - `props.dampedProgress` (`{ x: number, y: number }`): The progress values smoothed with the [`damp` function](/utils/math/damp.md).
 

--- a/packages/js-toolkit/decorators/withScrolledInView.js
+++ b/packages/js-toolkit/decorators/withScrolledInView.js
@@ -9,6 +9,26 @@ const scheduler = useScheduler(['update', 'render']);
  * @typedef {import('../Base').BaseConfig} BaseConfig
  */
 
+function updateProps(props, dampFactor, dampPrecision, axis = 'x') {
+  props.current[axis] = clamp(
+    axis === 'x' ? window.pageXOffset : window.pageYOffset,
+    props.start[axis],
+    props.end[axis]
+  );
+  props.dampedCurrent[axis] = damp(
+    props.current[axis],
+    props.dampedCurrent[axis],
+    dampFactor,
+    dampPrecision
+  );
+  props.progress[axis] = clamp01(
+    (props.current[axis] - props.start[axis]) / (props.end[axis] - props.start[axis])
+  );
+  props.dampedProgress[axis] = clamp01(
+    (props.dampedCurrent[axis] - props.start[axis]) / (props.end[axis] - props.start[axis])
+  );
+}
+
 /**
  * Add scrolled in view capabilities to a component.
  *
@@ -91,47 +111,8 @@ export default function withScrolledInView(BaseClass, options = {}) {
           }
         },
         ticked: () => {
-          // X axis
-          this.__props.current.x = clamp(
-            window.pageXOffset,
-            this.__props.start.x,
-            this.__props.end.x
-          );
-          this.__props.dampedCurrent.x = damp(
-            this.__props.current.x,
-            this.__props.dampedCurrent.x,
-            this.dampFactor,
-            this.dampPrecision
-          );
-          this.__props.progress.x = clamp01(
-            (this.__props.current.x - this.__props.start.x) /
-              (this.__props.end.x - this.__props.start.x)
-          );
-          this.__props.dampedProgress.x = clamp01(
-            (this.__props.dampedCurrent.x - this.__props.start.x) /
-              (this.__props.end.x - this.__props.start.x)
-          );
-
-          // Y axis
-          this.__props.current.y = clamp(
-            window.pageYOffset,
-            this.__props.start.y,
-            this.__props.end.y
-          );
-          this.__props.dampedCurrent.y = damp(
-            this.__props.current.y,
-            this.__props.dampedCurrent.y,
-            this.dampFactor,
-            this.dampPrecision
-          );
-          this.__props.progress.y = clamp01(
-            (this.__props.current.y - this.__props.start.y) /
-              (this.__props.end.y - this.__props.start.y)
-          );
-          this.__props.dampedProgress.y = clamp01(
-            (this.__props.dampedCurrent.y - this.__props.start.y) /
-              (this.__props.end.y - this.__props.start.y)
-          );
+          updateProps(this.__props, this.dampFactor, this.dampPrecision, 'x');
+          updateProps(this.__props, this.dampFactor, this.dampPrecision, 'y');
 
           if (
             this.__props.dampedCurrent.x === this.__props.current.x &&

--- a/packages/js-toolkit/decorators/withScrolledInView.js
+++ b/packages/js-toolkit/decorators/withScrolledInView.js
@@ -45,6 +45,10 @@ export default function withScrolledInView(BaseClass, options = {}) {
         x: 0,
         y: 0,
       },
+      dampedCurrent: {
+        x: 0,
+        y: 0,
+      },
       progress: {
         x: 0,
         y: 0,
@@ -93,15 +97,19 @@ export default function withScrolledInView(BaseClass, options = {}) {
             this.__props.start.x,
             this.__props.end.x
           );
+          this.__props.dampedCurrent.x = damp(
+            this.__props.current.x,
+            this.__props.dampedCurrent.x,
+            this.dampFactor,
+            this.dampPrecision
+          );
           this.__props.progress.x = clamp01(
             (this.__props.current.x - this.__props.start.x) /
               (this.__props.end.x - this.__props.start.x)
           );
-          this.__props.dampedProgress.x = damp(
-            this.__props.progress.x,
-            this.__props.dampedProgress.x,
-            this.dampFactor,
-            this.dampPrecision
+          this.__props.dampedProgress.x = clamp01(
+            (this.__props.dampedCurrent.x - this.__props.start.x) /
+              (this.__props.end.x - this.__props.start.x)
           );
 
           // Y axis
@@ -110,20 +118,24 @@ export default function withScrolledInView(BaseClass, options = {}) {
             this.__props.start.y,
             this.__props.end.y
           );
+          this.__props.dampedCurrent.y = damp(
+            this.__props.current.y,
+            this.__props.dampedCurrent.y,
+            this.dampFactor,
+            this.dampPrecision
+          );
           this.__props.progress.y = clamp01(
             (this.__props.current.y - this.__props.start.y) /
               (this.__props.end.y - this.__props.start.y)
           );
-          this.__props.dampedProgress.y = damp(
-            this.__props.progress.y,
-            this.__props.dampedProgress.y,
-            this.dampFactor,
-            this.dampPrecision
+          this.__props.dampedProgress.y = clamp01(
+            (this.__props.dampedCurrent.y - this.__props.start.y) /
+              (this.__props.end.y - this.__props.start.y)
           );
 
           if (
-            this.__props.dampedProgress.x === this.__props.progress.x &&
-            this.__props.dampedProgress.y === this.__props.progress.y
+            this.__props.dampedCurrent.x === this.__props.current.x &&
+            this.__props.dampedCurrent.y === this.__props.current.y
           ) {
             this.$services.disable('ticked');
           }

--- a/packages/js-toolkit/decorators/withScrolledInView.js
+++ b/packages/js-toolkit/decorators/withScrolledInView.js
@@ -7,8 +7,43 @@ const scheduler = useScheduler(['update', 'render']);
  * @typedef {import('../Base').default} Base
  * @typedef {import('../Base').BaseConstructor} BaseConstructor
  * @typedef {import('../Base').BaseConfig} BaseConfig
+ * @typedef {{
+ *   start: {
+ *     x: number,
+ *     y: number,
+ *   },
+ *   end: {
+ *     x: number,
+ *     y: number,
+ *   },
+ *   current: {
+ *     x: number,
+ *     y: number,
+ *   },
+ *   dampedCurrent: {
+ *     x: number,
+ *     y: number,
+ *   },
+ *   progress: {
+ *     x: number,
+ *     y: number,
+ *   },
+ *   dampedProgress: {
+ *     x: number,
+ *     y: number,
+ *   },
+ * }} ScrollInViewProps
  */
 
+/**
+ * Update props on tick.
+ *
+ * @param   {ScrollInViewProps} props
+ * @param   {number} dampFactor
+ * @param   {number} dampPrecision
+ * @param   {'x'|'y'} axis
+ * @returns {void}
+ */
 function updateProps(props, dampFactor, dampPrecision, axis = 'x') {
   props.current[axis] = clamp(
     axis === 'x' ? window.pageXOffset : window.pageYOffset,
@@ -50,6 +85,7 @@ export default function withScrolledInView(BaseClass, options = {}) {
     };
 
     /**
+     * @type {ScrollInViewProps}
      * @private
      */
     __props = {
@@ -237,10 +273,26 @@ export default function withScrolledInView(BaseClass, options = {}) {
       this.__props.end.y = yEnd;
       this.__props.current.x = xCurrent;
       this.__props.current.y = yCurrent;
+      this.__props.dampedCurrent.x = damp(
+        xCurrent,
+        this.__props.dampedCurrent.x,
+        this.dampFactor,
+        this.dampPrecision
+      );
+      this.__props.dampedCurrent.y = damp(
+        yCurrent,
+        this.__props.dampedCurrent.y,
+        this.dampFactor,
+        this.dampPrecision
+      );
       this.__props.progress.x = xProgress;
       this.__props.progress.y = yProgress;
-      this.__props.dampedProgress.x = damp(xProgress, this.__props.dampedProgress.x);
-      this.__props.dampedProgress.y = damp(yProgress, this.__props.dampedProgress.y);
+      this.__props.dampedProgress.x = clamp01(
+        (this.__props.dampedCurrent.x - xStart) / (xEnd - xStart)
+      );
+      this.__props.dampedProgress.y = clamp01(
+        (this.__props.dampedCurrent.y - yStart) / (yEnd - yStart)
+      );
     }
   };
 }

--- a/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
+++ b/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
@@ -6,6 +6,10 @@ Object {
     "x": 600,
     "y": 600,
   },
+  "dampedCurrent": Object {
+    "x": 162.6,
+    "y": 162.6,
+  },
   "end": Object {
     "x": 600,
     "y": 600,
@@ -26,6 +30,10 @@ Object {
   "current": Object {
     "x": 600,
     "y": 600,
+  },
+  "dampedCurrent": Object {
+    "x": 162.6,
+    "y": 162.6,
   },
   "end": Object {
     "x": 600,

--- a/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
+++ b/packages/tests/decorators/__snapshots__/withScrolledInView.spec.js.snap
@@ -6,10 +6,6 @@ Object {
     "x": 600,
     "y": 600,
   },
-  "dampedCurrent": Object {
-    "x": 162.6,
-    "y": 162.6,
-  },
   "end": Object {
     "x": 600,
     "y": 600,
@@ -30,10 +26,6 @@ Object {
   "current": Object {
     "x": 600,
     "y": 600,
-  },
-  "dampedCurrent": Object {
-    "x": 162.6,
-    "y": 162.6,
   },
   "end": Object {
     "x": 600,


### PR DESCRIPTION
## Changelog

### Fixed
- **withScrolledInView** 
  - Use damping on the current value instead of the progress (dd51924, #270)

    As the progress value is clamped to a 0–1 interval, the damp factor and precisions value can be off when working with large elements.

    For example, for an element of 100 pixels, progress from 0 to 0.1 represents 10px, but for an element of 1000 pixels, it represents 100px. To keep the same precision between the two elements, we would need to
adjust the `dampPrecision` property. By applying the damping on the sizes in pixels directly, we get rid of this problem, as the base unit is fixed in pixels.

  - Fix a bug where damped values were not updated on destroy (ba93c1b, #270)

    This impacted animation based on these values, which would not be finished when a component is destroyed.