### PR TITLE
[Bugfix] Fix a bug where empty classnames could be used

### DIFF
--- a/packages/js-toolkit/utils/css/classes.js
+++ b/packages/js-toolkit/utils/css/classes.js
@@ -15,7 +15,9 @@ function setClasses(element, classNames, method, forceToggle) {
     return;
   }
 
-  const normalizedClassNames = isArray(classNames) ? classNames : classNames.split(' ');
+  const normalizedClassNames = isArray(classNames)
+    ? classNames
+    : classNames.split(' ').filter((className) => className);
 
   if (method !== 'toggle') {
     eachElements(element, (el) => el.classList[method](...normalizedClassNames));

--- a/packages/tests/utils/css/classes.spec.js
+++ b/packages/tests/utils/css/classes.spec.js
@@ -12,6 +12,11 @@ describe('classes methods', () => {
     expect(Array.from(element.classList)).toEqual(['foo', 'bar']);
   });
 
+  it('should add classes to an element when empty spaces are added to the class parameter', () => {
+    add(element, 'foo  bar');
+    expect(Array.from(element.classList)).toEqual(['foo', 'bar']);
+  });
+
   it('should remove classes from an element', () => {
     remove(element, 'foo bar');
     expect(Array.from(element.classList)).toEqual([]);


### PR DESCRIPTION
Closes #283.

## Changelog

### Fixed
- **addClass, removeClass, toggleClass**: fix a bug where empty classes could be used (#298, fix ##283)