### PR TITLE
[Bugfix] Fix importing the services in SSR context

### DIFF
--- a/packages/js-toolkit/services/AbstractService.ts
+++ b/packages/js-toolkit/services/AbstractService.ts
@@ -1,5 +1,3 @@
-import { isFunction } from '../utils/index.js';
-
 export interface ServiceInterface<T> {
   /**
    * Remove a function from the resize service by its key.
@@ -23,7 +21,7 @@ export interface ServiceInterface<T> {
  * Service configuration of events to be attached to targets.
  */
 export type ServiceConfig = [
-  EventTarget | ((instance: AbstractService) => EventTarget),
+  ((instance: AbstractService) => EventTarget),
   [string, AddEventListenerOptions?][],
 ][];
 
@@ -147,7 +145,7 @@ export class AbstractService<PropsType = any> {
    */
   __manageEvents(mode: 'add' | 'remove') {
     for (const [target, events] of this.constructor.config) {
-      const resolvedTarget = isFunction(target) ? target(this) : target;
+      const resolvedTarget = target(this);
       for (const [type, options] of events) {
         resolvedTarget[`${mode}EventListener`](type, this, options);
       }

--- a/packages/js-toolkit/services/DragService.ts
+++ b/packages/js-toolkit/services/DragService.ts
@@ -77,7 +77,7 @@ export class DragService extends AbstractService<DragServiceProps> {
       ],
     ],
     [
-      window,
+      () => window,
       [
         ['pointerup', PASSIVE_EVENT_OPTIONS],
         ['touchend', PASSIVE_EVENT_OPTIONS],

--- a/packages/js-toolkit/services/KeyService.ts
+++ b/packages/js-toolkit/services/KeyService.ts
@@ -28,7 +28,7 @@ export interface KeyServiceProps {
 export type KeyServiceInterface = ServiceInterface<KeyServiceProps>;
 
 export class KeyService extends AbstractService<KeyServiceProps> {
-  static config: ServiceConfig = [[document, [['keydown'], ['keyup']]]];
+  static config: ServiceConfig = [[() => document, [['keydown'], ['keyup']]]];
 
   previousEvent: Event | null = null;
 

--- a/packages/js-toolkit/services/LoadService.ts
+++ b/packages/js-toolkit/services/LoadService.ts
@@ -8,7 +8,7 @@ export interface LoadServiceProps {
 export type LoadServiceInterface = ServiceInterface<LoadServiceProps>;
 
 export class LoadService extends AbstractService<LoadServiceProps> {
-  static config: ServiceConfig = [[window, [['load']]]];
+  static config: ServiceConfig = [[() => window, [['load']]]];
 
   props: LoadServiceProps = {
     time: performance.now(),

--- a/packages/js-toolkit/services/PointerService.ts
+++ b/packages/js-toolkit/services/PointerService.ts
@@ -19,7 +19,7 @@ export type PointerServiceInterface = ServiceInterface<PointerServiceProps>;
 export class PointerService extends AbstractService<PointerServiceProps> {
   static config: ServiceConfig = [
     [
-      document,
+      () => document,
       [
         ['mouseenter', ONCE_CAPTURE_EVENT_OPTIONS],
         ['mousemove', PASSIVE_CAPTURE_EVENT_OPTIONS],

--- a/packages/js-toolkit/services/ResizeService.ts
+++ b/packages/js-toolkit/services/ResizeService.ts
@@ -20,7 +20,7 @@ export type ResizeServiceInterface<U extends Features['breakpoints'] = Features[
 export class ResizeService<
   T extends Features['breakpoints'] = Features['breakpoints'],
 > extends AbstractService<ResizeServiceProps> {
-  static config: ServiceConfig = [[window, [['resize']]]];
+  static config: ServiceConfig = [[() => window, [['resize']]]];
 
   breakpoints: T;
 

--- a/packages/js-toolkit/services/ScrollService.ts
+++ b/packages/js-toolkit/services/ScrollService.ts
@@ -31,7 +31,7 @@ export interface ScrollServiceProps {
 export type ScrollServiceInterface = ServiceInterface<ScrollServiceProps>;
 
 export class ScrollService extends AbstractService<ScrollServiceProps> {
-  static config: ServiceConfig = [[document, [['scroll', PASSIVE_CAPTURE_EVENT_OPTIONS]]]];
+  static config: ServiceConfig = [[() => document, [['scroll', PASSIVE_CAPTURE_EVENT_OPTIONS]]]];
 
   props: ScrollServiceProps = {
     x: window.scrollX,


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using the `document` and `window` variable in static properties meant they must be defined when a service is imported. This is fixed by always using a function to return the target of the events in a service config.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
