### PR TITLE
[Feature] Improve TypeScript support 

### DIFF
--- a/packages/demo/src/js/components/AnimateTest.js
+++ b/packages/demo/src/js/components/AnimateTest.js
@@ -3,6 +3,20 @@ import { animate, ease, domScheduler } from '@studiometa/js-toolkit/utils';
 
 /**
  * AnimateTest class.
+ * @typedef {{
+ *   target: HTMLElement,
+ *   start: HTMLButtonElement,
+ *   pause: HTMLButtonElement,
+ *   play: HTMLButtonElement,
+ *   finish: HTMLButtonElement,
+ *   progress: HTMLInputElement,
+ * }} AnimateTestRefs
+ * @typedef {{
+ *   steps: Parameters<animate>[1],
+ *   duration: number,
+ *   easing: string,
+ * }} AnimateTestOptions
+ * @augments {Base<{ $refs: AnimateTestRefs, $options: AnimateTestOptions }>}
  */
 export default class AnimateTest extends Base {
   /**

--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -65,6 +65,7 @@ function getGuideSidebar() {
     {
       text: 'Going further',
       items: [
+        { text: 'Typing components', link: '/guide/going-further/typing-components.html' },
         { text: 'Using decorators', link: '/guide/going-further/using-decorators.html' },
         { text: 'Lazy imports', link: '/guide/going-further/lazy-imports.html' },
         {

--- a/packages/docs/guide/going-further/typing-components.md
+++ b/packages/docs/guide/going-further/typing-components.md
@@ -7,7 +7,7 @@ outline: deep
 To improve DX and autocompletion of a components' properties, it is possible to type the `$options`, `$refs` and `$children` properties either with JSDoc comments or directly in TypeScript. The `Base` class type accepts a [type parameter](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#type-parameters) with the following format:
 
 ```ts
-class Base<Params extends {
+class Base<BaseInterface extends {
   $options: BaseOptions;
   $refs: BaseRefs;
   $children: BaseChildren;

--- a/packages/docs/guide/going-further/typing-components.md
+++ b/packages/docs/guide/going-further/typing-components.md
@@ -1,0 +1,109 @@
+---
+outline: deep
+---
+
+# Typing components
+
+To improve DX and autocompletion of a components' properties, it is possible to type the `$options`, `$refs` and `$children` properties either with JSDoc comments or directly in TypeScript. The `Base` class type accepts a [type parameter](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#type-parameters) with the following format:
+
+```ts
+class Base<Params extends {
+  $options: BaseOptions;
+  $refs: BaseRefs;
+  $children: BaseChildren;
+}>
+```
+
+See below for an example of how to define the type parameter in JSDoc or in TypeScript.
+
+::: warning Knowledge requirements
+This guide assumes that you are familiar with [TypeScript types](https://www.typescriptlang.org/), make sure to read the basics before going any further.
+:::
+
+## With JSDoc comments
+
+```js
+import { Base } from '@studiometa/js-toolkit';
+import { Figure } from '@studiometa/ui';
+
+/**
+ * @typedef {{ name: string, lazy: boolean }} ComponentOptions
+ * @typedef {{ btn: HTMLButtonElement, items: HTMLElement[] }} ComponentRefs
+ * @typedef {{ Figure: Figure, LazyComponent: Promise<LazyComponent> }} ComponentChildren
+ * @extends {Base<{ $options: ComponentOptions, $refs: ComponentRefs, $children: ComponentChildren }>}
+ */
+export default class Component extends Base {
+  static config = {
+    name: 'Component',
+    refs: ['btn', 'items[]'],
+    options: {
+      name: String,
+      lazy: Boolean,
+    },
+    components: {
+      Figure,
+      LazyComponent: () => import('./LazyComponent.js'),
+    },
+  };
+
+  mounted() {
+    this.$refs.btn; // HTMLButtonElement
+    this.$refs.items; // HTMLElement[]
+    this.$options.name; // string
+    this.$options.lazy; // boolean
+    this.$children.Figure; // Figure[]
+    this.$children.LazyComponent; // Promise<LazyComponent>[]
+  }
+}
+```
+
+## With TypeScript
+
+```ts
+import { Base } from '@studiometa/js-toolkit';
+import { Figure } from '@studiometa/ui';
+import type LazyComponent from './LazyComponent.js';
+
+type ComponentOptions {
+  name: string;
+  lazy: boolean;
+}
+
+type ComponentRefs {
+  btn: HTMLButtonElement;
+  items: HTMLElement[];
+}
+
+type ComponentChildren {
+  Figure: Figure;
+  LazyComponent: Promise<LazyComponent>
+}
+
+export default class Component extends Base<{
+  $options: ComponentOptions,
+  $refs: ComponentRefs,
+  $children: ComponentChildren,
+}> {
+  static config = {
+    name: 'Component',
+    refs: ['btn', 'items[]'],
+    options: {
+      name: String,
+      lazy: Boolean,
+    },
+    components: {
+      Figure,
+      LazyComponent: () => import('./LazyComponent.js'),
+    },
+  };
+
+  mounted() {
+    this.$refs.btn; // HTMLButtonElement
+    this.$refs.items; // HTMLElement[]
+    this.$options.name; // string
+    this.$options.lazy; // boolean
+    this.$children.Figure; // Figure[]
+    this.$children.LazyComponent; // Promise<LazyComponent>[]
+  }
+}
+```

--- a/packages/js-toolkit/Base/index.js
+++ b/packages/js-toolkit/Base/index.js
@@ -53,11 +53,6 @@ function createAndTestManagers(instance) {
 }
 
 /**
- * @template {Record<string, any>} Type
- * @typedef {{ [Property in keyof Type]: Type[Property] }} ConcreteType
- */
-
-/**
  * @typedef {typeof Base} BaseConstructor
  * @typedef {(Base) => Promise<BaseConstructor | { default: BaseConstructor }>} BaseAsyncConstructor
  * @typedef {OptionsManager & { [name:string]: any }} BaseOptions
@@ -90,7 +85,7 @@ function createAndTestManagers(instance) {
 
 /**
  * Base class.
- * @template {{ $options: BaseOptions, $refs: BaseRefs, $children: BaseChildren }} Params
+ * @template {{ $options: BaseOptions, $refs: BaseRefs, $children: BaseChildren }} BaseInterface
  */
 export default class Base extends EventTarget {
   /**
@@ -222,39 +217,39 @@ export default class Base extends EventTarget {
   }
 
   /**
-   * @type {RefsManager & ConcreteType<Params['$refs']>}
+   * @type {RefsManager & { [key in keyof BaseInterface['$refs']]: BaseInterface['$refs'][key] }}
    * @private
    */
   __refs;
 
   /**
-   * @returns {RefsManager & ConcreteType<Params['$refs']>}
+   * @returns {RefsManager & { [key in keyof BaseInterface['$refs']]: BaseInterface['$refs'][key] }}
    */
   get $refs() {
     return this.__refs;
   }
 
   /**
-   * @type {BaseOptions & ConcreteType<Params['$options']>}
+   * @type {BaseOptions & { [key in keyof BaseInterface['$options']]: BaseInterface['$options'][key] }}
    * @private
    */
   __options;
 
   /**
-   * @returns {BaseOptions & ConcreteType<Params['$options']>}
+   * @returns {BaseOptions & { [key in keyof BaseInterface['$options']]: BaseInterface['$options'][key] }}
    */
   get $options() {
     return this.__options;
   }
 
   /**
-   * @type {ChildrenManager & ConcreteType<Params['$children']>}
+   * @type {ChildrenManager & { [key in keyof BaseInterface['$children']]: Array<BaseInterface['$children'][key]> }}
    * @private
    */
   __children;
 
   /**
-   * @returns {ChildrenManager & ConcreteType<Params['$children']>}
+   * @returns {ChildrenManager & { [key in keyof BaseInterface['$children']]: Array<BaseInterface['$children'][key]> }}
    */
   get $children() {
     return this.__children;

--- a/packages/js-toolkit/Base/index.js
+++ b/packages/js-toolkit/Base/index.js
@@ -53,6 +53,11 @@ function createAndTestManagers(instance) {
 }
 
 /**
+ * @template {Record<string, any>} Type
+ * @typedef {{ [Property in keyof Type]: Type[Property] }} ConcreteType
+ */
+
+/**
  * @typedef {typeof Base} BaseConstructor
  * @typedef {(Base) => Promise<BaseConstructor | { default: BaseConstructor }>} BaseAsyncConstructor
  * @typedef {OptionsManager & { [name:string]: any }} BaseOptions
@@ -85,6 +90,7 @@ function createAndTestManagers(instance) {
 
 /**
  * Base class.
+ * @template {{ $options: BaseOptions, $refs: BaseRefs, $children: BaseChildren }} Params
  */
 export default class Base extends EventTarget {
   /**
@@ -216,39 +222,39 @@ export default class Base extends EventTarget {
   }
 
   /**
-   * @type {RefsManager}
+   * @type {RefsManager & ConcreteType<Params['$refs']>}
    * @private
    */
   __refs;
 
   /**
-   * @returns {RefsManager}
+   * @returns {RefsManager & ConcreteType<Params['$refs']>}
    */
   get $refs() {
     return this.__refs;
   }
 
   /**
-   * @type {BaseOptions}
+   * @type {BaseOptions & ConcreteType<Params['$options']>}
    * @private
    */
   __options;
 
   /**
-   * @returns {BaseOptions}
+   * @returns {BaseOptions & ConcreteType<Params['$options']>}
    */
   get $options() {
     return this.__options;
   }
 
   /**
-   * @type {ChildrenManager}
+   * @type {ChildrenManager & ConcreteType<Params['$children']>}
    * @private
    */
   __children;
 
   /**
-   * @returns {ChildrenManager}
+   * @returns {ChildrenManager & ConcreteType<Params['$children']>}
    */
   get $children() {
     return this.__children;


### PR DESCRIPTION
Until now, to be able to have autocompletion when writing components based on the `Base` class, we had to force the type of `this` for each method by using the `@this` JSDoc tag: 

```js
class Component extends Base {
  static config = {
    name: 'Component',
    refs: ['btn'],
  };

  /**
   * @this {Component & { $refs: { btn: HTMLButtonElement } }} 
   */
  mounted() {
    this.$refs.btn; // HTMLButtonElement
  }
}
```

This is not really practical, as we can lose types when working with child components if we do not specify the type each time we make a reference to the component's class.

This PR improves typing of class components by introducing a [type parameter](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#type-parameters) to the `Base` class.

Types for a component can now be specified once, and only once, and every usage of the class will be correctly typed. Using the `@extends` (or `@augments`) JSDoc tag, you can now specify the refs, options and children of a component: 

```js
import OtherComponent from './OtherComponent.js';

/**
 * @extends {Base<{ $refs: { btn: HTMLButtonElement }, $options: { withExtra: boolean }, $children: { OtherComponent: OtherComponent } }>}
 */
class Component extends Base {
  static config = {
    name: 'Component',
    refs: ['btn'],
    options: {
      withExtra: Boolean,
    },
    components: {
      OtherComponent,
    }
  };

  mounted() {
    this.$refs.btn; // HTMLButtonElement type
    this.$options.withExtra; // boolean type
    this.$children.OtherComponent; // OtherComponent[] type
  }
}
```

## Changelog

### Changed
- Improve types definition for components (#271) 

## To do
- [x] Add a recipe to the doc on how to define types
- [x] Always force `$children` types to be arrays without having to define it