### PR TITLE
[Feature] Make the lifecycle methods async ⚠️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 - Migrate tests to Vitest ([#501](https://github.com/studiometa/js-toolkit/pull/501), [70e1b52](https://github.com/studiometa/js-toolkit/commit/70e1b52))
 - Make the HTML attributes configurable ([#495](https://github.com/studiometa/js-toolkit/pull/495), [823da97](https://github.com/studiometa/js-toolkit/commit/823da97))
 - ⚠️ Refactor event callbacks parameters ([#499](https://github.com/studiometa/js-toolkit/pull/499), [06df6b0](https://github.com/studiometa/js-toolkit/commit/06df6b0))
+- ⚠️ Make the lifecycle methods async ([#502](https://github.com/studiometa/js-toolkit/pull/502), [1e0d9ac](https://github.com/studiometa/js-toolkit/commit/1e0d9ac))
 
 ### Fixed
 

--- a/packages/docs/api/instance-methods.md
+++ b/packages/docs/api/instance-methods.md
@@ -160,7 +160,7 @@ Mount the component and its children, will trigger the `mounted` lifecycle metho
 
 **Return value**
 
-- `this`: Returns the current instance
+- `Promise<this>`: returns the current instance when all children components are mounted
 
 ## `$update()`
 
@@ -168,7 +168,7 @@ Update the children list from the DOM, and mount the new ones. This method can b
 
 **Return value**
 
-- `this`: Returns the current instance
+- `Promise<this>`: returns the current instance when all children components are updated
 
 ## `$destroy()`
 
@@ -176,11 +176,15 @@ Destroy the component and its children, will trigger the `destroyed` lifecycle m
 
 **Return value**
 
-- `this`: Returns the current instance
+- `Promise<this>`: returns the current instance when all children components are destroyed
 
 ## `$terminate()`
 
 Terminate the component, its instance is made available to garbage collection.
+
+**Return value**
+
+- `Promise<void>`: returns a promise resolving when all children components are terminated
 
 :::warning
 A terminated component can not be re-mounted, use with precaution.

--- a/packages/docs/guide/introduction/working-with-events.md
+++ b/packages/docs/guide/introduction/working-with-events.md
@@ -22,7 +22,7 @@ class App extends Base {
     refs: ['btn'],
     components: {
       Child,
-    }
+    },
   };
 
   // Will be triggered when `this.$el` is clicked

--- a/packages/docs/guide/migration/v2-to-v3.md
+++ b/packages/docs/guide/migration/v2-to-v3.md
@@ -129,3 +129,14 @@ class Component extends Base {
     target.doSomething()
   }
 }
+```
+
+## Lifecycle methods are now async
+
+The `$mount`, `$update`, `$destroy` and `$terminate` methods are now async and can be awaited. This should not have a big impact on existing projects, but in case you are trying to access a newly mounted child component after calling the `$update()` method, you should await its result to be sure the component is mounted.
+
+```js
+this.$update(); // [!code --]
+await this.$update(); // [!code ++]
+this.$children.Component[0].toggle();
+```

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -7,7 +7,7 @@ let queue: SmartQueue;
 /**
  * Add a task to the main queue.
  */
-export function addToQueue(fn: () => unknown): void {
+export function addToQueue(fn: () => unknown) {
   if (features.get('blocking')) {
     fn();
     return;
@@ -17,7 +17,7 @@ export function addToQueue(fn: () => unknown): void {
     queue = new SmartQueue();
   }
 
-  queue.add(fn);
+  return queue.add(fn);
 }
 
 const selectors = new Map();

--- a/packages/js-toolkit/decorators/withBreakpointManager.ts
+++ b/packages/js-toolkit/decorators/withBreakpointManager.ts
@@ -97,8 +97,8 @@ export function withBreakpointManager<S extends Base>(
      * Override the default $mount method to prevent component's from being
      * mounted when they should not.
      */
-    $mount(): this {
-      super.$mount();
+    async $mount() {
+      await super.$mount();
 
       testBreakpoints(instances.get(this));
 
@@ -108,12 +108,15 @@ export function withBreakpointManager<S extends Base>(
     /**
      * Destroy all instances when the main one is destroyed.
      */
-    $destroy(): this {
+    async $destroy() {
+      const promises = [];
       if (isArray(instances.get(this))) {
         for (const [, instance] of instances.get(this)) {
-          instance.$destroy();
+          promises.push(instance.$destroy());
         }
       }
+
+      await Promise.all(promises);
 
       return super.$destroy();
     }

--- a/packages/js-toolkit/decorators/withBreakpointObserver.ts
+++ b/packages/js-toolkit/decorators/withBreakpointObserver.ts
@@ -11,9 +11,7 @@ export interface WithBreakpointObserverProps extends BaseProps {
   };
 }
 
-export interface WithBreakpointObserverInterface extends BaseInterface {
-  $mount(): this;
-}
+export interface WithBreakpointObserverInterface extends BaseInterface {}
 
 /**
  * Test the breakpoins of the given Base instance and return the hook to call.
@@ -173,7 +171,7 @@ export function withBreakpointObserver<S extends Base>(
      * Override the default $mount method to prevent component's from being
      * mounted when they should not.
      */
-    $mount(): this {
+    async $mount() {
       // Execute normal behavior when no breakpoint configuration given.
       if (!hasBreakpointConfiguration(this)) {
         return super.$mount();

--- a/packages/js-toolkit/decorators/withMountOnMediaQuery.ts
+++ b/packages/js-toolkit/decorators/withMountOnMediaQuery.ts
@@ -89,9 +89,9 @@ export function withMountOnMediaQuery<S extends Base = Base>(
     /**
      * Override the mounting of the component.
      */
-    $mount() {
+    async $mount() {
       if (this.__matches) {
-        super.$mount();
+        return super.$mount();
       }
 
       return this;

--- a/packages/js-toolkit/decorators/withMountWhenInView.ts
+++ b/packages/js-toolkit/decorators/withMountWhenInView.ts
@@ -97,9 +97,9 @@ export function withMountWhenInView<S extends Base = Base>(
     /**
      * Override the mounting of the component.
      */
-    $mount() {
+    async $mount() {
       if (this.__isVisible) {
-        super.$mount();
+        return super.$mount();
       }
 
       return this;

--- a/packages/js-toolkit/helpers/createApp.ts
+++ b/packages/js-toolkit/helpers/createApp.ts
@@ -35,15 +35,16 @@ export default function createApp<S extends BaseConstructor<Base>, T extends Bas
     features.set('attributes', attributes);
   }
 
-  function init() {
-    app = (new App(root) as S & Base<T>).$mount();
+  async function init() {
+    app = (new App(root) as S & Base<T>)
+    await app.$mount();
     return app;
   }
 
   let p: Promise<S & Base<T>>;
 
   if (features.get('blocking')) {
-    p = Promise.resolve(init());
+    p = init();
   } else {
     p = new Promise<S & Base<T>>((resolve) => {
       if (document.readyState === 'complete') {

--- a/packages/tests/Base/features.spec.ts
+++ b/packages/tests/Base/features.spec.ts
@@ -52,10 +52,7 @@ describe('The configurable features', () => {
     }
 
     const app = new App(div);
-    useFakeTimers();
-    app.$mount();
-    await advanceTimersByTimeAsync(100);
-    useRealTimers();
+    await app.$mount();
     expect(app.$options.foo).toBe(div.getAttribute('tk-opt-foo'));
     expect(app.$refs.btn).toBe(ref);
     expect(app.$children.Foo[0].$el).toBe(component);

--- a/packages/tests/Base/managers/ChildrenManager.spec.ts
+++ b/packages/tests/Base/managers/ChildrenManager.spec.ts
@@ -1,15 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Base, BaseConfig } from '@studiometa/js-toolkit';
 import { getComponentElements } from '#private/Base/utils.js';
-import { h, useFakeTimers, useRealTimers, advanceTimersByTimeAsync } from '#test-utils';
+import { h } from '#test-utils';
 
 beforeEach(() => {
   document.body.innerHTML = '';
-  useFakeTimers();
-});
-
-afterEach(() => {
-  useRealTimers();
 });
 
 describe('The component resolution', () => {
@@ -72,8 +67,7 @@ describe('The component resolution', () => {
     }
 
     const component = new Component(div);
-    component.$mount();
-    await advanceTimersByTimeAsync(1);
+    await component.$mount();
     const asyncInstances = await Promise.all(component.$children.AsyncComponent);
     expect(asyncInstances[0]).toBeInstanceOf(Base);
     expect(fn).toHaveBeenCalledTimes(1);

--- a/packages/tests/Base/managers/EventsManager.spec.ts
+++ b/packages/tests/Base/managers/EventsManager.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Base, BaseConfig } from '@studiometa/js-toolkit';
-import { h, useFakeTimers, useRealTimers, advanceTimersByTimeAsync } from '#test-utils';
+import { h } from '#test-utils';
 import { normalizeEventName, normalizeName } from '#private/Base/managers/EventsManager.js';
 
 function getContext() {
@@ -139,26 +139,16 @@ function getContext() {
   };
 }
 
-beforeEach(() => {
-  useFakeTimers();
-});
-
-afterEach(() => {
-  useRealTimers();
-});
-
 describe('The EventsManager class', () => {
   it('can bind and unbind event methods to the root element', async () => {
     const { tpl, rootElementFn, app } = getContext();
     tpl.click();
     expect(rootElementFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     tpl.click();
     expect(rootElementFn).toHaveBeenCalledTimes(1);
     rootElementFn.mockClear();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     tpl.click();
     expect(rootElementFn).not.toHaveBeenCalled();
   });
@@ -167,13 +157,11 @@ describe('The EventsManager class', () => {
     const { clickEvent, documentFn, app } = getContext();
     document.dispatchEvent(clickEvent);
     expect(documentFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     document.dispatchEvent(clickEvent);
     expect(documentFn).toHaveBeenCalledTimes(1);
     documentFn.mockClear();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     document.dispatchEvent(clickEvent);
     expect(documentFn).not.toHaveBeenCalled();
   });
@@ -182,13 +170,11 @@ describe('The EventsManager class', () => {
     const { clickEvent, windowFn, app } = getContext();
     window.dispatchEvent(clickEvent);
     expect(windowFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     window.dispatchEvent(clickEvent);
     expect(windowFn).toHaveBeenCalledTimes(1);
     windowFn.mockClear();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     window.dispatchEvent(clickEvent);
     expect(windowFn).not.toHaveBeenCalled();
   });
@@ -198,8 +184,7 @@ describe('The EventsManager class', () => {
     const event = new PointerEvent('click');
     single.dispatchEvent(event);
     expect(singleRefFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     single.dispatchEvent(event);
     expect(singleRefFn).toHaveBeenCalledTimes(1);
     expect(singleRefFn).toHaveBeenLastCalledWith({
@@ -209,8 +194,7 @@ describe('The EventsManager class', () => {
       target: single,
     });
     singleRefFn.mockClear();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     single.dispatchEvent(event);
     expect(singleRefFn).not.toHaveBeenCalled();
   });
@@ -220,8 +204,7 @@ describe('The EventsManager class', () => {
     const event = new PointerEvent('click');
     multiple[1].dispatchEvent(event);
     expect(multipleRefFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     multiple[1].dispatchEvent(event);
     expect(multipleRefFn).toHaveBeenCalledTimes(1);
     expect(multipleRefFn).toHaveBeenLastCalledWith({
@@ -231,8 +214,7 @@ describe('The EventsManager class', () => {
       target: multiple[1],
     });
     multipleRefFn.mockClear();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     multiple[0].click();
     expect(multipleRefFn).not.toHaveBeenCalled();
   });
@@ -240,8 +222,7 @@ describe('The EventsManager class', () => {
   it('can bind, unbind and rebind event methods to children', async () => {
     const { componentFn, componentInnerFn, app } = getContext();
     expect(componentFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     expect(componentFn).toHaveBeenCalledTimes(2);
     const event = new CustomEvent('custom-event', { detail: [1, 2] });
     app.$children.Component[0].dispatchEvent(event);
@@ -288,13 +269,11 @@ describe('The EventsManager class', () => {
     });
     componentFn.mockClear();
     expect(componentFn).not.toHaveBeenCalled();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     expect(componentFn).not.toHaveBeenCalled();
     app.$children.Component[0].dispatchEvent(event);
     expect(componentFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     app.$children.Component[0].dispatchEvent(event);
     expect(componentFn).toHaveBeenLastCalledWith({
       event,
@@ -308,23 +287,20 @@ describe('The EventsManager class', () => {
       index: 0,
       target: app.$children.Component[0],
     });
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
   });
 
   it('can bind and unbind event methods to async children', async () => {
     const { asyncComponentFn, app } = getContext();
     expect(asyncComponentFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     expect(asyncComponentFn).toHaveBeenCalledTimes(1);
     const instances = await Promise.all(app.$children.AsyncComponent);
     instances[0].$emit('custom-event', 1, 2);
     expect(asyncComponentFn).toHaveBeenCalledTimes(2);
     asyncComponentFn.mockClear();
     expect(asyncComponentFn).not.toHaveBeenCalled();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     expect(asyncComponentFn).not.toHaveBeenCalled();
     const instances1 = await Promise.all(app.$children.AsyncComponent);
     instances1[0].$emit('custom-event', 1, 2);
@@ -367,8 +343,7 @@ describe('The EventsManager class', () => {
     const event = new PointerEvent('click');
     prefixed.dispatchEvent(event);
     expect(prefixedRefFn).not.toHaveBeenCalled();
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     prefixed.dispatchEvent(event);
     expect(prefixedRefFn).toHaveBeenCalledTimes(1);
     expect(prefixedRefFn).toHaveBeenLastCalledWith({
@@ -378,8 +353,7 @@ describe('The EventsManager class', () => {
       target: prefixed,
     });
     prefixedRefFn.mockClear();
-    app.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await app.$destroy();
     prefixed.dispatchEvent(event);
     expect(prefixedRefFn).not.toHaveBeenCalled();
   });

--- a/packages/tests/Base/managers/ServicesManager.spec.ts
+++ b/packages/tests/Base/managers/ServicesManager.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Base } from '@studiometa/js-toolkit';
 import { useFakeTimers, useRealTimers, runAllTimers } from '#test-utils';
 
-describe('The ServicesManager', () => {
+async function getContext() {
   const fn = vi.fn();
 
   class App extends Base {
@@ -19,17 +19,20 @@ describe('The ServicesManager', () => {
     }
   }
 
-  const app = new App(document.createElement('div')).$mount();
+  const app = new App(document.createElement('div'));
+  await app.$mount();
 
-  beforeEach(() => {
-    fn.mockClear();
-  });
+  return { app, App, fn };
+}
 
-  it('should return false if the service does not exists', () => {
+describe('The ServicesManager', () => {
+  it('should return false if the service does not exists', async () => {
+    const { app } = await getContext();
     expect(app.$services.has('foo')).toBe(false);
   });
 
-  it('should not enable a service twice', () => {
+  it('should not enable a service twice', async () => {
+    const { app, fn } = await getContext();
     useFakeTimers();
     app.$services.disable('resized');
     app.$services.enable('resized');
@@ -40,11 +43,13 @@ describe('The ServicesManager', () => {
     useRealTimers();
   });
 
-  it('should not disable a service that does not exist', () => {
+  it('should not disable a service that does not exist', async () => {
+    const { app } = await getContext();
     expect(app.$services.disable('foo')).toBeUndefined();
   });
 
-  it('should be able to toggle services', () => {
+  it('should be able to toggle services', async () => {
+    const { app, fn } = await getContext();
     useFakeTimers();
     app.$services.toggle('resized', false);
     window.dispatchEvent(new CustomEvent('resize'));
@@ -65,35 +70,24 @@ describe('The ServicesManager', () => {
     useRealTimers();
   });
 
-  it('should enable a service when it is used via event handlers', () => {
+  it('should enable a service when it is used via event handlers', async () => {
+    const { fn } = await getContext();
     useFakeTimers();
-
-    class Test extends Base {
-      static config = {
-        name: 'Test',
-      };
-
-      constructor(element) {
-        super(element);
-
-        this.$on('resized', fn);
-      }
-    }
-
-    const test = new Test(document.createElement('div'));
     window.dispatchEvent(new CustomEvent('resize'));
     runAllTimers();
     expect(fn).toHaveBeenCalledTimes(1);
     useRealTimers();
   });
 
-  it('should be able to unregister custom services but not core services', () => {
+  it('should be able to unregister custom services but not core services', async () => {
+    const { app } = await getContext();
     expect(() => app.$services.unregister('resized')).toThrow(
-      /core service can not be unregistered/
+      /core service can not be unregistered/,
     );
   });
 
-  it('should be able to register new services', () => {
+  it('should be able to register new services', async () => {
+    const { app, fn } = await getContext();
     let handler;
     const add = vi.fn();
     const service = {
@@ -116,7 +110,8 @@ describe('The ServicesManager', () => {
     app.$services.unregister('customService');
   });
 
-  it('should expose each services props', () => {
+  it('should expose each services props', async () => {
+    const { app } = await getContext();
     expect(app.$services.get('ticked')).toHaveProperty('time');
   });
 });

--- a/packages/tests/decorators/withDrag.spec.ts
+++ b/packages/tests/decorators/withDrag.spec.ts
@@ -1,14 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Base, withDrag } from '@studiometa/js-toolkit';
-import { h, createEvent, useFakeTimers, useRealTimers, advanceTimersByTimeAsync } from '#test-utils';
-
-beforeEach(() => {
-  useFakeTimers();
-});
-
-afterEach(() => {
-  useRealTimers();
-});
+import { h, createEvent } from '#test-utils';
 
 describe('The `withDrag` decorator', () => {
   it('should add a `dragged` hook', async () => {
@@ -23,12 +15,10 @@ describe('The `withDrag` decorator', () => {
 
     const div = h('div');
     const foo = new Foo(div);
-    foo.$mount();
-    await advanceTimersByTimeAsync(1);
+    await foo.$mount();
     div.dispatchEvent(createEvent('pointerdown', { button: 0, x: 0, y: 0 }));
     expect(fn).toHaveBeenCalledTimes(1);
-    foo.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await foo.$destroy();
     div.dispatchEvent(createEvent('pointerdown', { button: 0, x: 0, y: 0 }));
     expect(fn).toHaveBeenCalledTimes(1);
   });

--- a/packages/tests/decorators/withIntersectionObserver.spec.ts
+++ b/packages/tests/decorators/withIntersectionObserver.spec.ts
@@ -5,21 +5,13 @@ import {
   intersectionObserverAfterEachCallback,
   mockIsIntersecting,
   intersectionMockInstance,
-  advanceTimersByTimeAsync,
-  useFakeTimers,
-  useRealTimers,
 } from '#test-utils';
 
 beforeAll(() => {
   intersectionObserverBeforeAllCallback();
 });
 
-beforeEach(() => {
-  useFakeTimers();
-});
-
 afterEach(() => {
-  useRealTimers();
   intersectionObserverAfterEachCallback();
 });
 
@@ -37,19 +29,17 @@ describe('The withIntersectionObserver decorator', () => {
     }
 
     const div = document.createElement('div');
-    const foo = new Foo(div).$mount();
-    await advanceTimersByTimeAsync(1);
+    const foo = new Foo(div);
+    await foo.$mount();
     const observer = intersectionMockInstance(div);
     expect(foo.$observer).not.toBeUndefined();
     expect(observer.observe).toHaveBeenCalledTimes(1);
     mockIsIntersecting(div, true);
     expect(fn).toHaveBeenCalledTimes(1);
-    foo.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await foo.$destroy();
     expect(observer.unobserve).toHaveBeenCalledTimes(1);
     expect(fn).toHaveBeenCalledTimes(1);
-    foo.$mount();
-    await advanceTimersByTimeAsync(1);
+    await foo.$mount();
     expect(observer.observe).toHaveBeenCalledTimes(2);
   });
 
@@ -70,8 +60,8 @@ describe('The withIntersectionObserver decorator', () => {
 
     const div = document.createElement('div');
     div.innerHTML = '<div data-component="Detector"></div>';
-    new Foo(div).$mount();
-    await advanceTimersByTimeAsync(1);
+    const foo = new Foo(div)
+    await foo.$mount();
     mockIsIntersecting(div.firstElementChild, true);
     expect(fn).toHaveBeenCalledTimes(1);
     mockIsIntersecting(div.firstElementChild, true);

--- a/packages/tests/decorators/withRelativePointer.spec.ts
+++ b/packages/tests/decorators/withRelativePointer.spec.ts
@@ -1,9 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Base, withRelativePointer } from '@studiometa/js-toolkit';
-import { advanceTimersByTimeAsync, useFakeTimers, useRealTimers } from '#test-utils';
 
-beforeEach(() => useFakeTimers());
-afterEach(() => useRealTimers());
 
 function createEvent(type: string, data: Record<string, unknown> = {}, options?: EventInit) {
   const event = new Event(type, options);
@@ -30,12 +27,10 @@ describe('The `withRelativePointer` decorator', () => {
     }
 
     const foo = new Foo(document.createElement('div'));
-    foo.$mount();
-    await advanceTimersByTimeAsync(1);
+    await foo.$mount();
     document.dispatchEvent(createEvent('mousemove', { button: 0, clientX: 0, clientY: 0 }));
     expect(fn).toHaveBeenCalledTimes(1);
-    foo.$destroy();
-    await advanceTimersByTimeAsync(1);
+    await foo.$destroy();
     document.dispatchEvent(createEvent('mousemove', { button: 0, clientX: 0, clientY: 0 }));
     expect(fn).toHaveBeenCalledTimes(1);
   });

--- a/packages/tests/helpers/getClosestParent.spec.ts
+++ b/packages/tests/helpers/getClosestParent.spec.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Base, BaseConfig, getClosestParent } from '@studiometa/js-toolkit';
-import { advanceTimersByTimeAsync, h, useFakeTimers, useRealTimers } from '#test-utils';
-
-beforeEach(() => useFakeTimers());
-afterEach(() => useRealTimers());
+import { h } from '#test-utils';
 
 async function getContext() {
   class GrandChild extends Base {
@@ -51,8 +48,7 @@ async function getContext() {
     </div>
   `;
   const parent = new Parent(div.firstElementChild as HTMLElement);
-  parent.$mount();
-  await advanceTimersByTimeAsync(1);
+  await parent.$mount();
   const [firstChild, secondChild] = parent.$children.Child;
   const [nestedParent] = parent.$children.Parent;
 

--- a/packages/tests/helpers/getDirectChildren.spec.ts
+++ b/packages/tests/helpers/getDirectChildren.spec.ts
@@ -5,10 +5,7 @@ import {
   getInstanceFromElement,
   isDirectChild,
 } from '@studiometa/js-toolkit';
-import { h, useFakeTimers, useRealTimers, advanceTimersByTimeAsync  } from '#test-utils';
-
-beforeEach(() => useFakeTimers());
-afterEach(() => useRealTimers());
+import { h } from '#test-utils';
 
 async function createContext() {
   class Child extends Base {
@@ -34,8 +31,7 @@ async function createContext() {
   const div = h('div', { dataComponent: 'Parent' }, [firstChild, innerParent]);
 
   const parent = new Parent(div);
-  parent.$mount();
-  await advanceTimersByTimeAsync(1);
+  await parent.$mount();
 
   const directChildren = getDirectChildren(parent, 'Parent', 'Child');
 
@@ -65,8 +61,7 @@ describe('The `getDirectChildren` helper function', () => {
     const instance = new Parent(
       h('div', { dataComponent: 'Parent' }, [firstChild.cloneNode(), firstChild.cloneNode()]),
     );
-    instance.$mount();
-    await advanceTimersByTimeAsync(1);
+    await instance.$mount();
     expect(getDirectChildren(instance, 'Parent', 'Child')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR makes the `$mount`, `$update`, `$destroy` and `$terminate` method async. With the introduction of the non-blocking queue in #427, making these methods async will help us wait or not for the end of the different lifecycle action.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
