### PR TITLE
[Feature] Refactor event callbacks parameters ⚠️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Refactor attributes handling with methods ([#494](https://github.com/studiometa/js-toolkit/pull/494), [5c5c3ae](https://github.com/studiometa/js-toolkit/commits/5c5c3ae))
 - Migrate tests to Vitest ([#501](https://github.com/studiometa/js-toolkit/pull/501), [70e1b52](https://github.com/studiometa/js-toolkit/commit/70e1b52))
 - Make the HTML attributes configurable ([#495](https://github.com/studiometa/js-toolkit/pull/495), [823da97](https://github.com/studiometa/js-toolkit/commit/823da97))
+- ⚠️ Refactor event callbacks parameters ([#499](https://github.com/studiometa/js-toolkit/pull/499), [06df6b0](https://github.com/studiometa/js-toolkit/commit/06df6b0))
 
 ### Fixed
 

--- a/packages/docs/api/methods-hooks-events.md
+++ b/packages/docs/api/methods-hooks-events.md
@@ -1,12 +1,37 @@
 # Event hooks
 
+Event hooks are methods of a class prefixed by `on` which will be executed when the given event will be dispatched on the given target. All methods receives a single parameter `ctx` whose type is:
+
+```ts
+type EventHooksCallbackParams = {
+  /**
+   * The event emitted
+   */
+  event: Event;
+  /**
+   * If the event is emitted on a component, given arguments
+   * can be accessed with the `args` property.
+   */
+  args: Array<any>;
+  /**
+   * If the event is emitted on multiple refs or children, the `index`
+   * property will be the index of the current target.
+   */
+  index: number;
+  /**
+   * The target that emitted the event.
+   */
+  target: Element | Base | Promise<Base> | typeof window | typeof document;
+};
+```
+
 ## `on<Event>`
 
 Methods following this pattern will be executed when the event is triggered on the instance's `$el` element.
 
 **Arguments**
 
-- `event|...args` ([`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) or `any[]`): The event object when triggered from a native DOM event, the event arguments when triggered by a component.
+- `ctx` (`EventHooksCallbackParams`): the context of the event
 
 **Example**
 
@@ -20,12 +45,16 @@ class Foo extends Base {
   };
 
   // Will be triggered when clicking on `this.$el`
-  onClick(event) {
-    this.$emit('custom-event', 'arg1', 'arg2');
+  onClick({ event }) {
+    event.preventDefault();
+    this.$emit('custom-event', 'foo', 'bar');
   }
 
   // Will be triggered when emitting the `custom-event` event
-  onCustomEvent(arg1, arg2, event) {}
+  onCustomEvent({ event, args: [arg1, arg2] }) {
+    console.log(arg1); // 'foo'
+    console.log(arg2); // 'bar'
+  }
 }
 ```
 
@@ -35,9 +64,7 @@ Methods following this pattern will be executed when the corresponding event is 
 
 **Arguments**
 
-- `[...args]` (`any[]`)
-- `event` ([`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) or [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)): The event object.
-- `index` (`number`): The index of the ref triggering the event when multiple refs exists.
+- `ctx` (`EventHooksCallbackParams`): the context of the event
 
 :::tip
 Native DOM events registered on a child component will be binded to the child root element if it supports the event. See the second example below with the `<form>` element.
@@ -61,7 +88,8 @@ Native DOM events registered on a child component will be binded to the child ro
     // Will be triggered when clicking on one of `this.$refs.btn`
     // `event` is the click event's object
     // `index` is the index of the ref that triggered the event
-    onBtnClick(event, index) {}
+    // `target` is the DOM element
+    onBtnClick({ event, index, target }) {}
   }
 
   new Foo(document.querySelector('[data-component="Foo"]'));
@@ -89,10 +117,10 @@ Native DOM events registered on a child component will be binded to the child ro
     };
 
     // Will be triggered when the component emits the `mounted` event
-    onBazMounted(event) {}
+    onBazMounted({ event }) {}
 
     // Will be triggered when the `<form>` element is submitted
-    onBazSubmit(event) {}
+    onBazSubmit({ event }) {}
   }
 
   new Foo(document.querySelector('[data-component="Foo"]'));
@@ -105,7 +133,7 @@ Methods following this pattern will be triggered when the `event` event is dispa
 
 **Arguments**
 
-- `event` (`Event`): The event object
+- `ctx` (`EventHooksCallbackParams`): the context of the event
 
 **Examples**
 
@@ -120,7 +148,7 @@ class Dropdown extends Base {
     refs: ['btn'],
   };
 
-  onBtnClick(event) {
+  onBtnClick({ event }) {
     event.stopPropagation();
     this.open();
   }
@@ -137,7 +165,7 @@ Methods following this pattern will be triggered when the `event` event is dispa
 
 **Arguments**
 
-- `event` (`Event`): The event object
+- `ctx` (`EventHooksCallbackParams`): the context of the event
 
 **Examples**
 
@@ -151,7 +179,7 @@ class Component extends Base {
     name: 'Component',
   };
 
-  onWindowHashchange(event) {
+  onWindowHashchange({ event }) {
     // do something with the new hash...
   }
 }

--- a/packages/docs/guide/introduction/working-with-events.md
+++ b/packages/docs/guide/introduction/working-with-events.md
@@ -1,30 +1,71 @@
 # Working with events
 
-The `Base` class helps you manage event handler with automatic binding of a class methods following a naming convention.
+The `Base` class helps you manage event handler with automatic binding of all class methods prefixed with `on`. These methods can listen to events on different targets:
 
-There are two types of events:
+- the component itself with `on<CustomEventName>`
+- the root element of the component with `on<NativeEventName>`
+- the global `window` object with `onWindow<NativeEventName>`
+- the global `document` object with `onDocument<NativeEventName>`
+- any refs defined with `on<RefName><NativeEventName>`
+- any child component with `on<ChildName><CustomEventName>`
 
-- native events: click, mouseenter, submit, etc.
-- framework events
+The following methods can be used:
 
-## Emitting and listening to events
+```js
+import { Base } from '@studiometa/js-toolkit';
+import Child from './Child.js';
 
-Events can be emitted from a class instance with the [`$emit(event, ...args)`](/api/instance-methods.html#emit-event-args) method.
+class App extends Base {
+  static config = {
+    name: 'App',
+    emits: ['custom-event'],
+    refs: ['btn'],
+    components: {
+      Child,
+    }
+  };
 
-Handlers can be bounded to an event with the [`$on(event, handler)`](/api/instance-methods.html#on-event-callback) method.
+  // Will be triggered when `this.$el` is clicked
+  onClick({ event, index, target, args }) {}
 
-Handlers can be unbounded from an event with the [`$off(event, handler)`](/api/instance-methods.html#off-event-callback) method.
+  // Will be triggered when the `custom-event` is emitted on the instance
+  onCustomEvent({ event, index, target, args }) {}
 
-## Naming convention for event handlers binding
+  // Will be triggered when the `window` is clicked
+  onWindowClick({ event, index, target, args }) {}
 
-![Events diagram](../../assets/events-diagram.png)
+  // Will be triggered when the `document` is clicked
+  onDocumentClick({ event, index, target, args }) {}
 
-### on\<Event>
+  // Will be triggered when the `btn` ref is clicked
+  onBtnClick({ event, index, target, args }) {}
 
-### on\<Refname>\<Event>
+  // Will be triggered when any `Child` component is clicked
+  onChildClick({ event, index, target, args }) {}
+}
+```
 
-### on\<Childname>\<Event>
+All methods will be given the same unique `context` parameter when called. This parameter is an object of type:
 
-### onDocument\<Event>
-
-### onWindow\<Event>
+```ts
+type EventHooksCallbackParams = {
+  /**
+   * The event emitted
+   */
+  event: Event;
+  /**
+   * If the event is emitted on a component, given arguments
+   * can be accessed with the `args` property.
+   */
+  args: Array<any>;
+  /**
+   * If the event is emitted on multiple refs or children, the `index`
+   * property will be the index of the current target.
+   */
+  index: number;
+  /**
+   * The target that emitted the event.
+   */
+  target: Element | Base | Promise<Base> | typeof window | typeof document;
+};
+```

--- a/packages/docs/guide/migration/v2-to-v3.md
+++ b/packages/docs/guide/migration/v2-to-v3.md
@@ -89,3 +89,43 @@ import { scrollTo } from '@studiometa/js-toolkit/utils';
 const scrollY = await scrollTo('#target'); // [!code --]
 const { left: scrollY } = await scrollTo('#target'); // [!code ++]
 ```
+
+## The `on...` method arguments have been refactored
+
+The number of arguments passed to the `on...` methods and their order were different for each type of target: a child component, a ref, the current instance, etc. In v3, all `on...` methods receive a single `context` argument of the following type:
+
+```ts
+type EventHooksCallbackParams = {
+  event: Event;
+  args: Array<any>;
+  index: number;
+  target: Element | Base | Promise<Base> | typeof window | typeof document;
+};
+```
+
+To migrate from v2 to v3, update the arguments of all your `on...` methods:
+
+```js
+class Component extends Base {
+  onClick(event) { // [!code --]
+  onClick({ event }) { // [!code ++]
+    event.preventDefault();
+  }
+
+  onCustomEvent(event, arg1, arg2) { // [!code --]
+  onCustomEvent({ args: [arg1, arg2] }) { // [!code ++]
+    console.log(arg1, arg2);
+  }
+
+  onRefClick(event, index) { // [!code --]
+  onRefClick({ target }) { // [!code ++]
+    const target = this.$refs.Ref[index]; // [!code --]
+    target.classList.toggle('is-active');
+  }
+
+  onChildCustomEvent(event, arg1, index) { // [!code --]
+  onChildCustomEvent({ target }) { // [!code ++]
+    const target = this.$children.Child[index]; // [!code --]
+    target.doSomething()
+  }
+}


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#297

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR refactors the parameters given to the `on...` callback function to a more consistent API. See #297 for the why. 

With this PR, all `on...` methods will receive a single `context` parameter which is an object of the following type: 

```ts
export type EventManagerCallbackParams = {
  event: Event;
  args: Array<any>;
  index: number;
  target: Element | Base | Promise<Base> | typeof window | typeof document;
};
```

Usage will be:

```ts
onClick({ event }) {
  event.preventDefault();
}

onCustomEvent({ event, args: [arg1, arg2], target }) {
  console.log(target === this); // true
}

onChildClick({ event, args: [arg1, arg2], target, index }) {
  const currentChild = target;
  const currentChildIndex = index;
}

onRefClick({ event, target, index }) {
  const currentRef = target;
  const currentRefIndex = index;
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
