### PR TITLE
[Bugfix] Filter the elements of the references in the EventsManager

### DIFF
--- a/packages/js-toolkit/Base/managers/EventsManager.ts
+++ b/packages/js-toolkit/Base/managers/EventsManager.ts
@@ -140,7 +140,9 @@ function manageRef(
   const methods = getEventMethodsByName(that, name);
   methods.forEach((method) => {
     const event = getEventNameByMethod(method, name);
-    elements.forEach((element) => element[action](event, that.__refsHandler));
+    elements
+      .filter((element) => element)
+      .forEach((element) => element[action](event, that.__refsHandler));
   });
 }
 /**


### PR DESCRIPTION
This PR filters the elements of the references in the `EventManager`, so that it does not attach events to elements of the DOM that no longer exist (#278)