### PR TITLE
[Feature] Add support for multiple component declaration in `data-component` attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ yarn-error.log*
 # Build files
 dist/
 demo/dist/
-docs/.vuepress/dist/
+/packages/docs/.vitepress/cache
 coverage/
 /full.d.ts
 /index.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,143 +33,143 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       },
       "peerDependencies": {
-        "@algolia/client-search": "^4.9.1",
-        "algoliasearch": "^4.9.1"
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
+      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.14.3"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
+      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
+      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.14.3"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
+      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
+      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
+      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
+      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
+      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
+      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
+      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
       "dependencies": {
-        "@algolia/logger-common": "4.14.2"
+        "@algolia/logger-common": "4.14.3"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
+      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.14.3"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
+      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
+      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.14.3"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
+      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2059,27 +2059,27 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "node_modules/@docsearch/js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.2.1.tgz",
-      "integrity": "sha512-H1PekEtSeS0msetR2YGGey2w7jQ2wAKfGODJvQTygSwMgUZ+2DHpzUgeDyEBIXRIfaBcoQneqrzsljM62pm6Xg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.3.0.tgz",
+      "integrity": "sha512-oFXWRPNvPxAzBhnFJ9UCFIYZiQNc3Yrv6912nZHw/UIGxsyzKpNRZgHq8HDk1niYmOSoLKtVFcxkccpQmYGFyg==",
       "dependencies": {
-        "@docsearch/react": "3.2.1",
+        "@docsearch/react": "3.3.0",
         "preact": "^10.0.0"
       }
     },
     "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2127,6 +2127,141 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.9.tgz",
+      "integrity": "sha512-ndIAZJUeLx4O+4AJbFQCurQW4VRUXjDsUvt1L+nP8bVELOWdmdCEOtlIweCUE6P+hU0uxYbEK2AEP0n5IVQvhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.9.tgz",
+      "integrity": "sha512-UbMcJB4EHrAVOnknQklREPgclNU2CPet2h+sCBCXmF2mfoYWopBn/CfTfeyOkb/JglOcdEADqAljFndMKnFtOw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.9.tgz",
+      "integrity": "sha512-d7D7/nrt4CxPul98lx4PXhyNZwTYtbdaHhOSdXlZuu5zZIznjqtMqLac8Bv+IuT6SVHiHUwrkL6ywD7mOgLW+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.9.tgz",
+      "integrity": "sha512-LZc+Wlz06AkJYtwWsBM3x2rSqTG8lntDuftsUNQ3fCx9ZttYtvlDcVtgb+NQ6t9s6K5No5zutN3pcjZEC2a4iQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.9.tgz",
+      "integrity": "sha512-gIj0UQZlQo93CHYouHKkpzP7AuruSaMIm1etcWIxccFEVqCN1xDr6BWlN9bM+ol/f0W9w3hx3HDuEwcJVtGneQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.9.tgz",
+      "integrity": "sha512-GNors4vaMJ7lzGOuhzNc7jvgsQZqErGA8rsW+nck8N1nYu86CvsJW2seigVrQQWOV4QzEP8Zf3gm+QCjA2hnBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.9.tgz",
+      "integrity": "sha512-cNx1EF99c2t1Ztn0lk9N+MuwBijGF8mH6nx9GFsB3e0lpUpPkCE/yt5d+7NP9EwJf5uzqdjutgVYoH1SNqzudA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.9.tgz",
+      "integrity": "sha512-YPxQunReYp8RQ1FvexFrOEqqf+nLbS3bKVZF5FRT2uKM7Wio7BeATqAwO02AyrdSEntt3I5fhFsujUChIa8CZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.9.tgz",
+      "integrity": "sha512-zb12ixDIKNwFpIqR00J88FFitVwOEwO78EiUi8wi8FXlmSc3GtUuKV/BSO+730Kglt0B47+ZrJN1BhhOxZaVrw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.15.15",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
@@ -2137,6 +2272,171 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.9.tgz",
+      "integrity": "sha512-ZqyMDLt02c5smoS3enlF54ndK5zK4IpClLTxF0hHfzHJlfm4y8IAkIF8LUW0W7zxcKy7oAwI7BRDqeVvC120SA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.9.tgz",
+      "integrity": "sha512-k+ca5W5LDBEF3lfDwMV6YNXwm4wEpw9krMnNvvlNz3MrKSD2Eb2c861O0MaKrZkG/buTQAP4vkavbLwgIe6xjg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.9.tgz",
+      "integrity": "sha512-GuInVdogjmg9DhgkEmNipHkC+3tzkanPJzgzTC2ihsvrruLyFoR1YrTGixblNSMPudQLpiqkcwGwwe0oqfrvfA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.9.tgz",
+      "integrity": "sha512-49wQ0aYkvwXonGsxc7LuuLNICMX8XtO92Iqmug5Qau0kpnV6SP34jk+jIeu4suHwAbSbRhVFtDv75yRmyfQcHw==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.9.tgz",
+      "integrity": "sha512-Nx4oKEAJ6EcQlt4dK7qJyuZUoXZG7CAeY22R7rqZijFzwFfMOD+gLP56uV7RrV86jGf8PeRY8TBsRmOcZoG42w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.9.tgz",
+      "integrity": "sha512-d0WnpgJ+FTiMZXEQ1NOv9+0gvEhttbgKEvVqWWAtl1u9AvlspKXbodKHzQ5MLP6YV1y52Xp+p8FMYqj8ykTahg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.9.tgz",
+      "integrity": "sha512-jccK11278dvEscHFfMk5EIPjF4wv1qGD0vps7mBV1a6TspdR36O28fgPem/SA/0pcsCPHjww5ouCLwP+JNAFlw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.9.tgz",
+      "integrity": "sha512-OetwTSsv6mIDLqN7I7I2oX9MmHGwG+AP+wKIHvq+6sIHwcPPJqRx+DJB55jy9JG13CWcdcQno/7V5MTJ5a0xfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.9.tgz",
+      "integrity": "sha512-tKSSSK6unhxbGbHg+Cc+JhRzemkcsX0tPBvG0m5qsWbkShDK9c+/LSb13L18LWVdOQZwuA55Vbakxmt6OjBDOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.9.tgz",
+      "integrity": "sha512-ZTQ5vhNS5gli0KK8I6/s6+LwXmNEfq1ftjnSVyyNm33dBw8zDpstqhGXYUbZSWWLvkqiRRjgxgmoncmi6Yy7Ng==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.9.tgz",
+      "integrity": "sha512-C4ZX+YFIp6+lPrru3tpH6Gaapy8IBRHw/e7l63fzGDhn/EaiGpQgbIlT5paByyy+oMvRFQoxxyvC4LE0AjJMqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -3769,9 +4069,9 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
     },
     "node_modules/@types/web-bluetooth": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.15.tgz",
