### PR TITLE
[Feature] `scrollTo` enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add support for a `stagger` option for `animate` ([#419](https://github.com/studiometa/js-toolkit/pull/419))
 - Add support for `duration` and `stagger` options as functions for `animate` ([#419](https://github.com/studiometa/js-toolkit/pull/419))
 - Add a `mean` utility function ([#419](https://github.com/studiometa/js-toolkit/pull/419))
+- Add support for custom duration and easing function for `scrollTo` ([#418](https://github.com/studiometa/js-toolkit/pull/418))
 
 ### Fixed
 
@@ -30,6 +31,7 @@ All notable changes to this project will be documented in this file. The format 
 - Improve raf service usage ([#411](https://github.com/studiometa/js-toolkit/pull/411), [352f509](https://github.com/studiometa/js-toolkit/commit/352f509))
 - Migrate legacy `pageXOffset` and `pageYOffset` to their equivalent `scrollX` and `scrollY` ([#413](https://github.com/studiometa/js-toolkit/pull/413))
 - Update dependencies ([#422](https://github.com/studiometa/js-toolkit/pull/422))
+- ⚠️ Change the return value from `scrollTo` from `Promise<number>` to `Promise<{ left: number, top: number }>` ([#418](https://github.com/studiometa/js-toolkit/pull/418))
 
 ### Removed
 

--- a/packages/docs/guide/migration/v2-to-v3.md
+++ b/packages/docs/guide/migration/v2-to-v3.md
@@ -26,16 +26,16 @@ In the previous versions, breakpoints values for the [resize service](/api/servi
 - <div data-breakpoint>…</div>
 ```
 
-```diff
-- export default createApp(App, document.body);
-+ export default createApp(App, {
-+   root: document.body,
-+   screens: {
-+     s: '30rem',
-+     m: '60rem',
-+     l: '90rem',
-+   },
-+ });
+```js
+export default createApp(App, document.body); // [!code --]
+export default createApp(App, { // [!code ++]
+  root: document.body, // [!code ++]
+  screens: { // [!code ++]
+    s: '30rem', // [!code ++]
+    m: '60rem', // [!code ++]
+    l: '90rem', // [!code ++]
+  }, // [!code ++]
+}); // [!code ++]
 ```
 
 ## The `focusTrap` export has been refactored
@@ -44,37 +44,48 @@ In v2 you had to import the `focusTrap` function and then execute it to get the 
 
 The `trap` and `untrap` functions are now exported directly as `trapFocus` and `untrapFocus`.
 
-```diff
-- import { trapFocus } from '@studiometa/js-toolkit/utils';
-+ import { trapFocus, untrapFocus } from '@studiometa/js-toolkit/utils';
+```js
+import { trapFocus } from '@studiometa/js-toolkit/utils'; // [!code --]
+import { trapFocus, untrapFocus } from '@studiometa/js-toolkit/utils'; // [!code ++]
 
-- const { trap, untrap } = trapFocus();
-- trap(element, event);
-- untrap();
-+ trapFocus(element, event);
-+ untrapFocus();
+const { trap, untrap } = trapFocus(); // [!code --]
+trap(element, event); // [!code --]
+untrap(); // [!code --]
+trapFocus(element, event); // [!code ++]
+untrapFocus(); // [!code ++]
 ```
 
 ## The `loaded` hook has been removed
 
 In the previous versions, a `loaded` hook was present on any component extending the `Base` class. It was triggered by the `load` event on the `window`. Due to its ease of implementation and its low usage, it has been removed.
 
-```diff
-  import { Base } from '@studiometa/js-toolkit';}
+```js
+import { Base } from '@studiometa/js-toolkit';}
 
-  class Component extends Base {
-    static config = {
-      name: 'Component',
-    };
+class Component extends Base {
+  static config = {
+    name: 'Component',
+  };
 
--   loaded() {
--     console.log('page is loaded')
-+   mounted() {
-+     window.addEventListener('load', () => {
-+       console.log('page is loaded');
-+     });
-    }
+  loaded() { // [!code --]
+    console.log('page is loaded') // [!code --]
+  mounted() { // [!code ++]
+    window.addEventListener('load', () => { // [!code ++]
+      console.log('page is loaded'); // [!code ++]
+    }); // [!code ++]
   }
+}
 ```
 
 You can still use the [`useLoad` service](/api/services/useLoad.html) as a replacement if needed, as it handles the possibility of the `load` event having been fired already.
+
+## The return value of the `scrollTo` function has changed
+
+Previously, the `scrollTo` function could only be used to scroll vertically. It can now scroll horizontally as well. With this new feature, we had to change the return type of the function from `Promise<number>` to `Promise<{ top: number, left: number }>`.
+
+```js
+import { scrollTo } from '@studiometa/js-toolkit/utils';
+
+const scrollY = await scrollTo('#target'); // [!code --]
+const { left: scrollY } = await scrollTo('#target'); // [!code ++]
+```

--- a/packages/docs/utils/index.md
+++ b/packages/docs/utils/index.md
@@ -2,7 +2,7 @@
 
 Find below functions that can help you in your projects.
 
-## Misc.
+## Misc
 
 - [debounce](./debounce.html)
 - [trapFocus](./trapFocus.html)

--- a/packages/docs/utils/scrollTo.md
+++ b/packages/docs/utils/scrollTo.md
@@ -28,6 +28,14 @@ type BezierCurve = [number, number, number, number];
 
 interface ScrollToOptions {
   /**
+   * Root element that will be scrolled.
+   */
+  rootElement?: HTMLElement;
+  /**
+   * Scroll direction.
+   */
+  axis?: 'X' | 'Y' | 'BOTH';
+  /**
    * Distance from the target.
    */
   offset?: number;

--- a/packages/docs/utils/scrollTo.md
+++ b/packages/docs/utils/scrollTo.md
@@ -69,5 +69,8 @@ interface ScrollToOptions {
   onFinish?: (progress: number) => void;
 }
 
-function scrollTo(selectorElement: HTMLElement | string, options?: ScrollToOptions): Promise<number>;
+function scrollTo(
+  selectorElement: HTMLElement | string,
+  options?: ScrollToOptions,
+): Promise<number>;
 ```

--- a/packages/docs/utils/scrollTo.md
+++ b/packages/docs/utils/scrollTo.md
@@ -9,22 +9,29 @@ import { scrollTo } from '@studiometa/js-toolkit/utils';
 
 await scrollTo('#target');
 await scrollTo(document.querySelector('#target'));
+await scrollTo(800);
+await scrollTo({ left: 200 });
 ```
 
 ### Parameters
 
-- `selectorElement` (`string|HTMLElement`): the target of the scroll
+- `selectorOrElementOrValueOrValues` (`string|HTMLElement|number|ScrollPosition`): the target of the scroll
 - `options` (`ScrollToOptions`): options for the scroll (offset + [tween options](./tween.html))
 
 ### Return value
 
-This function returns a `Promise` resolving to the target scroll position, even when stopped by use interaction.
+This function returns a `Promise` resolving to the scroll position, even when stopped by use interaction.
 
 ### Types
 
 ```ts
 type EasingFunction = (value: number) => number;
 type BezierCurve = [number, number, number, number];
+
+interface ScrollPosition {
+  left?: number;
+  top?: number;
+}
 
 interface ScrollToOptions {
   /**

--- a/packages/docs/utils/scrollTo.md
+++ b/packages/docs/utils/scrollTo.md
@@ -1,21 +1,40 @@
 # scrollTo
 
-Scroll vertically using [tween](./tween.html) to a given target, be it a selector or an element, without blocking user interaction.
+Scroll to a given target without blocking user interaction. The target can be a selector, an element, a number or a scroll position object.
+
+If the target is a selector or an element, the `scroll-margin` CSS values will be respected when calculating the final scroll position.
+
+The `scrollTo` function uses the [tween](./tween.html) function under the hood, inheriting from its options.
 
 ## Usage
 
 ```js
-import { scrollTo } from '@studiometa/js-toolkit/utils';
+import { scrollTo, easeOutExpo } from '@studiometa/js-toolkit/utils';
 
 await scrollTo('#target');
 await scrollTo(document.querySelector('#target'));
 await scrollTo(800);
-await scrollTo({ left: 200 });
+await scrollTo({ top: 300, left: 200 });
+
+// Custom axis
+await scrollTo(800, { axis: scrollTo.axis.y }); // default
+await scrollTo(800, { axis: scrollTo.axis.x });
+await scrollTo(800, { axis: scrollTo.axis.both });
+
+// With offset
+await scrollTo('#target', { offset: 100 }); // stop at 100px from the target
+
+// With a different scrolling element
+await scrollTo(800, { rootElement: document.body });
+
+// With custom easing and duration
+await scrollTo(800, { duration: 2, easing: easeOutExpo });
+await scrollTo(800, { smooth: 0.5 }); // custom smooth factor
 ```
 
 ### Parameters
 
-- `selectorOrElementOrValueOrValues` (`string|HTMLElement|number|ScrollPosition`): the target of the scroll
+- `target` (`string | HTMLElement | number | ScrollPosition`): the target of the scroll
 - `options` (`ScrollToOptions`): options for the scroll (offset + [tween options](./tween.html))
 
 ### Return value
@@ -25,67 +44,30 @@ This function returns a `Promise` resolving to the scroll position, even when st
 ### Types
 
 ```ts
-type EasingFunction = (value: number) => number;
-type BezierCurve = [number, number, number, number];
-
 interface ScrollPosition {
-  left?: number;
-  top?: number;
+  left: number;
+  top: number;
 }
 
-interface ScrollToOptions {
+type ScrollTarget = string | HTMLElement | number | Partial<ScrollPosition>;
+
+interface ScrollToOptions extends TweenOptions {
   /**
    * Root element that will be scrolled.
    */
-  rootElement?: HTMLElement;
+  rootElement?: HTMLElement | typeof window;
   /**
-   * Scroll direction.
+   * Scroll direction, available values are:
+   * - scrollTo.axis.x (enabled if target is an object with a `left` key)
+   * - scrollTo.axis.y (default)
+   * - scrollTo.axis.both
    */
-  axis?: 'X' | 'Y' | 'BOTH';
+  axis?: (typeof scrollTo.axis)[keyof typeof scrollTo.axis];
   /**
    * Distance from the target.
    */
   offset?: number;
-  /**
-   * The duration, in seconds.
-   * Defaults to `1`.
-   */
-  duration?: number;
-  /**
-   * The delay, in seconds.
-   * Defaults to `0`.
-   */
-  delay?: number;
-  /**
-   * The easing function or bezier curve to use.
-   * Defaults to a linear easing function.
-   */
-  easing?: EasingFunction | BezierCurve;
-  /**
-   * The smooth factor. Setting this option to `true` or a `number` will disable the `duration` option.
-   */
-  smooth?: true | number;
-  /**
-   * The precision for when to consider the tween finished.
-   * Defaults to `0.0001`.
-   */
-  precision?: number;
-  /**
-   * A callback executed on start.
-   */
-  onStart?: (progress: number) => void;
-  /**
-   * A callback executed each time the progress is updated.
-   */
-  onProgress?: (progress: number) => void;
-  /**
-   * A callback executed when the tween is finished.
-   */
-  onFinish?: (progress: number) => void;
 }
 
-function scrollTo(
-  selectorElement: HTMLElement | string,
-  options?: ScrollToOptions,
-): Promise<number>;
+function scrollTo(target: ScrollTarget, options?: ScrollToOptions): Promise<ScrollPosition>;
 ```

--- a/packages/docs/utils/scrollTo.md
+++ b/packages/docs/utils/scrollTo.md
@@ -1,6 +1,6 @@
 # scrollTo
 
-Scroll vertically to a given target, be it a selector or an element, without blocking user interaction.
+Scroll vertically using [tween](./tween.html) to a given target, be it a selector or an element, without blocking user interaction.
 
 ## Usage
 
@@ -14,8 +14,60 @@ await scrollTo(document.querySelector('#target'));
 ### Parameters
 
 - `selectorElement` (`string|HTMLElement`): the target of the scroll
-- `options` (`{ offset?: number, dampFactor?: number }`): options for the scroll
+- `options` (`ScrollToOptions`): options for the scroll (offset + [tween options](./tween.html))
 
 ### Return value
 
 This function returns a `Promise` resolving to the target scroll position, even when stopped by use interaction.
+
+### Types
+
+```ts
+type EasingFunction = (value: number) => number;
+type BezierCurve = [number, number, number, number];
+
+interface ScrollToOptions {
+  /**
+   * Distance from the target.
+   */
+  offset?: number;
+  /**
+   * The duration, in seconds.
+   * Defaults to `1`.
+   */
+  duration?: number;
+  /**
+   * The delay, in seconds.
+   * Defaults to `0`.
+   */
+  delay?: number;
+  /**
+   * The easing function or bezier curve to use.
+   * Defaults to a linear easing function.
+   */
+  easing?: EasingFunction | BezierCurve;
+  /**
+   * The smooth factor. Setting this option to `true` or a `number` will disable the `duration` option.
+   */
+  smooth?: true | number;
+  /**
+   * The precision for when to consider the tween finished.
+   * Defaults to `0.0001`.
+   */
+  precision?: number;
+  /**
+   * A callback executed on start.
+   */
+  onStart?: (progress: number) => void;
+  /**
+   * A callback executed each time the progress is updated.
+   */
+  onProgress?: (progress: number) => void;
+  /**
+   * A callback executed when the tween is finished.
+   */
+  onFinish?: (progress: number) => void;
+}
+
+function scrollTo(selectorElement: HTMLElement | string, options?: ScrollToOptions): Promise<number>;
+```

--- a/packages/js-toolkit/utils/index.ts
+++ b/packages/js-toolkit/utils/index.ts
@@ -6,7 +6,7 @@ export { nextFrame } from './nextFrame.js';
 export { nextTick } from './nextTick.js';
 export { nextMicrotask } from './nextMicrotask.js';
 export { default as throttle } from './throttle.js';
-export { default as scrollTo } from './scrollTo.js';
+export { scrollTo } from './scrollTo.js';
 export { default as getComponentResolver } from './getComponentResolver.js';
 export * from './is.js';
 export * from './has.js';

--- a/packages/js-toolkit/utils/scrollTo.ts
+++ b/packages/js-toolkit/utils/scrollTo.ts
@@ -1,5 +1,6 @@
-import { TweenOptions, tween } from './tween.js';
-import { isString, isNumber, isObject, isFunction } from './is.js';
+import { tween } from './tween.js';
+import type { TweenOptions } from './tween.js';
+import { isString, isNumber, isFunction } from './is.js';
 import { lerp } from './math/index.js';
 
 export type ScrollPosition = {

--- a/packages/js-toolkit/utils/scrollTo.ts
+++ b/packages/js-toolkit/utils/scrollTo.ts
@@ -1,16 +1,16 @@
 import { tween } from './tween.js';
 import type { TweenOptions } from './tween.js';
-import { isString, isNumber, isFunction } from './is.js';
+import { isString, isNumber, isFunction, isDefined } from './is.js';
 import { lerp } from './math/index.js';
 
-export type ScrollPosition = {
+export interface ScrollPosition {
   left: number;
   top: number;
-};
+}
 
 export type ScrollTarget = string | HTMLElement | number | Partial<ScrollPosition>;
 
-export type ScrollToOptions = TweenOptions & {
+export interface ScrollToOptions extends TweenOptions {
   /**
    * Root element that will be scrolled.
    */
@@ -23,7 +23,7 @@ export type ScrollToOptions = TweenOptions & {
    * Distance from the target.
    */
   offset?: number;
-};
+}
 
 const xAxis = Symbol(0);
 const yAxis = Symbol(1);
@@ -98,7 +98,7 @@ function getTargetScrollPosition(
   top -= offset;
 
   if (axis !== bothAxis) {
-    if (axis !== xAxis) {
+    if (axis !== xAxis && !isDefined((target as Partial<ScrollPosition>).left)) {
       left = initialScrollPosition.left;
     }
 
@@ -134,10 +134,10 @@ export function scrollTo(
 
   return new Promise((resolve) => {
     function eventHandler() {
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      /* eslint-disable @typescript-eslint/no-use-before-define */
       tw.pause();
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       stop();
+      /* eslint-enable @typescript-eslint/no-use-before-define */
     }
 
     function stop() {
@@ -157,6 +157,7 @@ export function scrollTo(
         });
       },
       {
+        smooth: 0.2,
         ...tweenOptions,
         onFinish(progress) {
           if (isFunction(tweenOptions.onFinish)) {

--- a/packages/js-toolkit/utils/scrollTo.ts
+++ b/packages/js-toolkit/utils/scrollTo.ts
@@ -2,7 +2,19 @@ import { TweenOptions, tween } from './tween.js';
 import { isFunction } from './is.js';
 import { lerp } from './math/index.js';
 
-export type ScrollToOptions = TweenOptions & {
+// Rename ScrollToOptions type to ScrollPosition to be more understandable.
+type ScrollPosition = ScrollToOptions;
+
+// Set the type of TweenScrollToOptions options.
+export type TweenScrollToOptions = TweenOptions & {
+  /**
+   * Root element that will be scrolled.
+   */
+  rootElement?: HTMLElement;
+  /**
+   * Scroll direction.
+   */
+  axis?: 'X' | 'Y' | 'BOTH';
   /**
    * Distance from the target.
    */
@@ -10,71 +22,150 @@ export type ScrollToOptions = TweenOptions & {
 };
 
 /**
- * Handler for the click event on anchor links
+ * Scroll to an element.
  *
- * @returns {Promise<number>} A promising resolving with the target scroll position.
+ * @returns {Promise<ScrollPosition>} A promising resolving with the scroll position.
  */
 export default function scrollTo(
   selectorElement: HTMLElement | string,
-  { offset = 0, ...tweenOptions }: ScrollToOptions = {},
-): Promise<number> {
-  let targetElement = null;
-  const scroll = window.scrollY;
+  { rootElement = null, axis = 'Y', offset = 0, ...tweenOptions }: TweenScrollToOptions = {},
+): Promise<ScrollPosition> {
+  /**
+   * Get the current root element or window scroll position.
+   *
+   * @returns {ScrollPosition}
+   */
+  function getCurrentScrollPosition(): ScrollPosition {
+    return rootElement
+      ? {
+          left: rootElement.scrollTop,
+          top: rootElement.scrollLeft,
+        }
+      : {
+          left: window.scrollX,
+          top: window.scrollY,
+        };
+  }
 
+  // Save the current scroll position.
+  const initialScrollPosition = getCurrentScrollPosition();
+
+  // Init the target element.
+  let targetElement = null;
+
+  // Check if the given element is a selector or already a HTMLElement.
   if (selectorElement instanceof HTMLElement) {
     targetElement = selectorElement;
   } else {
     targetElement = document.querySelector(selectorElement);
   }
 
+  // Resolve the promise if there is no target element.
   if (!targetElement) {
-    return Promise.resolve(scroll);
+    return Promise.resolve(initialScrollPosition);
   }
 
+  // Get the size of the target element.
   const sizes = targetElement.getBoundingClientRect();
-  const scrollMargin = getComputedStyle(targetElement).scrollMarginTop || '0';
-  const max = document.documentElement.scrollHeight - window.innerHeight;
-  let scrollTarget = sizes.top + scroll - Number.parseInt(scrollMargin, 10) - offset;
 
-  // Make sure to not scroll more than the max scroll allowed
-  if (scrollTarget > max) {
-    scrollTarget = max;
-  }
+  // Get the scroll margins of the target element.
+  const targetElementComputedStyle = getComputedStyle(targetElement);
+  const scrollMargin = {
+    left: Number.parseInt(targetElementComputedStyle.scrollMarginLeft || '0', 10),
+    top: Number.parseInt(targetElementComputedStyle.scrollMarginTop || '0', 10),
+  };
 
+  // Get the maximum scroll of the root element or of the window.
+  const max = rootElement
+    ? {
+        left: rootElement.scrollWidth - rootElement.offsetWidth,
+        top: rootElement.scrollHeight - rootElement.offsetHeight,
+      }
+    : {
+        left: document.documentElement.scrollWidth - window.innerWidth,
+        top: document.documentElement.scrollHeight - window.innerHeight,
+      };
+
+  // Get the scroll position (or maximum scroll) of the target element.
+  const targetElementScrollPosition = {
+    left: Math.min(sizes.left + initialScrollPosition.left - scrollMargin.left - offset, max.left),
+    top: Math.min(sizes.top + initialScrollPosition.top - scrollMargin.top - offset, max.top),
+  };
+
+  // Create the final promise.
   return new Promise((resolve) => {
+    // Init tween.
     let tw = null;
 
+    // Set the event handler.
     const eventHandler = () => {
+      // Pause the tween animation.
       tw.pause();
 
-      window.removeEventListener('wheel', eventHandler);
-      window.removeEventListener('touchmove', eventHandler);
+      // Remove the event listeners.
+      if (rootElement) {
+        rootElement.removeEventListener('wheel', eventHandler);
+        rootElement.removeEventListener('touchmove', eventHandler);
+      } else {
+        window.removeEventListener('wheel', eventHandler);
+        window.removeEventListener('touchmove', eventHandler);
+      }
 
-      resolve(window.scrollY);
+      // Resolve the promise if the user interact with wheel or touchmove.
+      resolve(getCurrentScrollPosition());
     };
 
+    // Setup tween.
     tw = tween(
       (progress) => {
-        window.scrollTo(0, lerp(scroll, scrollTarget, progress));
+        // Scroll to the progress scroll position.
+        (rootElement ?? window).scrollTo({
+          left:
+            axis === 'X' || axis === 'BOTH'
+              ? lerp(initialScrollPosition.left, targetElementScrollPosition.left, progress)
+              : initialScrollPosition.left,
+          top:
+            axis === 'Y' || axis === 'BOTH'
+              ? lerp(initialScrollPosition.top, targetElementScrollPosition.top, progress)
+              : initialScrollPosition.top,
+        });
       },
       {
+        // Use tween options.
         ...tweenOptions,
-        onFinish(progress) {
-          window.removeEventListener('wheel', eventHandler);
-          window.removeEventListener('touchmove', eventHandler);
 
+        // Set finish actions.
+        onFinish(progress) {
+          // Remove the event listeners.
+          if (rootElement) {
+            rootElement.removeEventListener('wheel', eventHandler);
+            rootElement.removeEventListener('touchmove', eventHandler);
+          } else {
+            window.removeEventListener('wheel', eventHandler);
+            window.removeEventListener('touchmove', eventHandler);
+          }
+
+          // Run onFinish function passed in options.
           if (isFunction(tweenOptions.onFinish)) {
             tweenOptions.onFinish(progress);
           }
 
-          resolve(window.scrollY);
+          // Resolve the promise on animation finish.
+          resolve(getCurrentScrollPosition());
         },
       },
     );
 
-    window.addEventListener('wheel', eventHandler, { passive: true });
-    window.addEventListener('touchmove', eventHandler, { passive: true });
+    // Set the event listeners to catch user interaction
+    if (rootElement) {
+      rootElement.addEventListener('wheel', eventHandler, { passive: true });
+      rootElement.addEventListener('touchmove', eventHandler, { passive: true });
+    } else {
+      window.addEventListener('wheel', eventHandler, { passive: true });
+      window.addEventListener('touchmove', eventHandler, { passive: true });
+    }
 
+    // Start the tween animation.
     tw.start();
   });
 }

--- a/packages/js-toolkit/utils/scrollTo.ts
+++ b/packages/js-toolkit/utils/scrollTo.ts
@@ -142,11 +142,20 @@ export default function scrollTo(
     // Init tween.
     let tw = null;
 
+    // Init stop function.
+    let stop = () => {};
+
     // Set the event handler.
     const eventHandler = () => {
       // Pause the tween animation.
       tw.pause();
 
+      // Run stop function.
+      stop();
+    };
+
+    // Set stop function.
+    stop = () => {
       // Remove the event listeners.
       if (rootElement) {
         rootElement.removeEventListener('wheel', eventHandler);
@@ -156,7 +165,7 @@ export default function scrollTo(
         window.removeEventListener('touchmove', eventHandler);
       }
 
-      // Resolve the promise if the user interact with wheel or touchmove.
+      // Resolve the promise on animation finish.
       resolve(getCurrentScrollPosition());
     };
 
@@ -181,22 +190,13 @@ export default function scrollTo(
 
         // Set finish actions.
         onFinish(progress) {
-          // Remove the event listeners.
-          if (rootElement) {
-            rootElement.removeEventListener('wheel', eventHandler);
-            rootElement.removeEventListener('touchmove', eventHandler);
-          } else {
-            window.removeEventListener('wheel', eventHandler);
-            window.removeEventListener('touchmove', eventHandler);
-          }
-
           // Run onFinish function passed in options.
           if (isFunction(tweenOptions.onFinish)) {
             tweenOptions.onFinish(progress);
           }
 
-          // Resolve the promise on animation finish.
-          resolve(getCurrentScrollPosition());
+          // Run stop function.
+          stop();
         },
       },
     );

--- a/packages/tests/__utils__/happydom.ts
+++ b/packages/tests/__utils__/happydom.ts
@@ -5,6 +5,7 @@ GlobalRegistrator.register();
 window.__DEV__ = true;
 
 let y = 0;
+let x = 0;
 
 Object.defineProperties(window, {
   scrollY: {
@@ -13,6 +14,14 @@ Object.defineProperties(window, {
     },
     set: (value) => {
       y = Number(value);
+    },
+  },
+  scrollX: {
+    get: () => {
+      return x;
+    },
+    set: (value) => {
+      x = Number(value);
     },
   },
   requestAnimationFrame: {

--- a/packages/tests/__utils__/scroll.ts
+++ b/packages/tests/__utils__/scroll.ts
@@ -1,18 +1,25 @@
 import { mock } from 'bun:test';
 
 let scrollHeight: number;
+let scrollWidth: number;
 
 export function mockScroll({ height = 0, width = 0 } = {}) {
   scrollHeight = document.documentElement.scrollHeight;
+  scrollWidth = document.documentElement.scrollWidth;
   const scrollHeightSpy = mock(() => height);
+  const scrollWidthSpy = mock(() => width);
   Object.defineProperties(document.documentElement, {
     scrollHeight: {
       configurable: true,
       get: () => scrollHeightSpy(),
     },
+    scrollWidth: {
+      configurable: true,
+      get: () => scrollWidthSpy(),
+    },
   });
 
-  return { scrollHeightSpy };
+  return { scrollHeightSpy, scrollWidthSpy };
 }
 
 export function restoreScroll() {
@@ -20,6 +27,10 @@ export function restoreScroll() {
     scrollHeight: {
       configurable: true,
       value: scrollHeight,
+    },
+    scrollWidth: {
+      configurable: true,
+      value: scrollWidth,
     },
   });
 }

--- a/packages/tests/utils/scrollTo.spec.ts
+++ b/packages/tests/utils/scrollTo.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, spyOn, afterEach, beforeEach } from 'bun:te
 import { scrollTo } from '@studiometa/js-toolkit/utils';
 import { mockScroll, restoreScroll } from '../__utils__/scroll.js';
 import { useFakeTimers, useRealTimers, advanceTimersByTimeAsync } from '../__utils__/faketimers.js';
+import { h } from '../__utils__/h.js';
 
 describe('The `scrollTo` function', () => {
   let fn;
@@ -131,5 +132,21 @@ describe('The `scrollTo` function', () => {
     scrollTo(0);
     await advanceTimersByTimeAsync(2000);
     expect(window.scrollY).toBe(0);
+  });
+
+  it('should scroll on the given rootElement', async () => {
+    const div = h('div');
+    mockScroll({ height: 5000, width: 5000, element: div, left: 200 });
+    expect(div.scrollHeight).toBe(5000);
+    scrollTo(1000, { rootElement: div });
+    await advanceTimersByTimeAsync(2000);
+    expect(div.scrollTop).toBe(1000);
+    scrollTo(1000, { rootElement: div, axis: scrollTo.axis.x });
+    await advanceTimersByTimeAsync(2000);
+    expect(div.scrollLeft).toBe(1000);
+    scrollTo(2000, { rootElement: div, axis: scrollTo.axis.both });
+    await advanceTimersByTimeAsync(2000);
+    expect(div.scrollTop).toBe(2000);
+    expect(div.scrollLeft).toBe(2000);
   });
 });

--- a/packages/tests/utils/scrollTo.spec.ts
+++ b/packages/tests/utils/scrollTo.spec.ts
@@ -44,6 +44,18 @@ describe('The `scrollTo` function', () => {
     expect(fn).toHaveBeenLastCalledWith({ left: 0, top: 5000 });
   });
 
+  it('should scroll to a numeric value', async () => {
+    expect(fn).not.toHaveBeenCalled();
+    await scrollTo(800);
+    expect(fn).toHaveBeenLastCalledWith({ left: 0, top: 800 });
+  });
+
+  it('should scroll to a specific top numeric value', async () => {
+    expect(fn).not.toHaveBeenCalled();
+    await scrollTo({ top: 1600 });
+    expect(fn).toHaveBeenLastCalledWith({ left: 0, top: 1600 });
+  });
+
   it('should not scroll to an inexistant element', async () => {
     expect(fn).not.toHaveBeenCalled();
     const scrollY = await scrollTo('span');

--- a/packages/tests/utils/scrollTo.spec.ts
+++ b/packages/tests/utils/scrollTo.spec.ts
@@ -67,6 +67,13 @@ describe('The `scrollTo` function', () => {
     expect(fn).toHaveBeenLastCalledWith({ left: 0, top: 1600 });
   });
 
+  it('should scroll to a specific left numeric value', async () => {
+    expect(fn).not.toHaveBeenCalled();
+    scrollTo({ left: 1600 });
+    await advanceTimersByTimeAsync(2000);
+    expect(fn).toHaveBeenLastCalledWith({ left: 1600, top: 0 });
+  });
+
   it('should scroll to a left and top numeric value', async () => {
     expect(fn).not.toHaveBeenCalled();
     scrollTo({ left: 1600, top: 1600 }, { axis: scrollTo.axis.both });


### PR DESCRIPTION
- [x] Directly use tween in the initial scrollTo function after the merge of the Tween refactor #419
- [x] Fix #173
- [x] Fix #261 