### PR TITLE
[Feature] Add support for defining an option default value with a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- Add support for defining an option default value with a function ([#478](https://github.com/studiometa/js-toolkit/pull/478))
+- Add shorthand props on the scroll service for easier destructuring ([#432](https://github.com/studiometa/js-toolkit/pull/432))
+
 ### Fixed
 
 - Fix code coverage reports ([#474](https://github.com/studiometa/js-toolkit/pull/474))
-
-### Added
-
-- Add shorthand props on the scroll service for easier destructuring ([#432](https://github.com/studiometa/js-toolkit/pull/432))
 
 ## [v3.0.0-alpha.3](https://github.com/studiometa/js-toolkit/compare/3.0.0-alpha.2..3.0.0-alpha.3) (2023-04-17)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ And its accompanying HTML would be sprinkled with `data-…` attributes to bind 
 <div data-component="Counter">
   <button data-ref="add">Add</button>
   <button data-ref="remove">Remove</button>
-  <input data-ref="count" type="number" value="0">
+  <input data-ref="count" type="number" value="0" />
 </div>
 ```
 
@@ -128,7 +128,6 @@ export default createApp(App);
 ```
 
 Visit our ["Getting Started" guide](https://js-toolkit.studiometa.dev/guide/) to learn more and try the above component by visiting [the playground](https://ui.studiometa.dev/-/play/#script=eNqVkjFPwzAQhff%2BijcguRVtEGurSpTuDKyIwdiXYprYkX2pQFX%2BO7bjlg6A1EiJndO97873bNrOecYRjzLQHMqTZNp0HQbU3rUQD4F7bVxLLO8%2BwoKda%2FaGxWoyUY0MAVvXWyYP%2BmSyOmQOjhMgsGSjoJytzQ7rHAOsbGkJUVRinoOe6rDEi5BaizmEp9YdKO1UShOvY5br2DgbE0dSqkDdzx%2FAX11kP%2FXtG%2FlRkh5NtewbXuL%2BFBvGzRC%2FQzwHsCOOfeaOprMC9MS9t%2BB3E6qb1GCVM6qDbHrahLHKKiESIVwQcsYJ87s%2BjiOvZ72zG623jVH7cwNZWZi4XRdSGUKVzn6hfs4j%2Bwew%2BBsQEaOVyfbrbIyKYqFy8SJZsnzhTzG5TDstcdyp2umSTeM7W30DtazCdQ%3D%3D&html=eNptjkEKwyAQRfc9hcw%2BpHStQukNegOTmYJQZ8SOQm9fUzcJZPX5vLd4FmMzGDRMq6QsTKwOHlJZqcAAkjUKTx%2Bl7OAG%2FmKMXaqq8OCFXg4CIvg7op0HOrcKJWkE%2Fvnfgxs5V92p69YARr%2BZHHBNy9bTwrv2e%2B0Rdu7l%2Fgd%2BLEBJ&style=eNpLyk%2BpVKjmUlAoSExJycxLt1IwLErNteaqBQBpsgf8).
-
 
 ## Contributing
 

--- a/packages/docs/api/configuration.md
+++ b/packages/docs/api/configuration.md
@@ -30,13 +30,25 @@ class Component extends Base {
     options: {
       stringOption: String, // default to ''
       stringWithDefault: { type: String, default: 'Default value' },
+      stringWithDefaultAsAFunction: {
+        type: String,
+        default: (component) => component.$el.id,
+      },
       numberOption: Number, // default to 0
       numberWithDefault: { type: Number, default: 10 },
+      numberWithDefaultAsAFunction: {
+        type: Number,
+        default: (component) => component.$el.childElementCount,
+      },
       booleanOption: Boolean, // default to false
       // default to true, can be negated with the `data-option-no-boolean-with-default` attribute
       booleanWithDefault: {
         type: Boolean,
         default: true,
+      },
+      booleanWithDefaultAsAFunction: {
+        type: Boolean,
+        default: (component) => component.$el.classList.has('bool'),
       },
       arrayOption: Array, // default to []
       arrayWithDefault: { type: Array, default: () => [1, 2] },

--- a/packages/docs/guide/introduction/managing-options.md
+++ b/packages/docs/guide/introduction/managing-options.md
@@ -72,6 +72,33 @@ class VideoPlayer extends Base {
 }
 ```
 
+You can also use a callback function for the default value, it will be called with the current instance as only parameter:
+
+```js {9-18}
+import { Base } from '@studiometa/js-toolkit';
+
+class Player extends Base {
+  static config = {
+    name: 'Player',
+    options: {
+      type: {
+        type: String,
+        default(player) {
+          switch (player.$el.constructor) {
+            case HTMLVideoElement:
+              return 'video';
+            case HTMLAudioElement:
+              return 'audio';
+            default:
+              return 'unknown';
+          }
+        },
+      },
+    },
+  };
+}
+```
+
 ### Merging options
 
 When working with `Array` or `Object` as option type, it can be useful to merge the values from the `data-option-...` attribute with the default ones. You can use the `merge` property to enable merge with [`deepmerge`](https://github.com/TehShrike/deepmerge):

--- a/packages/tests/Base/managers/OptionsManager.spec.ts
+++ b/packages/tests/Base/managers/OptionsManager.spec.ts
@@ -27,7 +27,7 @@ describe('The Options class', () => {
         foo: Map,
       });
     }).toThrow(
-      'The "foo" option has an invalid type. The allowed types are: String, Number, Boolean, Array and Object.'
+      'The "foo" option has an invalid type. The allowed types are: String, Number, Boolean, Array and Object.',
     );
   });
 
@@ -84,12 +84,9 @@ describe('The Options class', () => {
   });
 
   it('should get and set boolean options', () => {
-    const instance = componentWithOptions(
-      '<div data-option-foo></div>',
-      {
-        foo: Boolean,
-      },
-    );
+    const instance = componentWithOptions('<div data-option-foo></div>', {
+      foo: Boolean,
+    });
 
     expect(instance.$options.foo).toBe(true);
     instance.$options.foo = false;
@@ -154,7 +151,7 @@ describe('The Options class', () => {
           default: () => [1, 2],
           merge: true,
         },
-      }
+      },
     );
 
     expect(instance.$options.foo).toEqual({ foo: 'foo', key: 'key' });
@@ -169,9 +166,13 @@ describe('The Options class', () => {
       array: Array,
       object: Object,
       stringWithDefault: { type: String, default: 'foo' },
+      stringWithDefaultFn: { type: String, default: (i) => i.$id },
       numberWithDefault: { type: Number, default: 10 },
+      numberWithDefaultFn: { type: Number, default: () => 10 },
       booleanWithDefault: { type: Boolean, default: true },
+      booleanWithDefaultFn: { type: Boolean, default: (i) => i.$isMounted },
       arrayWithDefault: { type: Array, default: () => [1, 2, 3] },
+      arrayWithDefaultFn: { type: Array, default: (i) => i.$options.arrayWithDefault },
       objectWithDefault: { type: Object, default: () => ({ foo: 'foo' }) },
     });
 
@@ -183,10 +184,14 @@ describe('The Options class', () => {
     expect(instance.$options.object).toEqual({});
 
     expect(instance.$options.stringWithDefault).toBe('foo');
+    expect(instance.$options.stringWithDefaultFn).toBe(instance.$id);
     expect(instance.$options.numberWithDefault).toBe(10);
+    expect(instance.$options.numberWithDefaultFn).toBe(10);
     expect(instance.$options.booleanWithDefault).toBe(true);
+    expect(instance.$options.booleanWithDefaultFn).toBe(instance.$isMounted);
     expect(instance.$el.hasAttribute('data-option-boolean-with-default')).toBe(false);
     expect(instance.$options.arrayWithDefault).toEqual([1, 2, 3]);
+    expect(instance.$options.arrayWithDefaultFn).toEqual(instance.$options.arrayWithDefault);
     expect(instance.$options.objectWithDefault).toEqual({ foo: 'foo' });
   });
 
@@ -194,7 +199,7 @@ describe('The Options class', () => {
     expect(() =>
       componentWithOptions('<div></div>', {
         array: { type: Array, default: [1, 2, 3] },
-      })
+      }),
     ).toThrow('The default value for options of type "Array" must be returned by a function.');
   });
 });


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality, like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for defining an option default value with a function for all types of options. The function is called with the current instance as only parameter, allowing for advanced management of default values. 

```js {9-18}
import { Base } from '@studiometa/js-toolkit';

class Player extends Base {
  static config = {
    name: 'Player',
    options: {
      type: {
        type: String,
        default(player) {
          switch (player.$el.constructor) {
            case HTMLVideoElement:
              return 'video';
            case HTMLAudioElement:
              return 'audio';
            default:
              return 'unknown';
          }
        },
      },
    },
  };
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