-      "integrity": "sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA=="
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz",
+      "integrity": "sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.13",
@@ -4016,48 +4316,48 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.1.2.tgz",
-      "integrity": "sha512-3zxKNlvA3oNaKDYX0NBclgxTQ1xaFdL7PzwF6zj9tGFziKwmBa3Q/6XcJQxudlT81WxDjEhHmevvIC4Orc1LhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.0.0.tgz",
+      "integrity": "sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==",
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^3.0.0",
+        "vite": "^4.0.0",
         "vue": "^3.2.25"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.41.tgz",
-      "integrity": "sha512-oA4mH6SA78DT+96/nsi4p9DX97PHcNROxs51lYk7gb9Z4BPKQ3Mh+BLn6CQZBw857Iuhu28BfMSRHAlPvD4vlw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
       "dependencies": {
         "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.41",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.41.tgz",
-      "integrity": "sha512-xe5TbbIsonjENxJsYRbDJvthzqxLNk+tb3d/c47zgREDa/PCp6/Y4gC/skM4H6PIuX5DAxm7fFJdbjjUH2QTMw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
       "dependencies": {
-        "@vue/compiler-core": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.41.tgz",
-      "integrity": "sha512-+1P2m5kxOeaxVmJNXnBskAn3BenbTmbxBxWOtBq3mQTCokIreuMULFantBUclP0+KnzNCMOvcnKinqQZmiOF8w==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
       "dependencies": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.41",
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/compiler-ssr": "3.2.41",
-        "@vue/reactivity-transform": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -4065,74 +4365,74 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.41.tgz",
-      "integrity": "sha512-Y5wPiNIiaMz/sps8+DmhaKfDm1xgj6GrH99z4gq2LQenfVQcYXmHIOBcs5qPwl7jaW3SUQWjkAPKMfQemEQZwQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.4.4.tgz",
-      "integrity": "sha512-Ku31WzpOV/8cruFaXaEZKF81WkNnvCSlBY4eOGtz5WMSdJvX1v1WWlSMGZeqUwPtQ27ZZz7B62erEMq8JDjcXw=="
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.4.5.tgz",
+      "integrity": "sha512-JD5fcdIuFxU4fQyXUu3w2KpAJHzTVdN+p4iOX2lMWSHMOoQdMAcpFLZzm9Z/2nmsoZ1a96QEhZ26e50xLBsgOQ=="
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.41.tgz",
-      "integrity": "sha512-9JvCnlj8uc5xRiQGZ28MKGjuCoPhhTwcoAdv3o31+cfGgonwdPNuvqAXLhlzu4zwqavFEG5tvaoINQEfxz+l6g==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
       "dependencies": {
-        "@vue/shared": "3.2.41"
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/reactivity-transform": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.41.tgz",
-      "integrity": "sha512-mK5+BNMsL4hHi+IR3Ft/ho6Za+L3FA5j8WvreJ7XzHrqkPq8jtF/SMo7tuc9gHjLDwKZX1nP1JQOKo9IEAn54A==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
       "dependencies": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.41.tgz",
-      "integrity": "sha512-0LBBRwqnI0p4FgIkO9q2aJBBTKDSjzhnxrxHYengkAF6dMOjeAIZFDADAlcf2h3GDALWnblbeprYYpItiulSVQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
+      "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
       "dependencies": {
-        "@vue/reactivity": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/reactivity": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.41.tgz",
-      "integrity": "sha512-U7zYuR1NVIP8BL6jmOqmapRAHovEFp7CSw4pR2FacqewXNGqZaRfHoNLQsqQvVQ8yuZNZtxSZy0FFyC70YXPpA==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
+      "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
       "dependencies": {
-        "@vue/runtime-core": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/runtime-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "csstype": "^2.6.8"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.41.tgz",
-      "integrity": "sha512-7YHLkfJdTlsZTV0ae5sPwl9Gn/EGr2hrlbcS/8naXm2CDpnKUwC68i1wGlrYAfIgYWL7vUZwk2GkYLQH5CvFig==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
+      "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/shared": "3.2.45"
       },
       "peerDependencies": {
-        "vue": "3.2.41"
+        "vue": "3.2.45"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.41.tgz",
-      "integrity": "sha512-W9mfWLHmJhkfAmV+7gDjcHeAWALQtgGT3JErxULl0oz6R6+3ug91I7IErs93eCFhPCZPHBs4QJS7YWEV7A3sxw=="
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
     },
     "node_modules/@vueuse/core": {
       "version": "7.7.1",
@@ -4159,9 +4459,9 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-9.3.0.tgz",
-      "integrity": "sha512-GnnfjbzIPJIh9ngL9s9oGU1+Hx/h5/KFqTfJykzh/1xjaHkedV9g0MASpdmPZIP+ynNhKAcEfA6g5i8KXwtoMA==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-9.7.0.tgz",
+      "integrity": "sha512-M7WsAgw28FNtTH0bzsGuHEtJOPJqPpyeHS6PHq+8UesLgNjZ9waMAntiUrgUQlxt09M4i2lH7y9sRi0jkfeXGA==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -4520,24 +4820,24 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
+      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/cache-browser-local-storage": "4.14.3",
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/cache-in-memory": "4.14.3",
+        "@algolia/client-account": "4.14.3",
+        "@algolia/client-analytics": "4.14.3",
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-personalization": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/logger-console": "4.14.3",
+        "@algolia/requester-browser-xhr": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/requester-node-http": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "node_modules/ansi-escapes": {
@@ -14373,9 +14673,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "funding": [
         {
           "type": "opencollective",
@@ -15515,9 +15815,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.1.tgz",
-      "integrity": "sha512-1Wz5PCRm6Fg+6BTXWJHhX4wRK9MZbZBHuwBqfZlOdVm2NqPe8/rjYpufvYCwJSGb9layyzB2jTTXfpCTynLqFQ==",
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -16442,14 +16742,15 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.5.tgz",
+      "integrity": "sha512-z0ZbqHBtS/et2EEUKMrAl2CoSdwN7ZPzL17UMiKN9RjjqHShTlv7F9J6ZJZJNREYjBh3TvBrdfjkFDIXFNeuiQ==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -17590,7 +17891,8 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -19655,14 +19957,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
-      "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.2.tgz",
+      "integrity": "sha512-QJaY3R+tFlTagH0exVqbgkkw45B+/bXVBzF2ZD1KB5Z8RiAoiKo60vSUf6/r4c2Vh9jfGBKM4oBI9b4/1ZJYng==",
       "dependencies": {
-        "esbuild": "^0.15.9",
-        "postcss": "^8.4.16",
+        "esbuild": "^0.16.3",
+        "postcss": "^8.4.20",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^3.7.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -19674,12 +19976,17 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
+        "@types/node": ">= 14",
         "less": "*",
         "sass": "*",
         "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
         "less": {
           "optional": true
         },
@@ -19689,38 +19996,107 @@
         "stylus": {
           "optional": true
         },
+        "sugarss": {
+          "optional": true
+        },
         "terser": {
           "optional": true
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.9.tgz",
+      "integrity": "sha512-kW5ccqWHVOOTGUkkJbtfoImtqu3kA1PFkivM+9QPFSHphPfPBlBalX9eDRqPK+wHCqKhU48/78T791qPgC9e9A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.9.tgz",
+      "integrity": "sha512-X8te4NLxtHiNT6H+4Pfm5RklzItA1Qy4nfyttihGGX+Koc53Ar20ViC+myY70QJ8PDEOehinXZj/F7QK3A+MKQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.9.tgz",
+      "integrity": "sha512-gkH83yHyijMSZcZFs1IWew342eMdFuWXmQo3zkDPTre25LIPBJsXryg02M3u8OpTwCJdBkdaQwqKkDLnAsAeLQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.16.9",
+        "@esbuild/android-arm64": "0.16.9",
+        "@esbuild/android-x64": "0.16.9",
+        "@esbuild/darwin-arm64": "0.16.9",
+        "@esbuild/darwin-x64": "0.16.9",
+        "@esbuild/freebsd-arm64": "0.16.9",
+        "@esbuild/freebsd-x64": "0.16.9",
+        "@esbuild/linux-arm": "0.16.9",
+        "@esbuild/linux-arm64": "0.16.9",
+        "@esbuild/linux-ia32": "0.16.9",
+        "@esbuild/linux-loong64": "0.16.9",
+        "@esbuild/linux-mips64el": "0.16.9",
+        "@esbuild/linux-ppc64": "0.16.9",
+        "@esbuild/linux-riscv64": "0.16.9",
+        "@esbuild/linux-s390x": "0.16.9",
+        "@esbuild/linux-x64": "0.16.9",
+        "@esbuild/netbsd-x64": "0.16.9",
+        "@esbuild/openbsd-x64": "0.16.9",
+        "@esbuild/sunos-x64": "0.16.9",
+        "@esbuild/win32-arm64": "0.16.9",
+        "@esbuild/win32-ia32": "0.16.9",
+        "@esbuild/win32-x64": "0.16.9"
+      }
+    },
     "node_modules/vitepress": {
-      "version": "1.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-alpha.21.tgz",
-      "integrity": "sha512-D/tkoDW16uUZ9pnWd28Kk1vX26zNiTml3m9oGbfx2pAfYg99PHd1GceZyEm4jZsJU0+n9S++1ctFxoQvsq376A==",
+      "version": "1.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-alpha.32.tgz",
+      "integrity": "sha512-Q45N1cLdRr8MAu/+wAKKow7CNQD4sNBlSNsW1UxYfkvSgwPN/dlEmpEkQl/uOpE3C1kv3jvvEJVY0RAIaJFWYQ==",
       "dependencies": {
-        "@docsearch/css": "^3.2.1",
-        "@docsearch/js": "^3.2.1",
-        "@vitejs/plugin-vue": "^3.1.2",
-        "@vue/devtools-api": "^6.4.4",
-        "@vueuse/core": "^9.3.0",
+        "@docsearch/css": "^3.3.0",
+        "@docsearch/js": "^3.3.0",
+        "@vitejs/plugin-vue": "^4.0.0",
+        "@vue/devtools-api": "^6.4.5",
+        "@vueuse/core": "^9.6.0",
         "body-scroll-lock": "4.0.0-beta.0",
         "shiki": "^0.11.1",
-        "vite": "^3.1.6",
-        "vue": "^3.2.40"
+        "vite": "^4.0.0",
+        "vue": "^3.2.45"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
       }
     },
     "node_modules/vitepress/node_modules/@vueuse/core": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-9.3.0.tgz",
-      "integrity": "sha512-64Rna8IQDWpdrJxgitDg7yv1yTp41ZmvV8zlLEylK4QQLWAhz1OFGZDPZ8bU4lwcGgbEJ2sGi2jrdNh4LttUSQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-9.7.0.tgz",
+      "integrity": "sha512-/AGY/t7jJPxCyRoVTygNKoroTiCvRaaZIW+yeSlBCnI7QRpQ9cvXNTdNaSl3GvSyFbn83+XwZwEZvI1OpQfeGw==",
       "dependencies": {
-        "@types/web-bluetooth": "^0.0.15",
-        "@vueuse/metadata": "9.3.0",
-        "@vueuse/shared": "9.3.0",
+        "@types/web-bluetooth": "^0.0.16",
+        "@vueuse/metadata": "9.7.0",
+        "@vueuse/shared": "9.7.0",
         "vue-demi": "*"
       },
       "funding": {
@@ -19728,9 +20104,9 @@
       }
     },
     "node_modules/vitepress/node_modules/@vueuse/shared": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-9.3.0.tgz",
-      "integrity": "sha512-caGUWLY0DpPC6l31KxeUy6vPVNA0yKxx81jFYLoMpyP6cF84FG5Dkf69DfSUqL57wX8JcUkJDMnQaQIZPWFEQQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-9.7.0.tgz",
+      "integrity": "sha512-pwmt1y3TJ2s5KqWmkv9ZKEV59GwuZQZk8XLiU+hGswz0jej318ozbea9E4A/A50ksyM26swSFr7sZ9llNPsZHg==",
       "dependencies": {
         "vue-demi": "*"
       },
@@ -19749,15 +20125,15 @@
       "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ=="
     },
     "node_modules/vue": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.41.tgz",
-      "integrity": "sha512-uuuvnrDXEeZ9VUPljgHkqB5IaVO8SxhPpqF2eWOukVrBnRBx2THPSGQBnVRt0GrIG1gvCmFXMGbd7FqcT1ixNQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
+      "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/compiler-sfc": "3.2.41",
-        "@vue/runtime-dom": "3.2.41",
-        "@vue/server-renderer": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-sfc": "3.2.45",
+        "@vue/runtime-dom": "3.2.45",
+        "@vue/server-renderer": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/vue-demi": {
@@ -20662,7 +21038,7 @@
         "@bytebase/vue-kbar": "^0.1.8",
         "@studiometa/tailwind-config": "^2.0.2",
         "tailwindcss": "^3.2.4",
-        "vitepress": "^1.0.0-alpha.21"
+        "vitepress": "^1.0.0-alpha.32"
       }
     },
     "packages/js-toolkit": {
@@ -20708,139 +21084,139 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
+      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
       "requires": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.14.3"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
+      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
+      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
       "requires": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.14.3"
       }
     },
     "@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
+      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
+      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
+      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
       "requires": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
+      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
+      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
+      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
     },
     "@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
+      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
       "requires": {
-        "@algolia/logger-common": "4.14.2"
+        "@algolia/logger-common": "4.14.3"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
+      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
       "requires": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.14.3"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
+      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
+      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
       "requires": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.14.3"
       }
     },
     "@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
