### PR TITLE
[Bugfix] Fix the `easeInExpo` value when progress is 0 or near 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+- **easeInExpo**: fix the expo easing functions never reaching 0 or 1 ([#353](https://github.com/studiometa/js-toolkit/pull/353))
+
 ## [v2.9.1](https://github.com/studiometa/js-toolkit/compare/2.9.0..2.9.1) (2023-02-08)
 
 ### Fixed

--- a/packages/js-toolkit/utils/math/ease.ts
+++ b/packages/js-toolkit/utils/math/ease.ts
@@ -83,7 +83,7 @@ export const easeInOutCirc = createEaseInOut(easeInCirc);
  * @returns {number}          Eased value between 0 and 1.
  */
 export function easeInExpo(progress: number) {
-  return 2 ** (10 * (progress - 1));
+  return progress === 0 ? 0 : 2 ** (10 * (progress - 1));
 }
 
 export const easeOutExpo = createEaseOut(easeInExpo);

--- a/packages/tests/utils/math/__snapshots__/ease.spec.js.snap
+++ b/packages/tests/utils/math/__snapshots__/ease.spec.js.snap
@@ -40,7 +40,7 @@ exports[`ease methods the easeInCubic method should give the correct value 9`] =
 
 exports[`ease methods the easeInCubic method should give the correct value 10`] = `1`;
 
-exports[`ease methods the easeInExpo method should give the correct value 1`] = `0.0009765625`;
+exports[`ease methods the easeInExpo method should give the correct value 1`] = `0`;
 
 exports[`ease methods the easeInExpo method should give the correct value 2`] = `0.002109491677524035`;
 
@@ -338,7 +338,7 @@ exports[`ease methods the easeOutExpo method should give the correct value 8`] =
 
 exports[`ease methods the easeOutExpo method should give the correct value 9`] = `0.9978905083224759`;
 
-exports[`ease methods the easeOutExpo method should give the correct value 10`] = `0.9990234375`;
+exports[`ease methods the easeOutExpo method should give the correct value 10`] = `1`;
 
 exports[`ease methods the easeOutQuad method should give the correct value 1`] = `0`;
 


### PR DESCRIPTION
Fix the `easeInExpo`, `easeInOutExpo` and `easeOutExpo` results when the progress is equal to `0` or `1`.