### PR TITLE
[Feature] Improve the `getInstances` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changed
+
+- Change behaviour of the `getInstances` helper ([#484](https://github.com/studiometa/js-toolkit/pull/484))
+
 ## [v3.0.0-alpha.4](https://github.com/studiometa/js-toolkit/compare/3.0.0-alpha.3..3.0.0-alpha.4) (2023-07-05)
 
 ### Added

--- a/packages/docs/api/helpers/getInstances.md
+++ b/packages/docs/api/helpers/getInstances.md
@@ -1,20 +1,23 @@
 # getInstances
 
-Use the `getInstances` function to retrieve all instances of a given component.
+Use the `getInstances` function to retrieve all mounted instances of every components. You can get instances for a specific component by providing its constructor as first parameter of the function.
 
 ## Usage
 
 ```js
 import { Base, getInstances } from '@studiometa/js-toolkit';
-import Child from './Child.js';
+import Component from './Component.js';
 
-const children = getInstances(Child);
-console.log(children.size); // number
+// Get all mounted instances of all components
+const instances = getInstances(); // Set<Base>
+
+// Get all mounted instances of the `Component` component
+getInstances(Component); // Set<Component>
 ```
 
 **Parameters**
 
-- `ctor` (`typeof Base`): the class from which the instances should be retrieved
+- `ctor` (`undefined | typeof Base`): the class from which the instances should be retrieved
 
 **Return value**
 

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -1,5 +1,11 @@
 /* eslint-disable no-use-before-define */
-import { getComponentElements, getEventTarget, addToQueue, registerInstance } from './utils.js';
+import {
+  getComponentElements,
+  getEventTarget,
+  addToQueue,
+  addInstance,
+  deleteInstance,
+} from './utils.js';
 import {
   ChildrenManager,
   RefsManager,
@@ -275,8 +281,6 @@ export class Base<T extends BaseProps = BaseProps> extends EventTarget {
       return;
     }
 
-    registerInstance(this);
-
     this.$id = `${__config.name}-${id}`;
     id += 1;
 
@@ -291,6 +295,13 @@ export class Base<T extends BaseProps = BaseProps> extends EventTarget {
     for (const service of ['Options', 'Services', 'Events', 'Refs', 'Children']) {
       this[`__${service.toLowerCase()}`] = new this.__managers[`${service}Manager`](this);
     }
+
+    this.$on('mounted', () => {
+      addInstance(this);
+    });
+    this.$on('destroyed', () => {
+      deleteInstance(this);
+    });
 
     if (isDev) {
       this.__debug('constructor', this);

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -123,6 +123,9 @@ export function getEventTarget(
 
 const instances = new Set<Base>();
 
+/**
+ * Get all mounted instances or the ones from a given component.
+ */
 export function getInstances(): Set<Base>;
 export function getInstances<T extends BaseConstructor = BaseConstructor>(ctor: T): Set<InstanceType<T>>;
 export function getInstances<T extends BaseConstructor = BaseConstructor>(ctor?: T): Set<InstanceType<T>> | Set<Base> {

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -1,5 +1,5 @@
 import { isArray, isDefined, isDev, SmartQueue } from '../utils/index.js';
-import type { Base, BaseConfig } from './index.js';
+import type { Base, BaseConfig, BaseConstructor } from './index.js';
 import { features } from './features.js';
 
 let queue: SmartQueue;
@@ -121,16 +121,28 @@ export function getEventTarget(
   return instance;
 }
 
-const instances = new Map<typeof Base, Set<Base>>();
+const instances = new Set<Base>();
 
-export function getInstances<T extends typeof Base = typeof Base>(ctor: T): Set<InstanceType<T>> {
-  if (!instances.has(ctor)) {
-    instances.set(ctor, new Set<InstanceType<T>>());
+export function getInstances(): Set<Base>;
+export function getInstances<T extends BaseConstructor = BaseConstructor>(ctor: T): Set<InstanceType<T>>;
+export function getInstances<T extends BaseConstructor = BaseConstructor>(ctor?: T): Set<InstanceType<T>> | Set<Base> {
+  if (isDefined(ctor)) {
+    const filteredInstances = new Set<InstanceType<T>>();
+    for (const instance of instances) {
+      if (instance instanceof ctor) {
+        filteredInstances.add(instance as InstanceType<T>);
+      }
+    }
+    return filteredInstances;
+  } else {
+    return new Set(instances);
   }
-
-  return instances.get(ctor) as Set<InstanceType<T>>;
 }
 
-export function registerInstance(instance) {
-  getInstances(instance.constructor).add(instance);
+export function addInstance(instance: Base) {
+  instances.add(instance);
+}
+
+export function deleteInstance(instance: Base) {
+  instances.delete(instance);
 }

--- a/packages/js-toolkit/index.ts
+++ b/packages/js-toolkit/index.ts
@@ -1,8 +1,5 @@
-export { Base } from './Base/index.js';
+export * from './Base/index.js';
+export * from './Base/types.js';
 export * from './decorators/index.js';
 export * from './helpers/index.js';
 export * from './services/index.js';
-
-export type { BaseProps, BaseConstructor, BaseAsyncConstructor, BaseConfig } from './Base/index.js';
-
-export type { BaseInterface, BaseDecorator } from './Base/types.js';

--- a/packages/tests/Base/utils.spec.ts
+++ b/packages/tests/Base/utils.spec.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, mock } from 'bun:test';
 import { Base, withName } from '@studiometa/js-toolkit';
 import { nextTick } from '@studiometa/js-toolkit/utils';
-import {
-  getComponentElements,
-  addToQueue,
-  registerInstance,
-  getInstances,
-} from '#private/Base/utils.js';
+import { getComponentElements, addToQueue, getInstances } from '#private/Base/utils.js';
 import { h } from '#test-utils';
 
 describe('The `getComponentElements` function', () => {
@@ -52,16 +47,27 @@ describe('The `addToQueue` function', () => {
 describe('The instance helpers', () => {
   it('should save and get instances for a given constructor', () => {
     const Foo = withName(Base, 'Foo');
-    const instances = getInstances(Foo);
+    const Bar = withName(Base, 'Bar');
 
-    expect(instances).toBeInstanceOf(Set);
-    expect(getInstances(Foo) === instances).toBe(true);
-    expect(instances).toHaveLength(0);
+    expect(getInstances(Foo)).toHaveLength(0);
+    expect(getInstances(Bar)).toHaveLength(0);
 
     const foo = new Foo(h('div'));
+    new Bar(h('div'));
+    foo.dispatchEvent(new CustomEvent('mounted'));
 
-    expect(Array.from(instances)[0]).toBe(foo);
-    expect(instances).toHaveLength(1);
-    expect(instances.has(foo)).toBe(true);
+    expect(getInstances(Foo)).toHaveLength(1);
+    expect(getInstances(Bar)).toHaveLength(0);
+    expect(getInstances(Foo).has(foo)).toBe(true);
+  });
+
+  it('should return a set with all instances if no constructor given', () => {
+    const Foo = withName(Base, 'Foo');
+    const foo = new Foo(h('div'));
+    const instances = getInstances();
+    expect(instances).toBeInstanceOf(Set);
+    expect(getInstances().has(foo)).toBe(false);
+    foo.dispatchEvent(new CustomEvent('mounted'));
+    expect(getInstances().has(foo)).toBe(true);
   });
 });

--- a/packages/tests/Base/utils.spec.ts
+++ b/packages/tests/Base/utils.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock } from 'bun:test';
-import { Base, withName } from '@studiometa/js-toolkit';
+import { Base, withName, getInstances } from '@studiometa/js-toolkit';
 import { nextTick } from '@studiometa/js-toolkit/utils';
-import { getComponentElements, addToQueue, getInstances } from '#private/Base/utils.js';
+import { getComponentElements, addToQueue } from '#private/Base/utils.js';
 import { h } from '#test-utils';
 
 describe('The `getComponentElements` function', () => {

--- a/packages/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/tests/__snapshots__/index.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`The package exports should export helpers and the Base class 1`] = `
   "getClosestParent",
   "getDirectChildren",
   "getInstanceFromElement",
+  "getInstances",
   "importOnInteraction",
   "importOnMediaQuery",
   "importWhenIdle",

--- a/scripts/add-utils-export.js
+++ b/scripts/add-utils-export.js
@@ -6,21 +6,23 @@ const index = resolve(
   '../packages/js-toolkit/index.ts',
 );
 
-const content = `import { Base } from './Base/index.js';
+const content = `
+import * as BASE from './base/index.js';
 import * as DECORATORS from './decorators/index.js';
 import * as HELPERS from './helpers/index.js';
 import * as SERVICES from './services/index.js';
 import * as UTILS from './utils/index.js';
 
+export * from './Base/index.js';
 export * from './decorators/index.js';
 export * from './helpers/index.js';
 export * from './services/index.js';
 export * from './utils/index.js';
 
-export { Base, DECORATORS, HELPERS, SERVICES, UTILS };
+export { BASE, DECORATORS, HELPERS, SERVICES, UTILS };
 
 export const FRAMEWORK = {
-  Base,
+  BASE,
   DECORATORS,
   HELPERS,
   SERVICES,


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR improves the `getInstances` helper with the following: 

- only return instances of mounted components (destroyed components are ignored)
- returns all instances of all components if no parameter is given

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
