### PR TITLE
[Feature] Add support for refs with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
-- **Base:** add support for multiple component declaration in data-component attributes ([#330](https://github.com/studiometa/js-toolkit/pull/330))
+- **Base:**
+  - add support for multiple component declaration in data-component attributes ([#330](https://github.com/studiometa/js-toolkit/pull/330))
+  - add support for refs with prefix ([#339](https://github.com/studiometa/js-toolkit/pull/339))
 - **animate:** add support for animating CSS Custom Properties ([#332](https://github.com/studiometa/js-toolkit/pull/332))
 
 ## [v2.7.0](https://github.com/studiometa/js-toolkit/compare/2.6.5..2.7.0) (2022-12-02)

--- a/packages/docs/.vitepress/theme/custom.scss
+++ b/packages/docs/.vitepress/theme/custom.scss
@@ -6,6 +6,7 @@ h3 + h4 {
 
 :root {
   --sidebar-width: 16.4rem;
+  --vp-code-line-height: 1.5;
 
   @media (min-width: 960px) {
     --sidebar-width: 24rem;
@@ -57,3 +58,4 @@ body {
 .VPHomeHero .text {
   max-width: 12em;
 }
+

--- a/packages/docs/api/configuration.md
+++ b/packages/docs/api/configuration.md
@@ -123,6 +123,8 @@ Define the refs of the components by specifying their name in the configuration.
     <li data-ref="otherItems[]">#1</li>
     <li data-ref="otherItems[]">#2</li>
   </ul>
+  <!-- Refs can be prefixed by the name of their component (in HTML only)  -->
+  <input data-ref="Component.input" type="text">
 </div>
 ```
 

--- a/packages/docs/guide/introduction/managing-refs.md
+++ b/packages/docs/guide/introduction/managing-refs.md
@@ -1,3 +1,7 @@
+---
+outline: deep
+---
+
 # Managing refs
 
 ## What are refs?
@@ -85,7 +89,7 @@ Then in the HTML template:
 
 ## Using refs
 
-Once refs are declared and added in the HTML template it becomes accessible via the instance property `this.$refs.<name>`.
+Once refs are declared and added in the HTML template it becomes accessible via the corresponding instance property `this.$refs.<name>`.
 
 ```html {2,5-7}
 <div data-component="Component">
@@ -110,9 +114,104 @@ class Component extends Base {
     this.$refs.btn; // <button data-ref="btn">Click me</button>
     this.$refs.items; // [<li data-ref="items[]">#1</li>, ...]
   }
+
+  /**
+   * Attaching a `click` event listener to the `btn` ref.
+   */
+  onBtnClick() {
+    console.log('Button has been clicked!');
+  }
 }
 ```
 
 ::: tip Attaching events to a ref
 Visit the [Working with events](/guide/introduction/working-with-events.html) section of the guide to learn how to handle events while using refs.
+:::
+
+### Nested refs
+
+By default, refs are resolved within the component's scope determined by the `data-component` attribute. In the following example, the parent component will only have one element in its `this.$refs.items` property.
+
+```html
+<div data-component="Parent"> <─────────┐
+  <div data-ref="items[]">direct</div> ─┘
+  <div data-component="Child">
+    <div data-ref="items[]">nested</div>
+  </div>
+</div>
+```
+
+```js
+import { Base } from '@studiometa/js-toolkit';
+import Child from './Child.js';
+
+class Parent extends Base {
+  static config = {
+    name: 'Parent',
+    components: { Child },
+    refs: ['items[]'],
+  };
+
+  mounted() {
+    console.log(this.$refs.items.length);
+    console.log(this.$refs.items[0]);
+  }
+}
+```
+
+```js
+// Logs
+1
+<div data-ref="items[]">direct</div>
+```
+
+If you need to access to nested refs, you can prefix the refs name with the component's name as defined in the static `config` property of the class.
+
+```html {4}
+<div data-component="Parent"> <─────────┐────────┐
+  <div data-ref="items[]">direct</div> ─┘        │
+  <div data-component="Child">                   │
+    <div data-ref="Parent.items[]">nested</div> ─┘
+  </div>
+</div>
+```
+
+```js
+import { Base } from '@studiometa/js-toolkit';
+import Child from './Child.js';
+
+class Parent extends Base {
+  static config = {
+    name: 'Parent',
+    components: { Child },
+    refs: ['items[]'],
+  };
+
+  mounted() {
+    console.log(this.$refs.items.length);
+    console.log(this.$refs.items[0]);
+    console.log(this.$refs.items[1]);
+  }
+}
+```
+
+```js
+// Logs
+2
+<div data-ref="items[]">direct</div>
+<div data-ref="Parent.items[]">nested</div>
+```
+
+:::warning Nested refs and nested components
+The resolution scope of nested refs will be limited in case of nested components.
+```html
+<div data-component="Parent"> <─────────┐
+  <div data-ref="items[]">direct</div> ─┘
+  <div data-component="Child">
+    <div data-component="Parent"> <────────────────┐
+      <div data-ref="Parent.items[]">nested</div> ─┘
+    </div>
+  </div>
+</div>
+``
 :::

--- a/packages/js-toolkit/helpers/getClosestParent.ts
+++ b/packages/js-toolkit/helpers/getClosestParent.ts
@@ -1,25 +1,6 @@
 import type { Base, BaseConstructor } from '../Base/index.js';
 import getInstanceFromElement from './getInstanceFromElement.js';
-
-/**
- * Walk through an element ancestors while the given condition is true with a
- * limit of 1000 iteration to avoid infinite loops.
- */
-function walkAncestorsWhile(
-  element: HTMLElement,
-  condition: (element: HTMLElement) => boolean,
-  limit = 1000,
-): HTMLElement | null {
-  let parent = element.parentElement;
-  let count = 0;
-
-  while (parent && condition(parent) && count < limit) {
-    parent = parent.parentElement;
-    count += 1;
-  }
-
-  return parent;
-}
+import { getAncestorWhere } from '../utils/index.js';
 
 /**
  * Get the closest parent of a component.
@@ -28,9 +9,9 @@ export default function getClosestParent<T extends BaseConstructor>(
   childInstance: Base,
   ParentConstructor: T,
 ) {
-  const parentEl = walkAncestorsWhile(
+  const parentEl = getAncestorWhere(
     childInstance.$el,
-    (element) => !getInstanceFromElement(element, ParentConstructor),
+    (element) => element && getInstanceFromElement(element, ParentConstructor) !== null,
   );
 
   return parentEl ? getInstanceFromElement(parentEl, ParentConstructor) : null;

--- a/packages/js-toolkit/utils/dom/ancestors.ts
+++ b/packages/js-toolkit/utils/dom/ancestors.ts
@@ -1,0 +1,23 @@
+/**
+ * Get an ancestor matching the given condition.
+ */
+export function getAncestorWhere(element: HTMLElement, condition: (el: HTMLElement) => boolean) {
+  if (!element) {
+    return null;
+  }
+
+  const ancestor = element.parentElement;
+
+  return condition(ancestor) ? ancestor : getAncestorWhere(ancestor, condition);
+}
+
+/**
+ * Get an ancestor matching the given condition, stop when the until function is truthy.
+ */
+export function getAncestorWhereUntil(
+  element: HTMLElement,
+  condition: (el: HTMLElement) => boolean,
+  until: (el: HTMLElement) => boolean,
+): HTMLElement | null {
+  return getAncestorWhere(element, (el) => condition(el) || until(el));
+}

--- a/packages/js-toolkit/utils/dom/index.ts
+++ b/packages/js-toolkit/utils/dom/index.ts
@@ -1,0 +1,1 @@
+export * from './ancestors.js';

--- a/packages/js-toolkit/utils/index.ts
+++ b/packages/js-toolkit/utils/index.ts
@@ -23,3 +23,4 @@ export * from './scheduler.js';
 export * from './noop.js';
 export { tween } from './tween.js';
 export { Queue } from './Queue.js';
+export * from './dom/index.js';

--- a/packages/tests/Base/managers/RefsManager.spec.js
+++ b/packages/tests/Base/managers/RefsManager.spec.js
@@ -67,6 +67,43 @@ describe('The refs resolution', () => {
     expect(app.$refs.bar).toEqual([]);
   });
 
+  it('should resolve nested ref with component’s name prefix', () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <div>
+        <div data-ref="foo"></div>
+        <div data-component="Component">
+          <div data-ref="App.bar[]"></div>
+        </div>
+      </div>
+    `;
+    const app = new App(div).$mount();
+    expect(app.$refs.bar).toHaveLength(1);
+  });
+
+  it('should not resolve nested ref with component’s name prefix inside nested component', () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <div>
+        <div data-ref="foo"></div>
+        <div data-direct data-ref="bar[]"></div>
+        <div data-direct data-prefixed data-ref="App.bar[]"></div>
+        <div data-component="Component">
+          <div data-prefixed data-ref="App.bar[]"></div>
+          <div data-component="App">
+            <div data-nested data-ref="App.bar[]"></div>
+          </div>
+        </div>
+      </div>
+    `;
+    const app = new App(div).$mount();
+    expect(app.$refs.bar).toHaveLength(3);
+    expect(app.$refs.bar[0].dataset.direct).toBeDefined();
+    expect(app.$refs.bar[1].dataset.direct).toBeDefined();
+    expect(app.$refs.bar[1].dataset.prefixed).toBeDefined();
+    expect(app.$refs.bar[2].dataset.prefixed).toBeDefined();
+  });
+
   it('should be able to resolve multiple refs as array with a warning', () => {
     const div = document.createElement('div');
     div.innerHTML = `

--- a/packages/tests/helpers/getClosestParent.spec.js
+++ b/packages/tests/helpers/getClosestParent.spec.js
@@ -47,6 +47,7 @@ describe('The `getInstanceFromElement` helper function', () => {
 
   it('should return the closest parent', () => {
     expect(getClosestParent(firstChild, Parent)).toBe(parent);
+    expect(getClosestParent(secondChild, Parent)).not.toBeNull();
     expect(getClosestParent(secondChild, Parent)).toBe(nestedParent);
   });
 

--- a/packages/tests/utils/__snapshots__/index.spec.js.snap
+++ b/packages/tests/utils/__snapshots__/index.spec.js.snap
@@ -42,6 +42,8 @@ exports[`@studiometa/js-toolkit/utils exports should export all scripts 1`] = `
   "easeOutQuint",
   "easeOutSine",
   "focusTrap",
+  "getAncestorWhere",
+  "getAncestorWhereUntil",
   "getOffsetSizes",
   "hasWindow",
   "historyPush",


### PR DESCRIPTION
This PR adds support for refs with prefix, allowing us to place refs from a component inside another component.

Refs in nested components will not be resolved from a parent component based on their name from the `data-component` attribute.

```html
<div data-component="App">
  <div data-ref="foo"></div>
  <div data-direct data-ref="bar[]"></div>
  <div data-direct data-prefixed data-ref="App.bar[]"></div>
  <div data-component="Component">
    <div data-ref="bar[]"></div>
    <div data-prefixed data-ref="App.bar[]"></div>
    <div data-component="App">
      <div data-nested data-ref="bar[]"></div>
      <div data-nested data-prefixed data-ref="App.bar[]"></div>
    </div>
  </div>
</div>
```

```js
class App extends Base {
  static config = {
    name: 'App',
    refs: ['bar[]'],
  };
}

const apps = App.$factory('App');

console.log(apps[0].$refs.bar.length); // 3
console.log(apps[0].$refs.bar[0]); // <div data-direct data-ref="bar[]"></div>
console.log(apps[0].$refs.bar[1]); // <div data-direct data-prefixed data-ref="App.bar[]"></div>
console.log(apps[0].$refs.bar[2]); // <div data-prefixed data-ref="App.bar[]"></div>

console.log(apps[1].$refs.bar.length); // 2
console.log(apps[1].$refs.bar[0]); // <div data-nested data-ref="bar[]"></div>
console.log(apps[1].$refs.bar[1]); // <div data-nested data-prefixed data-ref="App.bar[]"></div>
```

## To do

- [x] Update documentation
- [x] Update changelog