+      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
       "requires": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/requester-common": "4.14.3"
       }
     },
     "@ampproject/remapping": {
@@ -22059,27 +22435,27 @@
       "requires": {}
     },
     "@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "@docsearch/js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.2.1.tgz",
-      "integrity": "sha512-H1PekEtSeS0msetR2YGGey2w7jQ2wAKfGODJvQTygSwMgUZ+2DHpzUgeDyEBIXRIfaBcoQneqrzsljM62pm6Xg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.3.0.tgz",
+      "integrity": "sha512-oFXWRPNvPxAzBhnFJ9UCFIYZiQNc3Yrv6912nZHw/UIGxsyzKpNRZgHq8HDk1niYmOSoLKtVFcxkccpQmYGFyg==",
       "requires": {
-        "@docsearch/react": "3.2.1",
+        "@docsearch/react": "3.3.0",
         "preact": "^10.0.0"
       }
     },
     "@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "requires": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
       }
     },
@@ -22099,10 +22475,130 @@
       "integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
       "optional": true
     },
+    "@esbuild/android-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.9.tgz",
+      "integrity": "sha512-ndIAZJUeLx4O+4AJbFQCurQW4VRUXjDsUvt1L+nP8bVELOWdmdCEOtlIweCUE6P+hU0uxYbEK2AEP0n5IVQvhg==",
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.9.tgz",
+      "integrity": "sha512-UbMcJB4EHrAVOnknQklREPgclNU2CPet2h+sCBCXmF2mfoYWopBn/CfTfeyOkb/JglOcdEADqAljFndMKnFtOw==",
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.9.tgz",
+      "integrity": "sha512-d7D7/nrt4CxPul98lx4PXhyNZwTYtbdaHhOSdXlZuu5zZIznjqtMqLac8Bv+IuT6SVHiHUwrkL6ywD7mOgLW+A==",
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.9.tgz",
+      "integrity": "sha512-LZc+Wlz06AkJYtwWsBM3x2rSqTG8lntDuftsUNQ3fCx9ZttYtvlDcVtgb+NQ6t9s6K5No5zutN3pcjZEC2a4iQ==",
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.9.tgz",
+      "integrity": "sha512-gIj0UQZlQo93CHYouHKkpzP7AuruSaMIm1etcWIxccFEVqCN1xDr6BWlN9bM+ol/f0W9w3hx3HDuEwcJVtGneQ==",
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.9.tgz",
+      "integrity": "sha512-GNors4vaMJ7lzGOuhzNc7jvgsQZqErGA8rsW+nck8N1nYu86CvsJW2seigVrQQWOV4QzEP8Zf3gm+QCjA2hnBQ==",
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.9.tgz",
+      "integrity": "sha512-cNx1EF99c2t1Ztn0lk9N+MuwBijGF8mH6nx9GFsB3e0lpUpPkCE/yt5d+7NP9EwJf5uzqdjutgVYoH1SNqzudA==",
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.9.tgz",
+      "integrity": "sha512-YPxQunReYp8RQ1FvexFrOEqqf+nLbS3bKVZF5FRT2uKM7Wio7BeATqAwO02AyrdSEntt3I5fhFsujUChIa8CZg==",
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.9.tgz",
+      "integrity": "sha512-zb12ixDIKNwFpIqR00J88FFitVwOEwO78EiUi8wi8FXlmSc3GtUuKV/BSO+730Kglt0B47+ZrJN1BhhOxZaVrw==",
+      "optional": true
+    },
     "@esbuild/linux-loong64": {
       "version": "0.15.15",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
       "integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.9.tgz",
+      "integrity": "sha512-ZqyMDLt02c5smoS3enlF54ndK5zK4IpClLTxF0hHfzHJlfm4y8IAkIF8LUW0W7zxcKy7oAwI7BRDqeVvC120SA==",
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.9.tgz",
+      "integrity": "sha512-k+ca5W5LDBEF3lfDwMV6YNXwm4wEpw9krMnNvvlNz3MrKSD2Eb2c861O0MaKrZkG/buTQAP4vkavbLwgIe6xjg==",
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.9.tgz",
+      "integrity": "sha512-GuInVdogjmg9DhgkEmNipHkC+3tzkanPJzgzTC2ihsvrruLyFoR1YrTGixblNSMPudQLpiqkcwGwwe0oqfrvfA==",
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.9.tgz",
+      "integrity": "sha512-49wQ0aYkvwXonGsxc7LuuLNICMX8XtO92Iqmug5Qau0kpnV6SP34jk+jIeu4suHwAbSbRhVFtDv75yRmyfQcHw==",
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.9.tgz",
+      "integrity": "sha512-Nx4oKEAJ6EcQlt4dK7qJyuZUoXZG7CAeY22R7rqZijFzwFfMOD+gLP56uV7RrV86jGf8PeRY8TBsRmOcZoG42w==",
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.9.tgz",
+      "integrity": "sha512-d0WnpgJ+FTiMZXEQ1NOv9+0gvEhttbgKEvVqWWAtl1u9AvlspKXbodKHzQ5MLP6YV1y52Xp+p8FMYqj8ykTahg==",
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.9.tgz",
+      "integrity": "sha512-jccK11278dvEscHFfMk5EIPjF4wv1qGD0vps7mBV1a6TspdR36O28fgPem/SA/0pcsCPHjww5ouCLwP+JNAFlw==",
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.9.tgz",
+      "integrity": "sha512-OetwTSsv6mIDLqN7I7I2oX9MmHGwG+AP+wKIHvq+6sIHwcPPJqRx+DJB55jy9JG13CWcdcQno/7V5MTJ5a0xfQ==",
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.9.tgz",
+      "integrity": "sha512-tKSSSK6unhxbGbHg+Cc+JhRzemkcsX0tPBvG0m5qsWbkShDK9c+/LSb13L18LWVdOQZwuA55Vbakxmt6OjBDOQ==",
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.9.tgz",
+      "integrity": "sha512-ZTQ5vhNS5gli0KK8I6/s6+LwXmNEfq1ftjnSVyyNm33dBw8zDpstqhGXYUbZSWWLvkqiRRjgxgmoncmi6Yy7Ng==",
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.9.tgz",
+      "integrity": "sha512-C4ZX+YFIp6+lPrru3tpH6Gaapy8IBRHw/e7l63fzGDhn/EaiGpQgbIlT5paByyy+oMvRFQoxxyvC4LE0AjJMqQ==",
       "optional": true
     },
     "@eslint/eslintrc": {
@@ -23009,7 +23505,7 @@
         "@bytebase/vue-kbar": "^0.1.8",
         "@studiometa/tailwind-config": "^2.0.2",
         "tailwindcss": "^3.2.4",
-        "vitepress": "^1.0.0-alpha.21"
+        "vitepress": "^1.0.0-alpha.32"
       }
     },
     "@studiometa/js-toolkit-tests": {
@@ -23430,9 +23926,9 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
     },
     "@types/web-bluetooth": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.15.tgz",
