### PR TITLE
[Bugfix] Listen for drop events on the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- **useDrag:** listen for drop events on the window instead of the target element ([e0ab5b5](https://github.com/studiometa/js-toolkit/pull/348/commits/e0ab5b5))
+
 ## [v2.9.0](https://github.com/studiometa/js-toolkit/compare/2.8.0..2.9.0) (2023-01-28)
 
 ### Added

--- a/packages/js-toolkit/services/drag.ts
+++ b/packages/js-toolkit/services/drag.ts
@@ -66,7 +66,8 @@ const MODES: Record<Uppercase<DragLifecycle>, DragLifecycle> = {
 };
 
 let count = 0;
-const events = ['pointerdown', 'pointerup', 'touchend'];
+const targetEvents = ['pointerdown'];
+const windowEvents = ['pointerup', 'touchend'];
 const passiveEventOptions = { passive: true };
 
 /**
@@ -276,15 +277,21 @@ function createDragService(
       },
     } as DragServiceProps,
     init() {
-      events.forEach((event) => {
+      targetEvents.forEach((event) => {
         target.addEventListener(event, handleEvent, passiveEventOptions);
+      });
+      windowEvents.forEach((event) => {
+        window.addEventListener(event, handleEvent, passiveEventOptions);
       });
       target.addEventListener('dragstart', handleEvent, { capture: true });
       target.addEventListener('click', handleEvent, { capture: true });
     },
     kill() {
-      events.forEach((event) => {
+      targetEvents.forEach((event) => {
         target.removeEventListener(event, handleEvent);
+      });
+      windowEvents.forEach((event) => {
+        window.removeEventListener(event, handleEvent);
       });
       target.removeEventListener('dragstart', handleEvent);
       target.removeEventListener('click', handleEvent);

--- a/packages/tests/services/drag.spec.js
+++ b/packages/tests/services/drag.spec.js
@@ -43,7 +43,7 @@ describe('The drag service', () => {
     // Test double start prevention
     div.dispatchEvent(createEvent('pointerdown', { x: 0, y: 0, button: 0 }));
     expect(props().mode).toBe('drag');
-    div.dispatchEvent(createEvent('pointerup'));
+    window.dispatchEvent(createEvent('pointerup'));
     expect(props().mode).toBe('drop');
   });
 


### PR DESCRIPTION
Listen for drop events on the window to prevent the target object from sticking to the mouse when the drop occurs outside the window boundaries.