### PR TITLE
[Bugfix] Fix drag service triggering out of context drop action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. The format 
 
 - Refactor services to classes ([#535](https://github.com/studiometa/js-toolkit/pull/535), [#537](https://github.com/studiometa/js-toolkit/pull/537))
 
+### Fixed
+
+- **useDrag:** prevent drop when not dragging ([#538](https://github.com/studiometa/js-toolkit/issues/538), [#539](https://github.com/studiometa/js-toolkit/pull/539), [63ba2350](https://github.com/studiometa/js-toolkit/commit/63ba2350))
+
 ## [v3.0.0-alpha.12](https://github.com/studiometa/js-toolkit/compare/3.0.0-alpha.11..3.0.0-alpha.12) (2024-11-15)
 
 ### Fixed

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -27,7 +27,6 @@
     "prettier": "3.3.3",
     "stylelint": "16.10.0"
   },
-  "prettier": "@studiometa/prettier-config",
   "stylelint": {
     "extends": "@studiometa/stylelint-config"
   }

--- a/packages/demo/src/js/app.ts
+++ b/packages/demo/src/js/app.ts
@@ -9,6 +9,8 @@ import {
   withExtraConfig,
   importOnMediaQuery,
   BaseConfig,
+  withDrag,
+  withName,
 } from '@studiometa/js-toolkit';
 import { matrix } from '@studiometa/js-toolkit/utils';
 import ScrollToDemo from './components/ScrollToDemo.js';
@@ -80,6 +82,7 @@ class App extends Base {
     refs: ['modal'],
     log: true,
     components: {
+      Draggable: withDrag(withName(Base, 'Draggable')),
       PointerProps,
       ParentNativeEvent,
       AnimateTest,

--- a/packages/demo/src/templates/pages/drag.twig
+++ b/packages/demo/src/templates/pages/drag.twig
@@ -1,0 +1,7 @@
+{% extends '@layouts/base.twig' %}
+
+{% block main %}
+  <div class="p-10">
+    <div data-component="Draggable" data-option-debug class="w-96 h-96 bg-blue-400 rounded"></div>
+  </div>
+{% endblock %}

--- a/packages/js-toolkit/services/AbstractService.ts
+++ b/packages/js-toolkit/services/AbstractService.ts
@@ -134,6 +134,7 @@ export class AbstractService<PropsType = any> {
     }
   }
 
+  /* v8 ignore next 6 */
   /**
    * Implements the EventListenerObject interface.
    */

--- a/packages/js-toolkit/services/DragService.ts
+++ b/packages/js-toolkit/services/DragService.ts
@@ -194,6 +194,10 @@ export class DragService extends AbstractService<DragServiceProps> {
   drop() {
     const { props, dampFactor, id } = this;
 
+    if (!props.isGrabbing) {
+      return;
+    }
+
     document.removeEventListener('touchmove', this);
     document.removeEventListener('mousemove', this);
 

--- a/packages/js-toolkit/services/DragService.ts
+++ b/packages/js-toolkit/services/DragService.ts
@@ -67,6 +67,24 @@ export class DragService extends AbstractService<DragServiceProps> {
     STOP: 'stop',
   };
 
+  static config: ServiceConfig = [
+    [
+      (instance) => (instance as DragService).props.target,
+      [
+        ['dragstart', CAPTURE_EVENT_OPTIONS],
+        ['click', CAPTURE_EVENT_OPTIONS],
+        ['pointerdown', PASSIVE_EVENT_OPTIONS],
+      ],
+    ],
+    [
+      window,
+      [
+        ['pointerup', PASSIVE_EVENT_OPTIONS],
+        ['touchend', PASSIVE_EVENT_OPTIONS],
+      ],
+    ],
+  ];
+
   id: string;
 
   dampFactor = 0.85;
@@ -122,24 +140,6 @@ export class DragService extends AbstractService<DragServiceProps> {
     this.props.target = target;
   }
 
-  static config: ServiceConfig = [
-    [
-      (instance) => (instance as DragService).props.target,
-      [
-        ['dragstart', CAPTURE_EVENT_OPTIONS],
-        ['click', CAPTURE_EVENT_OPTIONS],
-        ['pointerdown', PASSIVE_EVENT_OPTIONS],
-      ],
-    ],
-    [
-      window,
-      [
-        ['pointerup', PASSIVE_EVENT_OPTIONS],
-        ['touchend', PASSIVE_EVENT_OPTIONS],
-      ],
-    ],
-  ];
-
   /**
    * Get the client value for the given axis.
    */
@@ -157,7 +157,6 @@ export class DragService extends AbstractService<DragServiceProps> {
    *
    * @param {number} x The initial horizontal position.
    * @param {number} y The initial vertical position.
-   * @returns {void}
    */
   start(x: number, y: number) {
     const { props } = this;
@@ -166,20 +165,11 @@ export class DragService extends AbstractService<DragServiceProps> {
     }
 
     // Reset state
-    props.x = x;
-    props.y = y;
-    props.origin.x = x;
-    props.origin.y = y;
-    props.delta.x = 0;
-    props.delta.y = 0;
-    props.distance.x = 0;
-    props.distance.y = 0;
-    props.final.x = x;
-    props.final.y = y;
-
+    props.x = props.origin.x = props.final.x = x;
+    props.y = props.origin.y = props.final.y = y;
+    props.delta.x = props.distance.x = 0;
+    props.delta.y = props.distance.y = 0;
     props.mode = DragService.MODES.START;
-
-    // Enable grabbing
     props.isGrabbing = true;
 
     this.trigger(props);
@@ -203,11 +193,9 @@ export class DragService extends AbstractService<DragServiceProps> {
 
     props.isGrabbing = false;
     props.mode = DragService.MODES.DROP;
-
     props.hasInertia = true;
     props.final.x = inertiaFinalValue(props.x, props.delta.x, dampFactor);
     props.final.y = inertiaFinalValue(props.y, props.delta.y, dampFactor);
-
     this.previousEvent = null;
 
     this.trigger(props);
@@ -216,7 +204,7 @@ export class DragService extends AbstractService<DragServiceProps> {
       const raf = useRaf();
       raf.remove(id);
       raf.add(id, () => this.rafHandler());
-    }, 0);
+    });
   }
 
   /**
@@ -229,6 +217,7 @@ export class DragService extends AbstractService<DragServiceProps> {
     props.isGrabbing = false;
     props.hasInertia = false;
     props.mode = DragService.MODES.STOP;
+
     this.trigger(props);
   }
 
@@ -243,13 +232,9 @@ export class DragService extends AbstractService<DragServiceProps> {
       props.y += props.delta.y;
       props.distance.x = props.x - props.origin.x;
       props.distance.y = props.y - props.origin.y;
-
       props.delta.x *= dampFactor;
       props.delta.y *= dampFactor;
-
-      if (props.mode !== DragService.MODES.INERTIA) {
-        props.mode = DragService.MODES.INERTIA;
-      }
+      props.mode = DragService.MODES.INERTIA;
 
       this.trigger(props);
 
@@ -280,10 +265,7 @@ export class DragService extends AbstractService<DragServiceProps> {
       props.final.y = position.y;
       props.distance.x = props.x - props.origin.x;
       props.distance.y = props.y - props.origin.y;
-
-      if (props.mode !== DragService.MODES.DRAG) {
-        props.mode = DragService.MODES.DRAG;
-      }
+      props.mode = DragService.MODES.DRAG;
 
       this.trigger(props);
       this.previousEvent = event;

--- a/packages/tests/services/DragService.spec.ts
+++ b/packages/tests/services/DragService.spec.ts
@@ -128,4 +128,15 @@ describe('The drag service', () => {
     dispatch(window, 'pointerup');
     expect(props().mode).toBe('drop');
   });
+
+  it('should not trigger the drop mode when no drag', () => {
+    const fn = vi.fn();
+    const div = h('div');
+    const service = useDrag(div, { dampFactor: 0.1 });
+    service.add('key', fn);
+    dispatch(window, 'pointerup');
+    expect(service.props().mode).not.toBe('drop');
+    expect(fn).not.toHaveBeenCalled();
+    service.remove('key');
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#538

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds an early return to the `drop()` method of the `DragService` class to prevent calling it before any drag interaction has happened.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog.
