### PR TITLE
[Feature] Remove the `loaded` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. The format 
 - ⚠️ Remove the `withVue2` decorator ([#395](https://github.com/studiometa/js-toolkit/pull/395))
 - ⚠️ Remove the `vue` dependency ([#395](https://github.com/studiometa/js-toolkit/pull/395))
 - ⚠️ Remove CJS files from the package ([#394](https://github.com/studiometa/js-toolkit/pull/394))
+- ⚠️ Remove the `loaded` hook ([#412](https://github.com/studiometa/js-toolkit/pull/412))
 
 ## [v2.12.0](https://github.com/studiometa/js-toolkit/compare/2.11.2..2.12.0) (2023-12-01)
 

--- a/packages/docs/api/instance-events.md
+++ b/packages/docs/api/instance-events.md
@@ -96,24 +96,6 @@ app.$on('keyed', () => {
 });
 ```
 
-### `loaded`
-
-```js
-import { Base } from '@studiometa/js-toolkit';
-
-class App extends Base {
-  static config = {
-    name: 'App',
-  };
-}
-
-const app = new App(document.body);
-
-app.$on('loaded', () => {
-  console.log('App is loaded');
-});
-```
-
 ### `moved`
 
 ```js

--- a/packages/docs/api/instance-properties.md
+++ b/packages/docs/api/instance-properties.md
@@ -57,7 +57,7 @@ The root instance of the application when the current instance has been mounted 
 
 ## `$services`
 
-A [Service](https://github.com/studiometa/js-toolkit/blob/master/src/abstracts/Base/classes/Services.js) instance to manage the [`scrolled`](#scrolled-props), [`resized`](#resized-props), [`ticked`](#ticked-props), [`moved`](#moved-props), [`keyed`](#keyed-props), [`loaded`](#loaded) services hooks.
+A [Service](https://github.com/studiometa/js-toolkit/blob/master/src/abstracts/Base/classes/Services.js) instance to manage the [`scrolled`](#scrolled-props), [`resized`](#resized-props), [`ticked`](#ticked-props), [`moved`](#moved-props), [`keyed`](#keyed-props) services hooks.
 
 The following methods are available:
 

--- a/packages/docs/api/methods-hooks-services.md
+++ b/packages/docs/api/methods-hooks-services.md
@@ -149,29 +149,3 @@ export default class Component extends Base {
 See the [`useRaf` service](/api/services/useRaf.html) for more details.
 :::
 
-## `loaded`
-
-Called when the page is loaded.
-
-**Arguments**
-
-The [raf service](/api/services/useRaf.html#props) does not have any props.
-
-**Example**
-
-```js
-export default class Component extends Base {
-  static config = {
-    name: 'Component',
-    log: true,
-  };
-
-  loaded() {
-    this.$log('Loaded');
-  }
-}
-```
-
-:::tip Tip
-See the [`useLoad` service](/api/services/useLoad.html) for more details.
-:::

--- a/packages/docs/guide/introduction/using-services.md
+++ b/packages/docs/guide/introduction/using-services.md
@@ -31,7 +31,6 @@ The following service hooks and events are available:
 - `ticked` for the `useRaf` service
 - `moved` for the `usePointer` service
 - `keyed` for the `useKey` service
-- `loaded` for the `useLoad` service
 
 The [services hooks diagram](#services-hooks-diagram) below present in greater detail what action will trigger a service method.
 

--- a/packages/docs/guide/migration/v2-to-v3.md
+++ b/packages/docs/guide/migration/v2-to-v3.md
@@ -54,3 +54,27 @@ The `trap` and `untrap` functions are now exported directly as `trapFocus` and `
 + trapFocus(element, event);
 + untrapFocus();
 ```
+
+## The `loaded` hook has been removed
+
+In the previous versions, a `loaded` hook was present on any component extending the `Base` class. It was triggered by the `load` event on the `window`. Due to its ease of implementation and its low usage, it has been removed.
+
+```diff
+  import { Base } from '@studiometa/js-toolkit';}
+
+  class Component extends Base {
+    static config = {
+      name: 'Component',
+    };
+
+-   loaded() {
+-     console.log('page is loaded')
++   mounted() {
++     window.addEventListener('load', () => {
++       console.log('page is loaded');
++     });
+    }
+  }
+```
+
+You can still use the [`useLoad` service](/api/services/useLoad.html) as a replacement if needed, as it handles the possibility of the `load` event having been fired already.

--- a/packages/js-toolkit/Base/managers/ServicesManager.ts
+++ b/packages/js-toolkit/Base/managers/ServicesManager.ts
@@ -1,11 +1,10 @@
-import { usePointer, useRaf, useResize, useScroll, useKey, useLoad } from '../../services/index.js';
+import { usePointer, useRaf, useResize, useScroll, useKey } from '../../services/index.js';
 import type {
   PointerServiceInterface,
   RafServiceInterface,
   ResizeServiceInterface,
   ScrollServiceInterface,
   KeyServiceInterface,
-  LoadServiceInterface,
   ServiceInterface,
 } from '../../services/index.js';
 import { AbstractManager } from './AbstractManager.js';
@@ -17,7 +16,6 @@ const SERVICES_MAP = {
   ticked: useRaf,
   moved: usePointer,
   keyed: useKey,
-  loaded: useLoad,
 };
 
 const SERVICE_NAMES = Object.keys(SERVICES_MAP);
@@ -28,7 +26,6 @@ type Services = {
   ticked: RafServiceInterface;
   moved: PointerServiceInterface;
   keyed: KeyServiceInterface;
-  loaded: LoadServiceInterface;
 } & Record<string, ServiceInterface<unknown>>;
 
 type ServiceNames = keyof Services;

--- a/packages/tests/Base/index.spec.ts
+++ b/packages/tests/Base/index.spec.ts
@@ -335,22 +335,6 @@ describe('A Base instance methods', () => {
     expect(baz.$children.Bar).toEqual([]);
   });
 
-  it('should listen to the window.onload event', () => {
-    const fn = jest.fn();
-    class Bar extends Foo {
-      loaded() {
-        fn();
-      }
-    }
-
-    const bar = new Bar(document.createElement('div')).$mount();
-    window.dispatchEvent(new CustomEvent('load'));
-    expect(fn).toHaveBeenCalledTimes(1);
-    bar.$destroy();
-    window.dispatchEvent(new CustomEvent('load'));
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
   it('should mount and destroy its children', () => {
     class Bar extends Base {
       static config = {


### PR DESCRIPTION
This PR lightens the `Base` class export by removing the default `loaded` hook.