### PR TITLE
[Feature] Configurable attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file. The format 
 
 - Refactor attributes handling with methods ([#494](https://github.com/studiometa/js-toolkit/pull/494), [5c5c3ae](https://github.com/studiometa/js-toolkit/commits/5c5c3ae))
 - Migrate tests to Vitest ([#501](https://github.com/studiometa/js-toolkit/pull/501), [70e1b52](https://github.com/studiometa/js-toolkit/commit/70e1b52))
+- Make the HTML attributes configurable ([#495](https://github.com/studiometa/js-toolkit/pull/495), [823da97](https://github.com/studiometa/js-toolkit/commit/823da97))
+
+### Fixed
+
+- Fix a bug where refs could be undefined ([c11eb49](https://github.com/studiometa/js-toolkit/commit/c11eb49))
 
 ## [v3.0.0-alpha.5](https://github.com/studiometa/js-toolkit/compare/3.0.0-alpha.4..3.0.0-alpha.5) (2023-07-16)
 

--- a/packages/docs/api/helpers/createApp.md
+++ b/packages/docs/api/helpers/createApp.md
@@ -28,6 +28,7 @@ The second parameter can either be one of the following:
    - `options.root` (`HTMLElement`): the root element for your app, defaults to `document.body`
    - `options.breakpoints` (`Record<string, string>`): a list of breakpoints to confgure the [`useResize` service](/api/services/useResize)
    - `options.blocking` (`boolean`): wether to enable the queue mechanism for the internals of the framework or not, defaults to `false`
+   - `options.attributes` (`{ component: string, option: string, ref: string }`): the HTML attributes to use for the [HTML API](/api/html/), defaults to `data-component`, `data-option` and `data-ref`
 
 **Return value**
 
@@ -92,3 +93,21 @@ export default createApp(App, {
   blocking: true,
 });
 ```
+
+### Configure the HTML API attributes
+
+The default attributes used to interact with the DOM are `data-component`, `data-option-...` and `data-ref`. These can be configured by specifying the `attributes` property of the options parameter:
+
+```js
+createApp(App, {
+  attributes: {
+    component: 'tk-is',
+    option: 'tk-opt',
+    ref: 'tk-ref',
+  },
+});
+```
+
+::: warning W3C validation
+Be aware that using other attributes than `data-...` attributes will probably make your HTML fail W3C validation tests.
+:::

--- a/packages/docs/api/html/index.md
+++ b/packages/docs/api/html/index.md
@@ -5,3 +5,31 @@ The following attributes can be used:
 - [data-component](./data-component.md)
 - [data-ref](./data-ref.md)
 - [data-option](./data-option.md)
+
+These attributes can be configured with the [`createApp` helper](/api/helpers/createApp.html):
+
+```js
+createApp(App, {
+  attributes: {
+    component: 'tk-is',
+    option: 'tk-opt',
+    ref: 'tk-ref',
+  },
+});
+```
+
+You will then be able to update your HTML templates:
+
+```diff
+  <div
+-   data-component="Component"
+-   data-option-data="Hello world"
++   tk-is="Component"
++   tk-opt-data="Hello world">
+    ...
+-   <button data-ref="btn">
++   <button tk-ref="btn">
+      Click me
+    </button>
+  </div>
+```

--- a/packages/js-toolkit/Base/features.ts
+++ b/packages/js-toolkit/Base/features.ts
@@ -1,6 +1,11 @@
 export type Features = {
   blocking: boolean;
   breakpoints: Record<string, string>;
+  attributes: {
+    component: string;
+    option: string;
+    ref: string;
+  }
 };
 
 interface FeaturesMap extends Map<keyof Features, Features[keyof Features]> {
@@ -23,4 +28,12 @@ export const features = new Map<keyof Features, Features[keyof Features]>([
       xxxl: '160rem', // 2560px
     },
   ],
+  [
+    'attributes',
+    {
+      component: 'data-component',
+      option: 'data-option',
+      ref: 'data-ref'
+    }
+  ]
 ]) as FeaturesMap;

--- a/packages/js-toolkit/Base/managers/EventsManager.ts
+++ b/packages/js-toolkit/Base/managers/EventsManager.ts
@@ -4,6 +4,7 @@ import { isArray } from '../../utils/index.js';
 import { getEventTarget, eventIsNative, eventIsDefinedInConfig } from '../utils.js';
 import { AbstractManager } from './AbstractManager.js';
 import { normalizeRefName } from './RefsManager.js';
+import { features } from '../features.js';
 
 const names = new Map();
 const normalizeRegex1 = /[A-Z]([A-Z].*)/g;
@@ -292,7 +293,8 @@ export class EventsManager extends AbstractManager {
   __refsHandler: EventListenerObject = {
     handleEvent: (event) => {
       const ref = event.currentTarget as HTMLElement;
-      const refName = normalizeRefName(ref.getAttribute('data-ref'));
+      const attributes = features.get('attributes');
+      const refName = normalizeRefName(ref.getAttribute(attributes.ref));
 
       const normalizedRefName = normalizeName(refName);
       const normalizedEventName = normalizeName(event.type);

--- a/packages/js-toolkit/Base/managers/OptionsManager.ts
+++ b/packages/js-toolkit/Base/managers/OptionsManager.ts
@@ -3,6 +3,7 @@ import type { Options as DeepmergeOptions } from 'deepmerge';
 import { AbstractManager } from './AbstractManager.js';
 import { isDev, isFunction, isDefined, isBoolean, isArray, isObject } from '../../utils/index.js';
 import type { Base } from '../index.js';
+import { features } from '../features.js';
 
 type OptionType =
   | StringConstructor
@@ -74,8 +75,9 @@ export function __getPropertyName(name: string, prefix = '') {
     return __propertyNameCache.get(key);
   }
 
+  const attributes = features.get('attributes');
   const normalizedName = name.replace(matchUppercaseRegexp, '-$1');
-  const propertyName = `data-option${prefix ? `-${prefix}` : ''}-${normalizedName}`;
+  const propertyName = `${attributes.option}${prefix ? `-${prefix}` : ''}-${normalizedName}`;
   __propertyNameCache.set(key, propertyName);
   return propertyName;
 }

--- a/packages/js-toolkit/Base/managers/RefsManager.ts
+++ b/packages/js-toolkit/Base/managers/RefsManager.ts
@@ -74,29 +74,18 @@ function __register(that: RefsManager, refName: string) {
     ),
   ).filter((ref) => refBelongToInstance(ref, that.__element, name));
 
+  /* v8 ignore next 7 */
   if (isDev && !isMultiple && refs.length > 1) {
     console.warn(
-      // @ts-ignore
-      `[${that.__base.$options.name}]`,
+      `[${that.__base.$id}]`,
       `The "${refName}" ref has been found multiple times.`,
       'Did you forgot to add the `[]` suffix to its name?',
     );
   }
 
-  if (!isMultiple && refs.length <= 1 && !isDefined(refs[0])) {
-    if (isDev) {
-      console.warn(
-        // @ts-ignore
-        `[${that.__base.$options.name}]`,
-        `The "${refName}" ref is missing.`,
-        `Is there an \`[${attributes.ref}="${refName}"]\` element in the component's scope?`,
-      );
-    }
-
-    return;
+  if (refs.length) {
+    that.__eventsManager.bindRef(refName, refs);
   }
-
-  that.__eventsManager.bindRef(refName, refs);
 
   Object.defineProperty(that, propName, {
     // @todo remove usage of non-multiple refs as array

--- a/packages/js-toolkit/Base/managers/RefsManager.ts
+++ b/packages/js-toolkit/Base/managers/RefsManager.ts
@@ -7,6 +7,7 @@ import {
   endsWith,
   startsWith,
 } from '../../utils/index.js';
+import { features } from '../features.js';
 
 const NORMALIZE_REF_NAME_REGEX = /\[\]$/;
 const NAMESPACED_REF_REGEX = /^(.*\.)/;
@@ -38,14 +39,15 @@ export function normalizeRefName(name: string) {
  * Filter refs belonging to the related Base instance.
  */
 function refBelongToInstance(ref: HTMLElement, rootElement: HTMLElement, name: string) {
-  const isPrefixed = startsWith(ref.getAttribute('data-ref'), name);
+  const attributes = features.get('attributes');
+  const isPrefixed = startsWith(ref.getAttribute(attributes.ref), name);
   const firstComponentAncestor = getAncestorWhereUntil(
     ref,
     (el) =>
       el &&
       (isPrefixed
-        ? el.getAttribute('data-component') === name && el
-        : el.getAttribute('data-component')) &&
+        ? el.getAttribute(attributes.component) === name && el
+        : el.getAttribute(attributes.component)) &&
       el !== rootElement,
     (el) => el === rootElement,
   );
@@ -64,10 +66,11 @@ function __register(that: RefsManager, refName: string) {
   const isMultiple = endsWith(refName, '[]');
   const propName = normalizeRefName(refName);
   const { name } = that.__base.$options;
+  const attributes = features.get('attributes');
 
   const refs = Array.from(
     that.__element.querySelectorAll<HTMLElement>(
-      `[data-ref="${refName}"],[data-ref="${name}.${refName}"]`,
+      `[${attributes.ref}="${refName}"],[${attributes.ref}="${name}.${refName}"]`,
     ),
   ).filter((ref) => refBelongToInstance(ref, that.__element, name));
 
@@ -86,7 +89,7 @@ function __register(that: RefsManager, refName: string) {
         // @ts-ignore
         `[${that.__base.$options.name}]`,
         `The "${refName}" ref is missing.`,
-        `Is there an \`[data-ref="${refName}"]\` element in the component's scope?`,
+        `Is there an \`[${attributes.ref}="${refName}"]\` element in the component's scope?`,
       );
     }
 

--- a/packages/js-toolkit/Base/managers/ResponsiveOptionsManager.ts
+++ b/packages/js-toolkit/Base/managers/ResponsiveOptionsManager.ts
@@ -2,10 +2,9 @@ import { OptionsManager, __getPropertyName } from './OptionsManager.js';
 import type { OptionObject } from './OptionsManager.js';
 import { useResize } from '../../services/index.js';
 import { isDev } from '../../utils/index.js';
+import { features } from '../features.js';
 
 export type ResponsiveOptionObject = OptionObject & { responsive?: boolean };
-
-const dataOptionRegExp = /^data-option-/;
 
 /**
  * Get the currently active responsive name of an option.
@@ -24,6 +23,8 @@ function __getResponsiveName(that: ResponsiveOptionsManager, name: string) {
   let responsiveName = name;
   const propertyName = __getPropertyName(name);
   const regex = new RegExp(`${propertyName}:(.+)$`);
+  const attributes = features.get('attributes');
+  const dataOptionRegExp = new RegExp(`^${attributes.option}-`);
 
   for (const optionName of that.__element.getAttributeNames()) {
     if (regex.test(optionName)) {

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -30,15 +30,16 @@ const separator = ' ';
  */
 function getSelector(nameOrSelector: string): string {
   if (!selectors.has(nameOrSelector)) {
+    const { component } = features.get('attributes')
     const parts = [
       // Single selector
-      `[data-component="${nameOrSelector}"]`,
+      `[${component}="${nameOrSelector}"]`,
       // Selector in the middle of a list of selectors
-      `[data-component*="${separator}${nameOrSelector}${separator}"]`,
+      `[${component}*="${separator}${nameOrSelector}${separator}"]`,
       // Selector at the end of a list of selectors
-      `[data-component$="${separator}${nameOrSelector}"]`,
+      `[${component}$="${separator}${nameOrSelector}"]`,
       // Selector at the beginning of a list of selectors
-      `[data-component^="${nameOrSelector}${separator}"]`,
+      `[${component}^="${nameOrSelector}${separator}"]`,
     ];
     selectors.set(nameOrSelector, parts.join(','));
   }

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -29,8 +29,10 @@ const separator = ' ';
  * Get the selector for a given component.
  */
 function getSelector(nameOrSelector: string): string {
-  if (!selectors.has(nameOrSelector)) {
-    const { component } = features.get('attributes')
+  const { component } = features.get('attributes');
+  const key = component + nameOrSelector;
+
+  if (!selectors.has(key)) {
     const parts = [
       // Single selector
       `[${component}="${nameOrSelector}"]`,
@@ -41,10 +43,10 @@ function getSelector(nameOrSelector: string): string {
       // Selector at the beginning of a list of selectors
       `[${component}^="${nameOrSelector}${separator}"]`,
     ];
-    selectors.set(nameOrSelector, parts.join(','));
+    selectors.set(key, parts.join(','));
   }
 
-  return selectors.get(nameOrSelector);
+  return selectors.get(key);
 }
 
 /**
@@ -128,8 +130,12 @@ const instances = new Set<Base>();
  * Get all mounted instances or the ones from a given component.
  */
 export function getInstances(): Set<Base>;
-export function getInstances<T extends BaseConstructor = BaseConstructor>(ctor: T): Set<InstanceType<T>>;
-export function getInstances<T extends BaseConstructor = BaseConstructor>(ctor?: T): Set<InstanceType<T>> | Set<Base> {
+export function getInstances<T extends BaseConstructor = BaseConstructor>(
+  ctor: T,
+): Set<InstanceType<T>>;
+export function getInstances<T extends BaseConstructor = BaseConstructor>(
+  ctor?: T,
+): Set<InstanceType<T>> | Set<Base> {
   if (isDefined(ctor)) {
     const filteredInstances = new Set<InstanceType<T>>();
     for (const instance of instances) {

--- a/packages/js-toolkit/decorators/withBreakpointObserver.ts
+++ b/packages/js-toolkit/decorators/withBreakpointObserver.ts
@@ -2,6 +2,7 @@ import type { BaseDecorator, BaseInterface } from '../Base/types.js';
 import type { Base, BaseProps, BaseConfig } from '../Base/index.js';
 import { useResize } from '../services/index.js';
 import { isDev, startsWith } from '../utils/index.js';
+import { features } from '../Base/features.js';
 
 export interface WithBreakpointObserverProps extends BaseProps {
   $options: {
@@ -140,13 +141,13 @@ export function withBreakpointObserver<S extends Base>(
       }
 
       const key = `BreakpointObserver-${this.$id}`;
+      const attributes = features.get('attributes');
 
       // Watch change on the `data-options` attribute to emit the `set:options` event.
       const mutationObserver = new MutationObserver(([mutation]) => {
         if (
           mutation.type === 'attributes' &&
-          (mutation.attributeName === 'data-options' ||
-            startsWith(mutation.attributeName, 'data-option-'))
+          startsWith(mutation.attributeName, `${attributes.option}-`)
         ) {
           // Stop here silently when no breakpoint configuration given.
           if (!hasBreakpointConfiguration(this)) {

--- a/packages/js-toolkit/helpers/createApp.ts
+++ b/packages/js-toolkit/helpers/createApp.ts
@@ -20,6 +20,7 @@ export default function createApp<S extends BaseConstructor<Base>, T extends Bas
     root = document.body,
     breakpoints = null,
     blocking = null,
+    attributes = null,
   } = options instanceof HTMLElement ? { root: options } : options;
 
   if (isObject(breakpoints)) {
@@ -28,6 +29,10 @@ export default function createApp<S extends BaseConstructor<Base>, T extends Bas
 
   if (isBoolean(blocking)) {
     features.set('blocking', blocking);
+  }
+
+  if (isObject(attributes)) {
+    features.set('attributes', attributes);
   }
 
   function init() {

--- a/packages/tests/Base/features.spec.ts
+++ b/packages/tests/Base/features.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+import { Base, createApp } from '@studiometa/js-toolkit';
+import {
+  advanceTimersByTimeAsync,
+  h,
+  useFakeTimers,
+  useRealTimers,
+  mockFeatures,
+} from '#test-utils';
+import { features } from '#private/Base/features';
+
+describe('The configurable features', () => {
+  it('should allow configuration of different attributes', async () => {
+    const { unmock } = mockFeatures({
+      attributes: {
+        component: 'tk-is',
+        option: 'tk-opt',
+        ref: 'tk-ref',
+      },
+    });
+
+    const component = h('div', { id: 'component', tkIs: 'Foo' });
+    const ref = h('div', { id: 'btn', tkRef: 'btn' });
+    const div = h('div', { tkOptFoo: 'foo' }, [component, ref]);
+
+    class Foo extends Base {
+      static config = {
+        name: 'Foo',
+      };
+    }
+
+    interface AppProps {
+      $refs: {
+        btn: HTMLElement;
+      };
+      $children: {
+        Foo: Foo[];
+      };
+      $options: {
+        foo: string;
+      };
+    }
+
+    class App extends Base<AppProps> {
+      static config = {
+        name: 'App',
+        refs: ['btn'],
+        options: { foo: String },
+        components: {
+          Foo,
+        },
+      };
+    }
+
+    const app = new App(div);
+    useFakeTimers();
+    app.$mount();
+    await advanceTimersByTimeAsync(100);
+    useRealTimers();
+    expect(app.$options.foo).toBe(div.getAttribute('tk-opt-foo'));
+    expect(app.$refs.btn).toBe(ref);
+    expect(app.$children.Foo[0].$el).toBe(component);
+    unmock();
+  });
+});

--- a/packages/tests/Base/features.spec.ts
+++ b/packages/tests/Base/features.spec.ts
@@ -1,13 +1,12 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import { Base, createApp } from '@studiometa/js-toolkit';
 import {
-  advanceTimersByTimeAsync,
   h,
+  mockFeatures,
+  advanceTimersByTimeAsync,
   useFakeTimers,
   useRealTimers,
-  mockFeatures,
 } from '#test-utils';
-import { features } from '#private/Base/features';
 
 describe('The configurable features', () => {
   it('should allow configuration of different attributes', async () => {

--- a/packages/tests/Base/utils.spec.ts
+++ b/packages/tests/Base/utils.spec.ts
@@ -33,13 +33,14 @@ describe('The `getComponentElements` function', () => {
 
 describe('The `addToQueue` function', () => {
   it('should delay given tasks if the `blocking` feature is disabled', async () => {
-    mockFeatures({ blocking: false })
+    const { unmock } = mockFeatures({ blocking: false })
     const fn = vi.fn();
 
     addToQueue(fn);
     expect(fn).not.toHaveBeenCalled();
     await nextTick();
     expect(fn).toHaveBeenCalledTimes(1);
+    unmock();
   });
 });
 

--- a/packages/tests/__utils__/mockFeatures.ts
+++ b/packages/tests/__utils__/mockFeatures.ts
@@ -1,19 +1,5 @@
 import { vi } from 'vitest';
-
-type Features = {
-  blocking: boolean;
-  breakpoints: Record<string, string>;
-  attributes: {
-    component: string;
-    option: string;
-    ref: string;
-  };
-};
-
-interface FeaturesMap extends Map<keyof Features, Features[keyof Features]> {
-  get<T extends keyof Features>(key: T): Features[T];
-  set<T extends keyof Features>(key: T, value: Features[T]): this;
-}
+import { features } from '#private/Base/features';
 
 const defaultBreakpoints = {
   xxs: '0rem',
@@ -37,15 +23,9 @@ export function mockFeatures({
   breakpoints = defaultBreakpoints,
   attributes = defaultAttributes,
 } = {}) {
-  const features = new Map<keyof Features, Features[keyof Features]>([
-    ['blocking', blocking],
-    ['breakpoints', breakpoints],
-    ['attributes', attributes],
-  ]) as FeaturesMap;
-
-  vi.mock('#private/Base/features.js', () => {
-    return { features };
-  });
+  features.set('blocking', blocking);
+  features.set('breakpoints', breakpoints);
+  features.set('attributes', attributes);
 
   function unmock() {
     features.set('blocking', false);

--- a/packages/tests/__utils__/mockFeatures.ts
+++ b/packages/tests/__utils__/mockFeatures.ts
@@ -3,6 +3,11 @@ import { vi } from 'vitest';
 type Features = {
   blocking: boolean;
   breakpoints: Record<string, string>;
+  attributes: {
+    component: string;
+    option: string;
+    ref: string;
+  };
 };
 
 interface FeaturesMap extends Map<keyof Features, Features[keyof Features]> {
@@ -10,27 +15,43 @@ interface FeaturesMap extends Map<keyof Features, Features[keyof Features]> {
   set<T extends keyof Features>(key: T, value: Features[T]): this;
 }
 
+const defaultBreakpoints = {
+  xxs: '0rem',
+  xs: '30rem', // 480px
+  s: '48rem', // 768px
+  m: '64rem', // 1024px
+  l: '80rem', // 1280px
+  xl: '90rem', // 1440px
+  xxl: '120rem', // 1920px
+  xxxl: '160rem', // 2560px
+};
+
+const defaultAttributes = {
+  component: 'data-component',
+  option: 'data-option',
+  ref: 'data-ref',
+};
+
 export function mockFeatures({
   blocking = true,
-  breakpoints = {
-    xxs: '0rem',
-    xs: '30rem', // 480px
-    s: '48rem', // 768px
-    m: '64rem', // 1024px
-    l: '80rem', // 1280px
-    xl: '90rem', // 1440px
-    xxl: '120rem', // 1920px
-    xxxl: '160rem', // 2560px
-  },
+  breakpoints = defaultBreakpoints,
+  attributes = defaultAttributes,
 } = {}) {
   const features = new Map<keyof Features, Features[keyof Features]>([
     ['blocking', blocking],
     ['breakpoints', breakpoints],
+    ['attributes', attributes],
   ]) as FeaturesMap;
 
   vi.mock('#private/Base/features.js', () => {
     return { features };
   });
 
-  return { features };
+  function unmock() {
+    features.set('blocking', false);
+    features.set('breakpoints', defaultBreakpoints);
+    features.set('attributes', defaultAttributes);
+  }
+
+  return { features, unmock };
 }

--- a/packages/tests/helpers/createApp.spec.ts
+++ b/packages/tests/helpers/createApp.spec.ts
@@ -97,13 +97,33 @@ describe('The `createApp` function', () => {
     });
   });
 
-  it.skip('should enable given features', () => {
+  it('should enable given features', () => {
     const { App, fn, features } = getContext();
     expect(features.get('blocking')).toBe(false);
     createApp(App, {
       blocking: true,
+      attributes: {
+        component: 'tk-is',
+        option: 'tk-opt',
+        ref: 'tk-ref',
+      },
+      breakpoints: {
+        s: '0rem',
+        m: '80rem',
+        l: '120rem',
+      },
     });
     expect(features.get('blocking')).toBe(true);
+    expect(features.get('attributes')).toEqual({
+      component: 'tk-is',
+      option: 'tk-opt',
+      ref: 'tk-ref',
+    });
+    expect(features.get('breakpoints')).toEqual({
+      s: '0rem',
+      m: '80rem',
+      l: '120rem',
+    });
   });
 
   it('should instantiate directly when the blocking feature is enabled', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#492 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds the possibility to configure the HTML attributes used to define components, refs and options. The defaults are still `data-component`, `data-ref` and `data-option-...`, but they can now be configured with [the `createApp()` helper](https://js-toolkit.studiometa.dev/api/helpers/createApp.html). 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
