### PR TITLE
[Bugfix] Improve timing of app instanciation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file. The format 
 - **getInstanceFromElement:** fix getting an instance from a falsy element ([#349](https://github.com/studiometa/js-toolkit/pull/349))
 - **withScrolledInView:** fix division by 0 resulting in `NaN` progress value ([#350](https://github.com/studiometa/js-toolkit/pull/350))
 
+### Changed
+
+- **createApp**: improve timing of app instanciation when using the `asyncChildren` feature ([#351](https://github.com/studiometa/js-toolkit/pull/351))
+
 ## [v2.9.0](https://github.com/studiometa/js-toolkit/compare/2.8.0..2.9.0) (2023-01-28)
 
 ### Added

--- a/packages/tests/helpers/createApp.spec.js
+++ b/packages/tests/helpers/createApp.spec.js
@@ -6,18 +6,27 @@ import { features } from '@studiometa/js-toolkit/Base/features.js';
 
 describe('The `createApp` function', () => {
   const fn = jest.fn();
+  const ctorFn = jest.fn();
 
   class App extends Base {
     static config = {
       name: 'App',
     };
 
+    constructor(...args) {
+      super(...args);
+      ctorFn();
+    }
+
     mounted() {
       fn();
     }
   }
 
-  beforeEach(() => fn.mockRestore());
+  beforeEach(() => {
+    fn.mockRestore();
+    ctorFn.mockRestore();
+  });
 
   it('should instantiate the app directly if the page is alreay loaded', async () => {
     const useApp = createApp(App, document.createElement('div'));
@@ -67,5 +76,16 @@ describe('The `createApp` function', () => {
       },
     });
     expect(features.get('asyncChildren')).toBe(true);
+  });
+
+  it('should instantiate directly when the asynChildren feature is enabled', async () => {
+    const useApp = createApp(App, {
+      features: {
+        asyncChildren: true,
+      },
+    });
+    expect(ctorFn).toHaveBeenCalledTimes(1);
+    expect(useApp()).toBeInstanceOf(Promise);
+    expect(await useApp()).toBeInstanceOf(App);
   });
 });


### PR DESCRIPTION
When using the `asyncChildren` feature, the components will be mounted without blocking the main thread by using a `SmartQueue` instance. This means that we can instantiate the app sooner without worrying about blocking time and might help to avoid layout shifts when mounting components.