### PR TITLE
[Bugfix] withScrolledInView: fix props not being defined in some contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 - **Base:** fix and improve the async children feature ([#328](https://github.com/studiometa/js-toolkit/pull/328), [79f295f](https://github.com/studiometa/js-toolkit/commit/79f295f))
+- **withScrolledInView:** fix props sometimes not being defined ([#343](https://github.com/studiometa/js-toolkit/pull/343))
 
 ### Changed
 - Improve the `nextTick` utility function ([ca35e6b](https://github.com/studiometa/js-toolkit/commit/ca35e6b))

--- a/packages/tests/decorators/withScrolledInView/__snapshots__/withScrolledInView.spec.js.snap
+++ b/packages/tests/decorators/withScrolledInView/__snapshots__/withScrolledInView.spec.js.snap
@@ -3,20 +3,20 @@
 exports[`The withScrolledInView decorator should trigger the \`scrolledInView\` hook when in view 1`] = `
 {
   "current": {
-    "x": 600,
-    "y": 600,
+    "x": 2560,
+    "y": 2560,
   },
   "end": {
-    "x": 600,
-    "y": 600,
+    "x": 3160,
+    "y": 3160,
   },
   "progress": {
-    "x": 1,
-    "y": 1,
+    "x": 0.46619217081850534,
+    "y": 0.3087557603686636,
   },
   "start": {
-    "x": -524,
-    "y": -268,
+    "x": 2036,
+    "y": 2292,
   },
 }
 `;


### PR DESCRIPTION
The render function could be called before the `mounted` event listener, resulting in the props not being set correctly and containing som `NaN` values. Using a lazy evaluation via a getter resolves this issue.