### PR TITLE
[Feature] Animate CSS custom properties

### DIFF
--- a/packages/demo/src/templates/components/animate-test.twig
+++ b/packages/demo/src/templates/components/animate-test.twig
@@ -1,9 +1,9 @@
 {% set easing = easing|default('easeInOutExpo') %}
 
 {% set steps = steps|default([
-  {},
-  { x: [50, '%'], rotate: 180, scale: 0.5, opacity: 0.5 },
-  { x: [100, '%'], rotate: 360 }
+  { '--red': 0 },
+  { x: [50, '%'], rotate: 180, scale: 0.5, opacity: 0.5, '--red': 255 },
+  { x: [100, '%'], rotate: 360, '--red': 0 }
 ]) %}
 
 {% set target_class = target_class|default('w-1/2') %}
@@ -40,7 +40,7 @@
   </div>
   <div class="w-96 rounded-xl bg-gray-200 {{ container_class }}">
     {% block target %}
-      <div data-ref="target" class="{{ target_class }} h-48 rounded-xl bg-black"></div>
+      <div data-ref="target" style="background-color: rgb(var(--red, 0), 0, 0);" class="{{ target_class }} h-48 rounded-xl bg-black"></div>
     {% endblock %}
   </div>
 </div>

--- a/packages/demo/src/templates/pages/index.twig
+++ b/packages/demo/src/templates/pages/index.twig
@@ -41,9 +41,9 @@
         target_class: 'w-full',
         container_class: 'overflow-hidden',
         steps: [
-          { scaleX: 0 },
-          { scaleX: 1, transformOrigin: 'top left' },
-          { scaleX: 0, transformOrigin: 'top right' }
+          { scaleX: 0, '--red': 0 },
+          { scaleX: 1, transformOrigin: 'top left', '--red': 255 },
+          { scaleX: 0, transformOrigin: 'top right', '--red': 0 }
         ]
       } %}
       <!-- BEGIN BreakpointManagerDemo -->

--- a/packages/docs/utils/css/animate.md
+++ b/packages/docs/utils/css/animate.md
@@ -10,9 +10,9 @@ import { animate, easeInOutExpo } from '@studiometa/js-toolkit/utils';
 const animation = animate(
   document.body,
   [
-    { x: 0 }, // from
-    { x: 100, scale: 0.5, opacity: 0.5, easing: [0, 1, 0, 1] },
-    { x: 0 }, // to
+    { x: 0, '--red': 0 }, // from
+    { x: 100, scale: 0.5, opacity: 0.5, '--red': 255, easing: [0, 1, 0, 1] },
+    { x: 0, '--red': 0 }, // to
   ],
   {
     duration: 10,
@@ -27,7 +27,7 @@ animation.start();
 
 - `element` (`HTMLElement | HTMLElement[] | NodeListOf<HTMLElement>`): the target HTML element
 - `keyframes` (`KeyFrame[]`): array of objects describing the key frames of the animation
-  `options` (`Options`): options for the animation
+- `options` (`Options`): options for the animation, see [types](#types) below for more details
 
 ### Return value
 
@@ -71,12 +71,14 @@ import { TransformProps } from '@studiometa/js-toolkit/utils';
 
 type EasingFunction = (value:number) => number;
 type BezierCurve = [number, number, number, number];
+type CSSCustomPropertyName = `--${string}`;
 
 interface KeyFrame extends TransformProps {
   opacity?: number;
   transformOrigin?: string;
   easing?: EasingFunction|BezierCurve;
   offset?: number;
+  [key:CSSCustomPropertyName]: number;
 }
 
 interface Options {

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -9,11 +9,14 @@ import type { TransformProps } from './transform.js';
 import type { EasingFunction } from '../math/index.js';
 import type { BezierCurve, TweenOptions } from '../tween.js';
 
+export type CSSCustomPropertyName = `--${string}`;
+
 export type Keyframe = TransformProps & {
   opacity?: number;
   transformOrigin?: string;
   easing?: EasingFunction | BezierCurve;
   offset?: number;
+  [key: CSSCustomPropertyName]: number;
 };
 
 export type NormalizedKeyframe = Keyframe & {
@@ -145,7 +148,7 @@ function render(
       }
       if (customProperties !== false) {
         customProperties.forEach((customProperty) => {
-          element.style.setProperty(customProperty[0], customProperty[1]);
+          element.style.setProperty(customProperty[0], customProperty[1].toString());
         });
       }
       transform(element, props);

--- a/packages/js-toolkit/utils/tween.ts
+++ b/packages/js-toolkit/utils/tween.ts
@@ -6,13 +6,14 @@ import useRaf from '../services/raf.js';
 import type { EasingFunction } from './math/createEases.js';
 
 let id = 0;
-const PROGRESS_PRECISION = 0.01;
+const DEFAULT_PROGRESS_PRECISION = 0.0001;
 
 export type BezierCurve = [number, number, number, number];
 
 export interface TweenOptions {
   duration?: number;
   easing?: EasingFunction | BezierCurve;
+  precision?: number;
   onStart?: () => void;
   onProgress?: (progress: number, easedProgress: number) => void;
   onFinish?: (progress: number, easedProgress: number) => void;
@@ -42,6 +43,7 @@ export function tween(callback: (progress: number) => unknown, options: TweenOpt
   let progressValue = 0;
   let easedProgress = 0;
 
+  const precision = options.precision ?? DEFAULT_PROGRESS_PRECISION;
   const ease = normalizeEase(options.easing);
   let duration = options.duration ?? 1;
   duration *= 1000;
@@ -75,7 +77,7 @@ export function tween(callback: (progress: number) => unknown, options: TweenOpt
     easedProgress = ease(progressValue);
 
     // Stop when reaching precision
-    if (Math.abs(1 - easedProgress) < PROGRESS_PRECISION) {
+    if (Math.abs(1 - easedProgress) < precision) {
       progressValue = 1;
       easedProgress = 1;
     }

--- a/packages/tests/utils/css/animate.spec.js
+++ b/packages/tests/utils/css/animate.spec.js
@@ -183,5 +183,19 @@ describe('The `animate` utility function', () => {
     expect(animation2.progress()).toBe(1);
   });
 
+  it('should animate CSS custom properties',async () => {
+    const div = document.createElement('div');
+    const animation = animate(div, [{'--var': 0}, {'--var': 1}]);
+    animation.progress(0);
+    await wait();
+    expect(div.style.getPropertyValue('--var')).toBe('0');
+    animation.progress(0.5);
+    await wait();
+    expect(div.style.getPropertyValue('--var')).toBe('0.5');
+    animation.progress(1);
+    await wait();
+    expect(div.style.getPropertyValue('--var')).toBe('1');
+  });
+
   // should be able to specify offset
 });


### PR DESCRIPTION
This PR adds support for animating CSS custom properties with the `animate` function: 

```js
import { animate } from '@studiometa/js-toolkit/utils';

const element = document.querySelector('.element');

animate(element, [
  { '--red': 0 },
  { '--red': 255 },
]).start();
```

This opens up the ability to animate any CSS property using the `calc()` and `var()` CSS functions. 