### PR TITLE
[Feature] Queue: add support for promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. The format 
 - Add a `SmartQueue` utility class ([f179d8b](https://github.com/studiometa/js-toolkit/commit/f179d8b))
 - Add a `wait` utility function ([7c9d038](https://github.com/studiometa/js-toolkit/commit/7c9d038))
 - **Base:** add a `$warn()` helper ([#335](https://github.com/studiometa/js-toolkit/pull/335))
+- **Queue:** add support for promises for easier task orchestration ([#341](https://github.com/studiometa/js-toolkit/pull/341))
+
 
 ### Fixed
 - **Base:** fix and improve the async children feature ([#328](https://github.com/studiometa/js-toolkit/pull/328), [79f295f](https://github.com/studiometa/js-toolkit/commit/79f295f))

--- a/packages/js-toolkit/utils/Queue.ts
+++ b/packages/js-toolkit/utils/Queue.ts
@@ -39,9 +39,12 @@ export class Queue {
   /**
    * Add a task to the queue.
    */
-  add(task: (...args: unknown[]) => unknown) {
-    this.tasks.push(task);
+  add(task: () => unknown) {
+    const p = new Promise((resolve) => {
+      this.tasks.push(() => resolve(task()));
+    });
     this.scheduleFlush();
+    return p;
   }
 
   /**

--- a/packages/tests/utils/Queue.spec.js
+++ b/packages/tests/utils/Queue.spec.js
@@ -27,4 +27,14 @@ describe('The `Queue` class', () => {
     queue.add(spy);
     expect(spy).toHaveBeenCalledTimes(3);
   });
+
+  it('should return a promise when adding a task', async () => {
+    const queue = new Queue(1, nextTick);
+    const spy = jest.fn();
+    const p = queue.add(spy);
+    expect(p).toBeInstanceOf(Promise);
+    expect(spy).toHaveBeenCalledTimes(0);
+    await p;
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
This allows us to know when a task has been executed: 

```js
import { Queue, nextTick } from '@studiometa/js-toolkit/utils';

const q = new Queue(10, nextTick);
const task = () => console.log('I am a task');

q.add(task).then(() => console.log('Task has been executed'));
```