-      "integrity": "sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA=="
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz",
+      "integrity": "sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ=="
     },
     "@types/yargs": {
       "version": "17.0.13",
@@ -23575,42 +24071,42 @@
       }
     },
     "@vitejs/plugin-vue": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.1.2.tgz",
-      "integrity": "sha512-3zxKNlvA3oNaKDYX0NBclgxTQ1xaFdL7PzwF6zj9tGFziKwmBa3Q/6XcJQxudlT81WxDjEhHmevvIC4Orc1LhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.0.0.tgz",
+      "integrity": "sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==",
       "requires": {}
     },
     "@vue/compiler-core": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.41.tgz",
-      "integrity": "sha512-oA4mH6SA78DT+96/nsi4p9DX97PHcNROxs51lYk7gb9Z4BPKQ3Mh+BLn6CQZBw857Iuhu28BfMSRHAlPvD4vlw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.41",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.41.tgz",
-      "integrity": "sha512-xe5TbbIsonjENxJsYRbDJvthzqxLNk+tb3d/c47zgREDa/PCp6/Y4gC/skM4H6PIuX5DAxm7fFJdbjjUH2QTMw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
       "requires": {
-        "@vue/compiler-core": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.41.tgz",
-      "integrity": "sha512-+1P2m5kxOeaxVmJNXnBskAn3BenbTmbxBxWOtBq3mQTCokIreuMULFantBUclP0+KnzNCMOvcnKinqQZmiOF8w==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.41",
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/compiler-ssr": "3.2.41",
-        "@vue/reactivity-transform": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -23618,71 +24114,71 @@
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.41.tgz",
-      "integrity": "sha512-Y5wPiNIiaMz/sps8+DmhaKfDm1xgj6GrH99z4gq2LQenfVQcYXmHIOBcs5qPwl7jaW3SUQWjkAPKMfQemEQZwQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
       "requires": {
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/devtools-api": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.4.4.tgz",
-      "integrity": "sha512-Ku31WzpOV/8cruFaXaEZKF81WkNnvCSlBY4eOGtz5WMSdJvX1v1WWlSMGZeqUwPtQ27ZZz7B62erEMq8JDjcXw=="
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.4.5.tgz",
+      "integrity": "sha512-JD5fcdIuFxU4fQyXUu3w2KpAJHzTVdN+p4iOX2lMWSHMOoQdMAcpFLZzm9Z/2nmsoZ1a96QEhZ26e50xLBsgOQ=="
     },
     "@vue/reactivity": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.41.tgz",
-      "integrity": "sha512-9JvCnlj8uc5xRiQGZ28MKGjuCoPhhTwcoAdv3o31+cfGgonwdPNuvqAXLhlzu4zwqavFEG5tvaoINQEfxz+l6g==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
       "requires": {
-        "@vue/shared": "3.2.41"
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/reactivity-transform": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.41.tgz",
-      "integrity": "sha512-mK5+BNMsL4hHi+IR3Ft/ho6Za+L3FA5j8WvreJ7XzHrqkPq8jtF/SMo7tuc9gHjLDwKZX1nP1JQOKo9IEAn54A==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.41.tgz",
-      "integrity": "sha512-0LBBRwqnI0p4FgIkO9q2aJBBTKDSjzhnxrxHYengkAF6dMOjeAIZFDADAlcf2h3GDALWnblbeprYYpItiulSVQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
+      "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
       "requires": {
-        "@vue/reactivity": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/reactivity": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.41.tgz",
-      "integrity": "sha512-U7zYuR1NVIP8BL6jmOqmapRAHovEFp7CSw4pR2FacqewXNGqZaRfHoNLQsqQvVQ8yuZNZtxSZy0FFyC70YXPpA==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
+      "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
       "requires": {
-        "@vue/runtime-core": "3.2.41",
-        "@vue/shared": "3.2.41",
+        "@vue/runtime-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "csstype": "^2.6.8"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.41.tgz",
-      "integrity": "sha512-7YHLkfJdTlsZTV0ae5sPwl9Gn/EGr2hrlbcS/8naXm2CDpnKUwC68i1wGlrYAfIgYWL7vUZwk2GkYLQH5CvFig==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
+      "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
       "requires": {
-        "@vue/compiler-ssr": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/shared": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.41.tgz",
-      "integrity": "sha512-W9mfWLHmJhkfAmV+7gDjcHeAWALQtgGT3JErxULl0oz6R6+3ug91I7IErs93eCFhPCZPHBs4QJS7YWEV7A3sxw=="
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
     },
     "@vueuse/core": {
       "version": "7.7.1",
@@ -23694,9 +24190,9 @@
       }
     },
     "@vueuse/metadata": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-9.3.0.tgz",
-      "integrity": "sha512-GnnfjbzIPJIh9ngL9s9oGU1+Hx/h5/KFqTfJykzh/1xjaHkedV9g0MASpdmPZIP+ynNhKAcEfA6g5i8KXwtoMA=="
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-9.7.0.tgz",
+      "integrity": "sha512-M7WsAgw28FNtTH0bzsGuHEtJOPJqPpyeHS6PHq+8UesLgNjZ9waMAntiUrgUQlxt09M4i2lH7y9sRi0jkfeXGA=="
     },
     "@vueuse/shared": {
       "version": "7.7.1",
@@ -23989,24 +24485,24 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
+      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/cache-browser-local-storage": "4.14.3",
+        "@algolia/cache-common": "4.14.3",
+        "@algolia/cache-in-memory": "4.14.3",
+        "@algolia/client-account": "4.14.3",
+        "@algolia/client-analytics": "4.14.3",
+        "@algolia/client-common": "4.14.3",
+        "@algolia/client-personalization": "4.14.3",
+        "@algolia/client-search": "4.14.3",
+        "@algolia/logger-common": "4.14.3",
+        "@algolia/logger-console": "4.14.3",
+        "@algolia/requester-browser-xhr": "4.14.3",
+        "@algolia/requester-common": "4.14.3",
+        "@algolia/requester-node-http": "4.14.3",
+        "@algolia/transporter": "4.14.3"
       }
     },
     "ansi-escapes": {
@@ -31107,9 +31603,9 @@
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
     },
     "postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -31736,9 +32232,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "preact": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.1.tgz",
-      "integrity": "sha512-1Wz5PCRm6Fg+6BTXWJHhX4wRK9MZbZBHuwBqfZlOdVm2NqPe8/rjYpufvYCwJSGb9layyzB2jTTXfpCTynLqFQ=="
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -32420,9 +32916,9 @@
       }
     },
     "rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.5.tgz",
