### PR TITLE
[Bugfix] Fix the `useDrag` delta props not being correct on multiple drag actions

### DIFF
--- a/packages/js-toolkit/services/drag.ts
+++ b/packages/js-toolkit/services/drag.ts
@@ -148,6 +148,8 @@ function createDragService(
     props.final.x = inertiaFinalValue(props.x, props.delta.x, dampFactor);
     props.final.y = inertiaFinalValue(props.y, props.delta.y, dampFactor);
 
+    previousEvent = null;
+
     trigger(props);
 
     setTimeout(() => {

--- a/packages/tests/services/drag.spec.ts
+++ b/packages/tests/services/drag.spec.ts
@@ -104,4 +104,32 @@ describe('The drag service', () => {
     expect(eventSpy).toHaveBeenCalledTimes(1);
     eventSpy.mockRestore();
   });
+
+  it('should reset delta props correctly', () => {
+    const fn = vi.fn();
+    const div = h('div');
+    const { add, props } = useDrag(div, { dampFactor: 0.1 });
+
+    add('key', fn);
+
+    // First drag
+    div.dispatchEvent(createEvent('pointerdown', { x: 0, y: 0, button: 0 }));
+    expect(props().delta).toEqual({ x: 0, y: 0 });
+    document.dispatchEvent(createEvent('mousemove', { clientX: 0, clientY: 0 }));
+    expect(props().delta).toEqual({ x: 0, y: 0 });
+    document.dispatchEvent(createEvent('mousemove', { clientX: 10, clientY: 10 }));
+    expect(props().delta).toEqual({ x: 10, y: 10 });
+    window.dispatchEvent(createEvent('pointerup'));
+    expect(props().mode).toBe('drop');
+
+    // Second drag
+    div.dispatchEvent(createEvent('pointerdown', { x: 0, y: 0, button: 0 }));
+    expect(props().delta).toEqual({ x: 0, y: 0 });
+    document.dispatchEvent(createEvent('mousemove', { clientX: 0, clientY: 0 }));
+    expect(props().delta).toEqual({ x: 0, y: 0 });
+    document.dispatchEvent(createEvent('mousemove', { clientX: 20, clientY: 20 }));
+    expect(props().delta).toEqual({ x: 20, y: 20 });
+    window.dispatchEvent(createEvent('pointerup'));
+    expect(props().mode).toBe('drop');
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#532 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

See #532 for details on the bug.

The bug is fixed by correctly resetting the `previousEvent` variable when the drop occurs in a drag and drop interaction.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
