### PR TITLE
[Release] 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v2.11.0](https://github.com/studiometa/js-toolkit/compare/2.10.3..2.11.0) (2023-07-13)
+
 ### Added
 
 - **usePointer:** add support for props relative to an element ([#377](https://github.com/studiometa/js-toolkit/pull/377))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/js-toolkit-workspace",
-      "version": "2.10.3",
+      "version": "2.11.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## [v2.11.0](https://github.com/studiometa/js-toolkit/compare/2.10.3..2.11.0) (2023-07-13)

### Added

- **usePointer:** add support for props relative to an element ([#377](https://github.com/studiometa/js-toolkit/pull/377))
- Add a `withRelativePointer` decorator ([#377](https://github.com/studiometa/js-toolkit/pull/377))

### Fixed

- Fix refs name normalization when used with prefix ([#361](https://github.com/studiometa/js-toolkit/pull/361))

### Changed

- Update dependencies ([#378](https://github.com/studiometa/js-toolkit/pull/378))