+      "integrity": "sha512-z0ZbqHBtS/et2EEUKMrAl2CoSdwN7ZPzL17UMiKN9RjjqHShTlv7F9J6ZJZJNREYjBh3TvBrdfjkFDIXFNeuiQ==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -34848,48 +35344,91 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vite": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
-      "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.2.tgz",
+      "integrity": "sha512-QJaY3R+tFlTagH0exVqbgkkw45B+/bXVBzF2ZD1KB5Z8RiAoiKo60vSUf6/r4c2Vh9jfGBKM4oBI9b4/1ZJYng==",
       "requires": {
-        "esbuild": "^0.15.9",
+        "esbuild": "^0.16.3",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.16",
+        "postcss": "^8.4.20",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^3.7.0"
+      },
+      "dependencies": {
+        "@esbuild/android-arm": {
+          "version": "0.16.9",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.9.tgz",
+          "integrity": "sha512-kW5ccqWHVOOTGUkkJbtfoImtqu3kA1PFkivM+9QPFSHphPfPBlBalX9eDRqPK+wHCqKhU48/78T791qPgC9e9A==",
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.16.9",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.9.tgz",
+          "integrity": "sha512-X8te4NLxtHiNT6H+4Pfm5RklzItA1Qy4nfyttihGGX+Koc53Ar20ViC+myY70QJ8PDEOehinXZj/F7QK3A+MKQ==",
+          "optional": true
+        },
+        "esbuild": {
+          "version": "0.16.9",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.9.tgz",
+          "integrity": "sha512-gkH83yHyijMSZcZFs1IWew342eMdFuWXmQo3zkDPTre25LIPBJsXryg02M3u8OpTwCJdBkdaQwqKkDLnAsAeLQ==",
+          "requires": {
+            "@esbuild/android-arm": "0.16.9",
+            "@esbuild/android-arm64": "0.16.9",
+            "@esbuild/android-x64": "0.16.9",
+            "@esbuild/darwin-arm64": "0.16.9",
+            "@esbuild/darwin-x64": "0.16.9",
+            "@esbuild/freebsd-arm64": "0.16.9",
+            "@esbuild/freebsd-x64": "0.16.9",
+            "@esbuild/linux-arm": "0.16.9",
+            "@esbuild/linux-arm64": "0.16.9",
+            "@esbuild/linux-ia32": "0.16.9",
+            "@esbuild/linux-loong64": "0.16.9",
+            "@esbuild/linux-mips64el": "0.16.9",
+            "@esbuild/linux-ppc64": "0.16.9",
+            "@esbuild/linux-riscv64": "0.16.9",
+            "@esbuild/linux-s390x": "0.16.9",
+            "@esbuild/linux-x64": "0.16.9",
+            "@esbuild/netbsd-x64": "0.16.9",
+            "@esbuild/openbsd-x64": "0.16.9",
+            "@esbuild/sunos-x64": "0.16.9",
+            "@esbuild/win32-arm64": "0.16.9",
+            "@esbuild/win32-ia32": "0.16.9",
+            "@esbuild/win32-x64": "0.16.9"
+          }
+        }
       }
     },
     "vitepress": {
-      "version": "1.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-alpha.21.tgz",
-      "integrity": "sha512-D/tkoDW16uUZ9pnWd28Kk1vX26zNiTml3m9oGbfx2pAfYg99PHd1GceZyEm4jZsJU0+n9S++1ctFxoQvsq376A==",
+      "version": "1.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-alpha.32.tgz",
+      "integrity": "sha512-Q45N1cLdRr8MAu/+wAKKow7CNQD4sNBlSNsW1UxYfkvSgwPN/dlEmpEkQl/uOpE3C1kv3jvvEJVY0RAIaJFWYQ==",
       "requires": {
-        "@docsearch/css": "^3.2.1",
-        "@docsearch/js": "^3.2.1",
-        "@vitejs/plugin-vue": "^3.1.2",
-        "@vue/devtools-api": "^6.4.4",
-        "@vueuse/core": "^9.3.0",
+        "@docsearch/css": "^3.3.0",
+        "@docsearch/js": "^3.3.0",
+        "@vitejs/plugin-vue": "^4.0.0",
+        "@vue/devtools-api": "^6.4.5",
+        "@vueuse/core": "^9.6.0",
         "body-scroll-lock": "4.0.0-beta.0",
         "shiki": "^0.11.1",
-        "vite": "^3.1.6",
-        "vue": "^3.2.40"
+        "vite": "^4.0.0",
+        "vue": "^3.2.45"
       },
       "dependencies": {
         "@vueuse/core": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-9.3.0.tgz",
-          "integrity": "sha512-64Rna8IQDWpdrJxgitDg7yv1yTp41ZmvV8zlLEylK4QQLWAhz1OFGZDPZ8bU4lwcGgbEJ2sGi2jrdNh4LttUSQ==",
+          "version": "9.7.0",
+          "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-9.7.0.tgz",
+          "integrity": "sha512-/AGY/t7jJPxCyRoVTygNKoroTiCvRaaZIW+yeSlBCnI7QRpQ9cvXNTdNaSl3GvSyFbn83+XwZwEZvI1OpQfeGw==",
           "requires": {
-            "@types/web-bluetooth": "^0.0.15",
-            "@vueuse/metadata": "9.3.0",
-            "@vueuse/shared": "9.3.0",
+            "@types/web-bluetooth": "^0.0.16",
+            "@vueuse/metadata": "9.7.0",
+            "@vueuse/shared": "9.7.0",
             "vue-demi": "*"
           }
         },
         "@vueuse/shared": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-9.3.0.tgz",
-          "integrity": "sha512-caGUWLY0DpPC6l31KxeUy6vPVNA0yKxx81jFYLoMpyP6cF84FG5Dkf69DfSUqL57wX8JcUkJDMnQaQIZPWFEQQ==",
+          "version": "9.7.0",
+          "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-9.7.0.tgz",
+          "integrity": "sha512-pwmt1y3TJ2s5KqWmkv9ZKEV59GwuZQZk8XLiU+hGswz0jej318ozbea9E4A/A50ksyM26swSFr7sZ9llNPsZHg==",
           "requires": {
             "vue-demi": "*"
           }
@@ -34907,15 +35446,15 @@
       "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ=="
     },
     "vue": {
-      "version": "3.2.41",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.41.tgz",
-      "integrity": "sha512-uuuvnrDXEeZ9VUPljgHkqB5IaVO8SxhPpqF2eWOukVrBnRBx2THPSGQBnVRt0GrIG1gvCmFXMGbd7FqcT1ixNQ==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
+      "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
       "requires": {
-        "@vue/compiler-dom": "3.2.41",
-        "@vue/compiler-sfc": "3.2.41",
-        "@vue/runtime-dom": "3.2.41",
-        "@vue/server-renderer": "3.2.41",
-        "@vue/shared": "3.2.41"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-sfc": "3.2.45",
+        "@vue/runtime-dom": "3.2.45",
+        "@vue/server-renderer": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "vue-demi": {

--- a/packages/docs/.vitepress/config.js
+++ b/packages/docs/.vitepress/config.js
@@ -43,6 +43,7 @@ export default defineConfig({
       '/api/services/': getApiSidebar({ expanded: 'services' }),
       '/api/decorators/': getApiSidebar({ expanded: 'decorators' }),
       '/api/helpers/': getApiSidebar({ expanded: 'helpers' }),
+      '/api/html/': getApiSidebar({ expanded: 'html' }),
       '/api/': getApiSidebar({ expanded: 'api' }),
       '/utils/': getUtilsSidebar(),
     },
@@ -117,6 +118,12 @@ function getApiSidebar({ expanded = 'api' } = {}) {
       items: expanded === 'api' ? getBaseSidebar() : getBaseSidebar(),
     },
     {
+      text: 'HTML',
+      link: '/api/html/',
+      collapsible: true,
+      items: expanded === 'html' ? getHtmlSidebar() : getHtmlSidebar(),
+    },
+    {
       text: 'Helpers',
       link: '/api/helpers/',
       collapsible: true,
@@ -175,6 +182,14 @@ function getBaseSidebar() {
       text: 'Static methods',
       link: '/api/static-methods.html',
     },
+  ];
+}
+
+function getHtmlSidebar() {
+  return [
+    { text: 'data-component', link: '/api/html/data-component.html' },
+    { text: 'data-ref', link: '/api/html/data-ref.html' },
+    { text: 'data-option-<​name>', link: '/api/html/data-option.html' },
   ];
 }
 

--- a/packages/docs/api/html/data-component.md
+++ b/packages/docs/api/html/data-component.md
@@ -1,0 +1,65 @@
+# data-component
+
+Use the `data-component` in HTML to bind a JavaScript class to an element.
+
+:::tip READ MORE
+- [Configuration: `config.components`](/api/configuration.html#config-components)
+- [Guide: managing components](/guide/introduction/managing-components.html)
+:::
+
+## Simple usage
+
+When using the `config.components` property, the framework will find components by using a selector combining the `data-component` attribute and the key declared in the configuration.
+
+In the following example, both of the imported components will be mounted. One with the name `Component`, mounted on `[data-component="Component"]` elements found in the DOM. The other with the name `CustomName`, mounted on `[data-component="CustomName"]` elements.
+
+```js
+import { Base, createApp } from '@studiometa/js-toolkit';
+import Component from './Component.js';
+import OtherComponent from './OtherComponent.js';
+
+class App extends Base {
+  static config = {
+    name: 'App',
+    components: {
+      Component,
+      CustomName: OtherComponent,
+    },
+  };
+}
+
+export default createApp(App);
+```
+
+```html
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>App</title>
+  </head>
+  <body>
+    <div data-component="Component"></div>
+    <div data-component="CustomName"></div>
+  </body>
+</html>
+```
+
+## Multiple components on a single HTML element
+
+Mutliptle components can be declared on a single HTMLElement by declaring multiple names in the `data-component` attribute separated by a whitespace.
+
+In the following example, both components from our previous app will be mounted on the same element.
+
+```html
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>App</title>
+  </head>
+  <body>
+    <div data-component="Component CustomName"></div>
+  </body>
+</html>
+```

--- a/packages/docs/api/html/data-option.md
+++ b/packages/docs/api/html/data-option.md
@@ -1,0 +1,34 @@
+# data-option-<​name>
+
+Use `data-option-<name>` attributes to configure the options of components from your HTML.
+
+:::tip READ MORE
+- [Configuration: `config.options`](/api/configuration.html#config-options)
+- [Guide: managing options](/guide/introduction/managing-options.html)
+:::
+
+## data-option-no-<​name>
+
+When using a boolean option, you can negate its value by prefixing its name with `no-`.
+
+```js
+class Component extends Base {
+  static config = {
+    name: 'Component',
+    options: {
+      open: {
+        type: Boolean,
+        default: true,
+      },
+    },
+  };
+
+  mounted() {
+    console.log(this.$options.open); // false
+  }
+}
+```
+
+```html
+<div data-component="Component" data-option-no-open></div>
+```

--- a/packages/docs/api/html/data-ref.md
+++ b/packages/docs/api/html/data-ref.md
@@ -1,0 +1,8 @@
+# data-ref
+
+Use `data-ref` attributes to define elements inside the scope of a component which should be accessed in JavaScript with the `$refs` instance property.
+
+:::tip READ MORE
+- [Configuration: `config.refs`](/api/configuration.html#config-refs)
+- [Guide: managing refs](/guide/introduction/managing-refs.html)
+:::

--- a/packages/docs/api/html/index.md
+++ b/packages/docs/api/html/index.md
@@ -1,0 +1,8 @@
+# HTML API
+
+The following attributes can be used:
+
+- [data-component](./data-component.md)
+- [data-ref](./data-ref.md)
+- [data-option](./data-option.md)
+

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,6 +11,6 @@
     "@bytebase/vue-kbar": "^0.1.8",
     "@studiometa/tailwind-config": "^2.0.2",
     "tailwindcss": "^3.2.4",
-    "vitepress": "^1.0.0-alpha.21"
+    "vitepress": "^1.0.0-alpha.32"
   }
 }

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -1,6 +1,8 @@
 import { isArray, isDefined, isDev } from '../utils/index.js';
 import type { Base, BaseConfig } from './index.js';
 
+const selectors = new Map();
+
 /**
  * Get a list of elements based on the name of a component.
  *
@@ -15,7 +17,14 @@ export function getComponentElements(
   nameOrSelector: string,
   element: HTMLElement | Document = document,
 ): HTMLElement[] {
-  const selector = `[data-component="${nameOrSelector}"]`;
+  if (!selectors.has(nameOrSelector)) {
+    selectors.set(
+      nameOrSelector,
+      `[data-component="${nameOrSelector}"],[data-component*=",${nameOrSelector},"],[data-component$=",${nameOrSelector}"],[data-component^="${nameOrSelector},"]`,
+    );
+  }
+
+  const selector = selectors.get(nameOrSelector);
   let elements = [];
 
   try {

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -3,6 +3,30 @@ import type { Base, BaseConfig } from './index.js';
 
 const selectors = new Map();
 
+// Separator used for multi-component declaration in `data-component` attributeS.
+const separator = ' ';
+
+/**
+ * Get the selector for a given component.
+ */
+function getSelector(nameOrSelector: string): string {
+  if (!selectors.has(nameOrSelector)) {
+    const parts = [
+      // Single selector
+      `[data-component="${nameOrSelector}"]`,
+      // Selector in the middle of a list of selectors
+      `[data-component*="${separator}${nameOrSelector}${separator}"]`,
+      // Selector at the end of a list of selectors
+      `[data-component$="${separator}${nameOrSelector}"]`,
+      // Selector at the beginning of a list of selectors
+      `[data-component^="${nameOrSelector}${separator}"]`,
+    ];
+    selectors.set(nameOrSelector, parts.join(','));
+  }
+
+  return selectors.get(nameOrSelector);
+}
+
 /**
  * Get a list of elements based on the name of a component.
  *
@@ -17,14 +41,7 @@ export function getComponentElements(
   nameOrSelector: string,
   element: HTMLElement | Document = document,
 ): HTMLElement[] {
-  if (!selectors.has(nameOrSelector)) {
-    selectors.set(
-      nameOrSelector,
-      `[data-component="${nameOrSelector}"],[data-component*=",${nameOrSelector},"],[data-component$=",${nameOrSelector}"],[data-component^="${nameOrSelector},"]`,
-    );
-  }
-
-  const selector = selectors.get(nameOrSelector);
+  const selector = getSelector(nameOrSelector);
   let elements = [];
 
   try {

--- a/packages/tests/Base/utils.spec.js
+++ b/packages/tests/Base/utils.spec.js
@@ -1,0 +1,21 @@
+import { getComponentElements } from '@studiometa/js-toolkit/Base/utils.js';
+
+describe('The `getComponentElements` function', () => {
+  it('should find components with multiple declarations', () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <div data-component="Foo"></div>
+      <div data-component="Foo,Bar"></div>
+      <div data-component="Bar,Foo"></div>
+      <div data-component="Bar,Foo,Baz"></div>
+      <div data-component="Baz"></div>
+    `;
+
+    const foo = getComponentElements('Foo', div);
+    const bar = getComponentElements('Bar', div);
+    const baz = getComponentElements('Baz', div);
+    expect(foo).toHaveLength(4);
+    expect(bar).toHaveLength(3);
+    expect(baz).toHaveLength(2);
+  });
+})

--- a/packages/tests/Base/utils.spec.js
+++ b/packages/tests/Base/utils.spec.js
@@ -5,17 +5,17 @@ describe('The `getComponentElements` function', () => {
     const div = document.createElement('div');
     div.innerHTML = `
       <div data-component="Foo"></div>
-      <div data-component="Foo,Bar"></div>
-      <div data-component="Bar,Foo"></div>
-      <div data-component="Bar,Foo,Baz"></div>
+      <div data-component="Foo Bar"></div>
+      <div data-component="Bar Foo"></div>
+      <div data-component="Bar Foo Baz"></div>
       <div data-component="Baz"></div>
+      <!-- The following should not be found -->
+      <div data-component="FooBaz"></div>
+      <div data-component="FooBaz BarFoo"></div>
     `;
 
-    const foo = getComponentElements('Foo', div);
-    const bar = getComponentElements('Bar', div);
-    const baz = getComponentElements('Baz', div);
-    expect(foo).toHaveLength(4);
-    expect(bar).toHaveLength(3);
-    expect(baz).toHaveLength(2);
+    expect(getComponentElements('Foo', div)).toHaveLength(4);
+    expect(getComponentElements('Bar', div)).toHaveLength(3);
+    expect(getComponentElements('Baz', div)).toHaveLength(2);
   });
-})
+});


### PR DESCRIPTION
Since [v2.0.0-beta.18](https://github.com/studiometa/js-toolkit/releases/tag/2.0.0-beta.18) (see #206), an HTML element can be used as root for multiple components. It was not possible yet to easily register multiple components on one element without using CSS selectors as component names. 

This feature adds support for registration of multiple components on a single HTML element via its `data-component` attribute:

```html
<div data-component="One Two Three"></div>
```

## To do
- [x] Write docs
- [x] Decide if the `,` as separator is the best option