### PR TITLE
[Bugfix] Fix awaiting the $mount and $update methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,20 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- **Base:** add a `$config` getter to access the resolved configuration ([#543](https://github.com/studiometa/js-toolkit/pull/543), [e4b0fe4d](https://github.com/studiometa/js-toolkit/commit/e4b0fe4d))
+
+### Fixed
+
+- **Base:** prevent callling the `$mount` method multiple times ([#543](https://github.com/studiometa/js-toolkit/pull/543), [da1fa92a](https://github.com/studiometa/js-toolkit/commit/da1fa92a))
+- **Base:** fix `$mount` and `$update` method never resolving ([#542]((https://github.com/studiometa/js-toolkit/issues/542), [#543](https://github.com/studiometa/js-toolkit/pull/543), [c2749610](https://github.com/studiometa/js-toolkit/commit/c2749610))
+- **Base:** fix order of component lifecycle hooks ([#542]((https://github.com/studiometa/js-toolkit/issues/542), [#543](https://github.com/studiometa/js-toolkit/pull/543), [b4dfc4d5](https://github.com/studiometa/js-toolkit/commit/b4dfc4d5))
+
 ### Changed
 
+- **Base:** refactor manager dynamic properties ([#543](https://github.com/studiometa/js-toolkit/pull/543), [926738ee](https://github.com/studiometa/js-toolkit/commit/926738ee))
+- **Base:** refactor constructor access ([#543](https://github.com/studiometa/js-toolkit/pull/543), [e445e2f0](https://github.com/studiometa/js-toolkit/commit/e445e2f0))
 - **loadElement :** add examples on how to use the memo function with the loadElement function ([1bc3363a](https://github.com/studiometa/js-toolkit/commit/1bc3363a))
 
 ## [v3.0.0-beta.1](https://github.com/studiometa/js-toolkit/compare/3.0.0-beta.0..3.0.0-beta.1) (2024-11-18)

--- a/packages/docs/api/instance-properties.md
+++ b/packages/docs/api/instance-properties.md
@@ -47,6 +47,10 @@ interface ChildrenInterface {
 }
 ```
 
+## `$config`
+
+The resolved configuration based on the current class [static `config` property](/api/configuration.html) merged with its ancestors properties.
+
 ## `$parent`
 
 The parent instance when the current instance has been mounted as a [child component](#components), defaults to `null` if the component as been instantiated as a stand-alone component.

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -95,7 +95,14 @@ export class Base<T extends BaseProps = BaseProps> {
   $isMounted = false;
 
   /**
+   * Is the component currently mounting itself and its children?
+   * @private
+   */
+  __isMounting = false;
+
+  /**
    * Store the event handlers.
+   * @private
    */
   __eventHandlers: Map<string, Set<EventListenerOrEventListenerObject>> = new Map();
 
@@ -321,10 +328,11 @@ export class Base<T extends BaseProps = BaseProps> {
    * Trigger the `mounted` callback.
    */
   async $mount(): Promise<this> {
-    if (this.$isMounted) {
+    if (this.$isMounted || this.__isMounting) {
       return this;
     }
 
+    this.__isMounting = true;
     this.$emit('before-mounted');
 
     if (isDev) {
@@ -343,6 +351,8 @@ export class Base<T extends BaseProps = BaseProps> {
       this.$isMounted = true;
       this.__callMethod('mounted');
     });
+
+    this.__isMounting = false;
 
     return this;
   }

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -117,6 +117,7 @@ export class Base<T extends BaseProps = BaseProps> {
 
   /**
    * Merge configuration with the parents' configurations.
+   * @private
    */
   get __config(): BaseConfig {
     let proto = Object.getPrototypeOf(this);
@@ -141,6 +142,10 @@ export class Base<T extends BaseProps = BaseProps> {
     config.components = config.components ?? {};
 
     return config;
+  }
+
+  get $config() {
+    return this.__config;
   }
 
   static config: BaseConfig = {

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -337,9 +337,12 @@ export class Base<T extends BaseProps = BaseProps> {
       addToQueue(() => this.__events.bindRootElement()),
       addToQueue(() => this.__services.enableAll()),
       addToQueue(() => this.__children.mountAll()),
-      addToQueue(() => (this.$isMounted = true)),
-      addToQueue(() => this.__callMethod('mounted')),
     ]);
+
+    await addToQueue(() => {
+      this.$isMounted = true;
+      this.__callMethod('mounted');
+    });
 
     return this;
   }
@@ -362,8 +365,9 @@ export class Base<T extends BaseProps = BaseProps> {
       addToQueue(() => this.__services.enableAll()),
       // Update
       addToQueue(() => this.__children.updateAll()),
-      addToQueue(() => this.__callMethod('updated')),
     ]);
+
+    await addToQueue(() => this.__callMethod('updated'));
 
     return this;
   }
@@ -380,14 +384,16 @@ export class Base<T extends BaseProps = BaseProps> {
       this.__debug('$destroy');
     }
 
+    this.$isMounted = false;
+
     await Promise.all([
-      addToQueue(() => (this.$isMounted = false)),
       addToQueue(() => this.__events.unbindRootElement()),
       addToQueue(() => this.__refs.unregisterAll()),
       addToQueue(() => this.__services.disableAll()),
       addToQueue(() => this.__children.destroyAll()),
-      addToQueue(() => this.__callMethod('destroyed')),
     ]);
+
+    await addToQueue(() => this.__callMethod('destroyed'));
 
     return this;
   }
@@ -523,7 +529,9 @@ export class Base<T extends BaseProps = BaseProps> {
       this.__debug('$emit', event, args);
     }
 
-    this.$el.dispatchEvent(event instanceof Event ? event : new CustomEvent(event, { detail: args }));
+    this.$el.dispatchEvent(
+      event instanceof Event ? event : new CustomEvent(event, { detail: args }),
+    );
   }
 
   /**

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -64,6 +64,12 @@ export type Managers = {
  */
 export class Base<T extends BaseProps = BaseProps> {
   /**
+   * Declare the `this.constructor` type
+   * @see https://github.com/microsoft/TypeScript/issues/3841#issuecomment-2381594311
+   */
+  declare ['constructor']: BaseConstructor;
+
+  /**
    * This is a Base instance.
    */
   static readonly $isBase = true as const;
@@ -293,7 +299,7 @@ export class Base<T extends BaseProps = BaseProps> {
       this.$el.__base__ = new WeakMap();
     }
 
-    this.$el.__base__.set(this.__ctor, this);
+    this.$el.__base__.set(this.constructor, this);
 
     for (const service of ['Options', 'Services', 'Events', 'Refs', 'Children']) {
       this[`__${service.toLowerCase()}`] = new this.__managers[`${service}Manager`](this);
@@ -400,7 +406,7 @@ export class Base<T extends BaseProps = BaseProps> {
       // Execute the `terminated` hook if it exists
       addToQueue(() => this.__callMethod('terminated')),
       // Delete instance
-      addToQueue(() => this.$el.__base__.set(this.__ctor, 'terminated')),
+      addToQueue(() => this.$el.__base__.set(this.constructor, 'terminated')),
     ]);
   }
 
@@ -411,7 +417,7 @@ export class Base<T extends BaseProps = BaseProps> {
    * @returns {void}
    */
   __addEmits(event: string): void {
-    const ctor = this.__ctor;
+    const ctor = this.constructor;
     if (isArray(ctor.config.emits)) {
       ctor.config.emits.push(event);
     } else {
@@ -426,16 +432,9 @@ export class Base<T extends BaseProps = BaseProps> {
    * @returns {void}
    */
   __removeEmits(event: string): void {
-    const ctor = this.__ctor;
+    const ctor = this.constructor;
     const index = ctor.config.emits.indexOf(event);
     ctor.config.emits.splice(index, 1);
-  }
-
-  /**
-   * Get the instance constructor.
-   */
-  get __ctor(): BaseConstructor {
-    return this.constructor as BaseConstructor;
   }
 
   /**

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -179,22 +179,22 @@ export class Base<T extends BaseProps = BaseProps> {
     return this.__services;
   }
 
-  __refs: RefsManager & T['$refs'] & BaseRefs;
+  __refs: RefsManager<T['$refs']>;
 
-  get $refs(): RefsManager & T['$refs'] & BaseRefs {
-    return this.__refs;
+  get $refs(): T['$refs'] & BaseRefs {
+    return this.__refs.props;
   }
 
-  __options: OptionsManager & T['$options'] & BaseOptions;
+  __options: OptionsManager<T['$options']>;
 
-  get $options(): OptionsManager & T['$options'] & BaseOptions {
-    return this.__options;
+  get $options(): T['$options'] & BaseOptions {
+    return this.__options.props;
   }
 
-  __children: ChildrenManager & T['$children'] & BaseChildren;
+  __children: ChildrenManager<T['$children']>;
 
-  get $children(): ChildrenManager & T['$children'] & BaseChildren {
-    return this.__children;
+  get $children(): T['$children'] & BaseChildren {
+    return this.__children.props;
   }
 
   __events: EventsManager;
@@ -203,21 +203,21 @@ export class Base<T extends BaseProps = BaseProps> {
    * Small helper to log stuff.
    */
   get $log(): (...args: unknown[]) => void {
-    return this.__options.log ? window.console.log.bind(window, `[${this.$id}]`) : noop;
+    return this.$options.log ? window.console.log.bind(window, `[${this.$id}]`) : noop;
   }
 
   /**
    * Small helper to make warning easier.
    */
   get $warn(): (...args: unknown[]) => void {
-    return this.__options.log ? window.console.warn.bind(window, `[${this.$id}]`) : noop;
+    return this.$options.log ? window.console.warn.bind(window, `[${this.$id}]`) : noop;
   }
 
   /**
    * Small helper to debug information.
    */
   get __debug(): (...args: unknown[]) => void {
-    return isDev && this.__options.debug
+    return isDev && this.$options.debug
       ? window.console.log.bind(window, `[debug] [${this.$id}]`)
       : noop;
   }
@@ -332,11 +332,11 @@ export class Base<T extends BaseProps = BaseProps> {
     }
 
     await Promise.all([
-      addToQueue(() => this.$children.registerAll()),
-      addToQueue(() => this.$refs.registerAll()),
+      addToQueue(() => this.__children.registerAll()),
+      addToQueue(() => this.__refs.registerAll()),
       addToQueue(() => this.__events.bindRootElement()),
-      addToQueue(() => this.$services.enableAll()),
-      addToQueue(() => this.$children.mountAll()),
+      addToQueue(() => this.__services.enableAll()),
+      addToQueue(() => this.__children.mountAll()),
       addToQueue(() => (this.$isMounted = true)),
       addToQueue(() => this.__callMethod('mounted')),
     ]);
@@ -354,14 +354,14 @@ export class Base<T extends BaseProps = BaseProps> {
 
     await Promise.all([
       // Undo
-      addToQueue(() => this.$refs.unregisterAll()),
-      addToQueue(() => this.$services.disableAll()),
+      addToQueue(() => this.__refs.unregisterAll()),
+      addToQueue(() => this.__services.disableAll()),
       // Redo
-      addToQueue(() => this.$children.registerAll()),
-      addToQueue(() => this.$refs.registerAll()),
-      addToQueue(() => this.$services.enableAll()),
+      addToQueue(() => this.__children.registerAll()),
+      addToQueue(() => this.__refs.registerAll()),
+      addToQueue(() => this.__services.enableAll()),
       // Update
-      addToQueue(() => this.$children.updateAll()),
+      addToQueue(() => this.__children.updateAll()),
       addToQueue(() => this.__callMethod('updated')),
     ]);
 
@@ -383,9 +383,9 @@ export class Base<T extends BaseProps = BaseProps> {
     await Promise.all([
       addToQueue(() => (this.$isMounted = false)),
       addToQueue(() => this.__events.unbindRootElement()),
-      addToQueue(() => this.$refs.unregisterAll()),
-      addToQueue(() => this.$services.disableAll()),
-      addToQueue(() => this.$children.destroyAll()),
+      addToQueue(() => this.__refs.unregisterAll()),
+      addToQueue(() => this.__services.disableAll()),
+      addToQueue(() => this.__children.destroyAll()),
       addToQueue(() => this.__callMethod('destroyed')),
     ]);
 

--- a/packages/js-toolkit/Base/managers/AbstractManager.ts
+++ b/packages/js-toolkit/Base/managers/AbstractManager.ts
@@ -3,7 +3,7 @@ import type { Base } from '../index.js';
 /**
  * AbstractManager class.
  */
-export class AbstractManager {
+export class AbstractManager<T extends any = any> {
   /**
    * Base instance.
    */
@@ -30,33 +30,16 @@ export class AbstractManager {
     return this.__base.__events;
   }
 
+  __props: T = {} as any;
+
+  get props() {
+    return this.__props;
+  }
+
   /**
    * Class constructor.
    */
   constructor(base: Base) {
     this.__base = base;
-    this.__hideProperties(['__base']);
-  }
-
-  /**
-   * Prevent a list of properties from being enumerable and writable.
-   *
-   * @param   {string[]} properties
-   * @returns {void}
-   */
-  __hideProperties(properties: string[]) {
-    Object.defineProperties(
-      this,
-      Object.fromEntries(
-        properties.map((property) => [
-          property,
-          {
-            enumerable: false,
-            writable: false,
-            value: this[property],
-          },
-        ]),
-      ),
-    );
   }
 }

--- a/packages/js-toolkit/Base/managers/ChildrenManager.ts
+++ b/packages/js-toolkit/Base/managers/ChildrenManager.ts
@@ -200,10 +200,8 @@ export class ChildrenManager<T> extends AbstractManager<T> {
       for (const name of this.registeredNames) {
         for (const instance of this.props[name]) {
           if (instance instanceof Promise) {
-            promises.push(
-              instance.then((resolvedInstance) =>
-                addToQueue(() => this.__triggerHook(hook, resolvedInstance, name)),
-              ),
+            instance.then((resolvedInstance) =>
+              addToQueue(() => this.__triggerHook(hook, resolvedInstance, name)),
             );
           } else {
             promises.push(addToQueue(() => this.__triggerHook(hook, instance, name)));

--- a/packages/js-toolkit/Base/managers/EventsManager.ts
+++ b/packages/js-toolkit/Base/managers/EventsManager.ts
@@ -277,12 +277,12 @@ export class EventsManager extends AbstractManager {
    */
   __childrenHandler: EventListenerObject = {
     handleEvent: (event: CustomEvent) => {
-      const childrenManager = this.__base.$children;
+      const children = this.__base.$children;
 
-      for (const childName of childrenManager.registeredNames) {
+      for (const childName of Object.keys(children)) {
         let index = -1;
 
-        for (const child of childrenManager[childName] as Base<BaseProps>[]) {
+        for (const child of children[childName] as Base<BaseProps>[]) {
           index++;
 
           if (
@@ -306,15 +306,6 @@ export class EventsManager extends AbstractManager {
    */
   constructor(base: Base) {
     super(base);
-
-    this.__hideProperties([
-      '__methodsCache',
-      '__rootElementHandler',
-      '__refsHandler',
-      '__childrenHandler',
-      '__documentHandler',
-      '__windowHandler',
-    ]);
   }
 
   /**

--- a/packages/js-toolkit/Base/managers/OptionsManager.ts
+++ b/packages/js-toolkit/Base/managers/OptionsManager.ts
@@ -194,6 +194,7 @@ export class OptionsManager<T> extends AbstractManager<T & { name: string; debug
           `The "${val}" value for the "${name}" option must be of type "${type.name}"`,
         );
       }
+      /* v8 ignore next 2 */
       return;
     }
 
@@ -233,6 +234,7 @@ export class OptionsManager<T> extends AbstractManager<T & { name: string; debug
           `The "${name}" option has an invalid type. The allowed types are: String, Number, Boolean, Array and Object.`,
         );
       }
+      /* v8 ignore next 2 */
       return;
     }
 
@@ -244,6 +246,7 @@ export class OptionsManager<T> extends AbstractManager<T & { name: string; debug
           `The default value for options of type "${config.type.name}" must be returned by a function.`,
         );
       }
+      /* v8 ignore next 2 */
       return;
     }
 

--- a/packages/js-toolkit/Base/managers/OptionsManager.ts
+++ b/packages/js-toolkit/Base/managers/OptionsManager.ts
@@ -72,55 +72,20 @@ const UPPERCASE_REGEX = /([A-Z])/g;
 /**
  * Get a property name.
  */
-export const __getPropertyName = memo(function __getPropertyName(name: string, prefix = '', optionAttribute = features.get('attributes').option) {
+export const __getPropertyName = memo(function __getPropertyName(
+  name: string,
+  prefix = '',
+  optionAttribute = features.get('attributes').option,
+) {
   return `${optionAttribute}${prefix ? `-${prefix}` : ''}-${name.replaceAll(UPPERCASE_REGEX, '-$1')}`;
 });
-
-/**
- * Register an option.
- *
- * @param  {OptionsManager} that
- * @param  {string} name
- * @param  {OptionObject} config
- * @returns {void}
- * @private
- */
-function __register(that: OptionsManager, name: string, config: OptionObject) {
-  if (!types.has(config.type)) {
-    if (isDev) {
-      throw new Error(
-        `The "${name}" option has an invalid type. The allowed types are: String, Number, Boolean, Array and Object.`,
-      );
-    }
-    return;
-  }
-
-  config.default = config.default ?? __defaultValues[config.type.name];
-
-  if ((config.type === Array || config.type === Object) && !isFunction(config.default)) {
-    if (isDev) {
-      throw new Error(
-        `The default value for options of type "${config.type.name}" must be returned by a function.`,
-      );
-    }
-    return;
-  }
-
-  Object.defineProperty(that, name, {
-    get: () => that.get(name, config),
-    set: (value) => {
-      that.set(name, value, config);
-    },
-    enumerable: true,
-  });
-}
 
 /**
  * Class options to manage options as data attributes on an HTML element.
  *
  * @todo Use `MutationObserver` to update values? Might be more performant.
  */
-export class OptionsManager extends AbstractManager {
+export class OptionsManager<T> extends AbstractManager<T & { name: string; debug: boolean; log: boolean }> {
   /**
    * An object to store Array and Object values for reference.
    *
@@ -129,29 +94,21 @@ export class OptionsManager extends AbstractManager {
   __values = {};
 
   /**
-   * Default value for the name property.
+   * Default props.
    */
-  name = 'Base';
-
-  /**
-   * Default value for the debug property.
-   */
-  debug = false;
-
-  /**
-   * Default value for the log property.
-   */
-  log = false;
+  __props = {
+    name: 'Base',
+    debug: false,
+    log: false,
+  } as T & { name: string; debug: boolean; log: boolean };
 
   /**
    * Class constructor.
    */
   constructor(base: Base) {
     super(base);
-
-    this.__hideProperties(['__values', '__defaultValues']);
     const schema: OptionsSchema = this.__config.options || {};
-    this.name = this.__config.name;
+    this.props.name = this.__config.name;
 
     schema.debug = {
       type: Boolean,
@@ -164,8 +121,7 @@ export class OptionsManager extends AbstractManager {
     };
 
     for (const [name, config] of Object.entries(schema)) {
-      __register(
-        this,
+      this.__register(
         name,
         types.has(config as OptionType)
           ? ({ type: config as OptionType } as OptionObject)
@@ -264,5 +220,39 @@ export class OptionsManager extends AbstractManager {
       default:
         this.__element.setAttribute(propertyName, value as string);
     }
+  }
+
+  /**
+   * Register an option.
+   * @private
+   */
+  __register(name: string, config: OptionObject) {
+    if (!types.has(config.type)) {
+      if (isDev) {
+        throw new Error(
+          `The "${name}" option has an invalid type. The allowed types are: String, Number, Boolean, Array and Object.`,
+        );
+      }
+      return;
+    }
+
+    config.default = config.default ?? __defaultValues[config.type.name];
+
+    if ((config.type === Array || config.type === Object) && !isFunction(config.default)) {
+      if (isDev) {
+        throw new Error(
+          `The default value for options of type "${config.type.name}" must be returned by a function.`,
+        );
+      }
+      return;
+    }
+
+    Object.defineProperty(this.props, name, {
+      get: () => this.get(name, config),
+      set: (value) => {
+        this.set(name, value, config);
+      },
+      enumerable: true,
+    });
   }
 }

--- a/packages/js-toolkit/Base/managers/ResponsiveOptionsManager.ts
+++ b/packages/js-toolkit/Base/managers/ResponsiveOptionsManager.ts
@@ -7,42 +7,9 @@ import { features } from '../features.js';
 export type ResponsiveOptionObject = OptionObject & { responsive?: boolean };
 
 /**
- * Get the currently active responsive name of an option.
- *
- * @param   {ResponsiveOptionsManager} that
- * @param   {string} name The default name of the option.
- * @returns {string}      The responsive name if one matches the current breakpoint, the default name otherwise.
- */
-function __getResponsiveName(that: ResponsiveOptionsManager, name: string) {
-  const { breakpoint } = useResize().props();
-
-  if (!breakpoint) {
-    return name;
-  }
-
-  let responsiveName = name;
-  const propertyName = __getPropertyName(name).toLowerCase();
-  const regex = new RegExp(`${propertyName}:(.+)$`, 'i');
-  const attributes = features.get('attributes');
-  const dataOptionRegExp = new RegExp(`^${attributes.option}-`);
-
-  for (const optionName of that.__element.getAttributeNames()) {
-    if (regex.test(optionName)) {
-      const [, breakpoints] = optionName.match(regex);
-      const isInBreakpoint = breakpoints.split(':').includes(breakpoint);
-      if (isInBreakpoint) {
-        responsiveName = optionName.replace(dataOptionRegExp, '');
-      }
-    }
-  }
-
-  return responsiveName;
-}
-
-/**
  * Class options to manage options as data attributes on an HTML element.
  */
-export class ResponsiveOptionsManager extends OptionsManager {
+export class ResponsiveOptionsManager<T> extends OptionsManager<T> {
   /**
    * Get an option value.
    *
@@ -55,7 +22,7 @@ export class ResponsiveOptionsManager extends OptionsManager {
       return super.get(name, config);
     }
 
-    return super.get(__getResponsiveName(this, name), config);
+    return super.get(this.__getResponsiveName(name), config);
   }
 
   /**
@@ -72,7 +39,40 @@ export class ResponsiveOptionsManager extends OptionsManager {
     }
 
     if (isDev) {
-      console.warn(`[${this.__config.name}]`, 'Responsive options are read-only.');
+      console.warn(`[${this.__base.$id}]`, 'Responsive options are read-only.');
     }
+  }
+
+  /**
+   * Get the currently active responsive name of an option.
+   *
+   * @param   {ResponsiveOptionsManager} that
+   * @param   {string} name The default name of the option.
+   * @returns {string}      The responsive name if one matches the current breakpoint, the default name otherwise.
+   */
+  __getResponsiveName(name: string) {
+    const { breakpoint } = useResize().props();
+
+    if (!breakpoint) {
+      return name;
+    }
+
+    let responsiveName = name;
+    const propertyName = __getPropertyName(name).toLowerCase();
+    const regex = new RegExp(`${propertyName}:(.+)$`, 'i');
+    const attributes = features.get('attributes');
+    const dataOptionRegExp = new RegExp(`^${attributes.option}-`);
+
+    for (const optionName of this.__element.getAttributeNames()) {
+      if (regex.test(optionName)) {
+        const [, breakpoints] = optionName.match(regex);
+        const isInBreakpoint = breakpoints.split(':').includes(breakpoint);
+        if (isInBreakpoint) {
+          responsiveName = optionName.replace(dataOptionRegExp, '');
+        }
+      }
+    }
+
+    return responsiveName;
   }
 }

--- a/packages/tests/Base/Base.spec.ts
+++ b/packages/tests/Base/Base.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Base, BaseConfig, BaseProps, getInstanceFromElement } from '@studiometa/js-toolkit';
-import { ChildrenManager, OptionsManager, RefsManager } from '#private/Base/managers/index.js';
 import { h } from '#test-utils';
 
 let mockedIsDev = true;
@@ -94,17 +93,17 @@ describe('A Base instance', () => {
 
   it('should have a `$refs` property', async () => {
     const { foo } = await getContext();
-    expect(foo.$refs).toBeInstanceOf(RefsManager);
+    expect(foo.$refs).toBe(foo.__refs.props);
   });
 
   it('should have a `$children` property', async () => {
     const { foo } = await getContext();
-    expect(foo.$children).toBeInstanceOf(ChildrenManager);
+    expect(foo.$children).toBe(foo.__children.props);
   });
 
   it('should have an `$options` property', async () => {
     const { foo } = await getContext();
-    expect(foo.$options).toBeInstanceOf(OptionsManager);
+    expect(foo.$options).toBe(foo.__options.props);
     expect(foo.$options.name).toBe('Foo');
   });
 
@@ -361,7 +360,7 @@ describe('A Base instance methods', () => {
       };
     }
 
-    expect(foo.$children.registeredNames).toEqual([]);
+    expect(Object.keys(foo.$children)).toEqual([]);
     const baz = new Baz(h('div'));
     await baz.$mount();
     expect(baz.$children.Bar).toEqual([]);

--- a/packages/tests/Base/Base.spec.ts
+++ b/packages/tests/Base/Base.spec.ts
@@ -91,6 +91,11 @@ describe('A Base instance', () => {
     expect(foo.$isMounted).toBe(true);
   });
 
+  it('should have a `$config` property', async () => {
+    const { foo } = await getContext();
+    expect(foo.$config).toEqual(foo.__config);
+  });
+
   it('should have a `$refs` property', async () => {
     const { foo } = await getContext();
     expect(foo.$refs).toBe(foo.__refs.props);

--- a/packages/tests/Base/managers/ResponsiveOptionsManager.spec.ts
+++ b/packages/tests/Base/managers/ResponsiveOptionsManager.spec.ts
@@ -51,7 +51,7 @@ describe('The ResponsiveOptionsManager class', () => {
     const warnMock = vi.spyOn(console, 'warn');
     warnMock.mockImplementation(() => null);
     instance.$options.str = 'baz';
-    expect(warnMock).toHaveBeenCalledWith('[Foo]', 'Responsive options are read-only.');
+    expect(warnMock).toHaveBeenCalledWith(`[${instance.$id}]`, 'Responsive options are read-only.');
     instance.$options.foo = 'foo';
     expect(warnMock).toHaveBeenCalledTimes(1);
     warnMock.mockRestore();

--- a/packages/tests/Base/managers/ResponsiveOptionsManager.spec.ts
+++ b/packages/tests/Base/managers/ResponsiveOptionsManager.spec.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { Base, withResponsiveOptions } from '@studiometa/js-toolkit';
 import { h, mockFeatures, useMatchMedia } from '#test-utils';
 
-function componentWithOptions(content, options) {
+function componentWithOptions(content, options, mock?: any) {
   useMatchMedia();
-  mockFeatures();
+  const { unmock } = mockFeatures(mock);
   const div = h('div');
   div.innerHTML = content;
   const element = div.firstElementChild;
@@ -18,12 +18,12 @@ function componentWithOptions(content, options) {
 
   const instance = new Foo(element);
 
-  return instance;
+  return { instance, unmock };
 }
 
 describe('The ResponsiveOptionsManager class', () => {
   it('should return the values for the active breakpoint', () => {
-    const instance = componentWithOptions(
+    const { instance } = componentWithOptions(
       `<div
         data-option-str-str="foo"
         data-option-str-str:l="bar"
@@ -40,7 +40,7 @@ describe('The ResponsiveOptionsManager class', () => {
   });
 
   it('should warn when trying to set the value of a responsive option.', () => {
-    const instance = componentWithOptions(
+    const { instance } = componentWithOptions(
       '<div data-option-str="foo" data-option-str:l="bar"></div>',
       {
         str: { type: String, responsive: true },
@@ -55,5 +55,20 @@ describe('The ResponsiveOptionsManager class', () => {
     instance.$options.foo = 'foo';
     expect(warnMock).toHaveBeenCalledTimes(1);
     warnMock.mockRestore();
+  });
+
+  it('should return the original value when no breakpoint', () => {
+    const { instance, unmock } = componentWithOptions(
+      `<div data-option-foo="foo" data-option-foo:l="bar"></div>`,
+      {
+        foo: { type: String, responsive: true },
+      },
+      {
+        breakpoints: {},
+      },
+    );
+
+    expect(instance.$options.foo).toBe('foo');
+    unmock();
   });
 });

--- a/packages/tests/decorators/withBreakpointObserver.spec.ts
+++ b/packages/tests/decorators/withBreakpointObserver.spec.ts
@@ -185,18 +185,48 @@ describe("The withBreakpointObserver decorator", () => {
     matchMedia.useMediaQuery("(min-width: 64rem)");
     await resizeWindow({ width: 1024 });
 
-    await new App1(root).$mount();
+    await (new App1(root)).$mount();
+    expect(fn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Desktop",
+          "mounted",
+        ],
+      ]
+    `);
+    fn.mockClear();
 
-    expect(fn).toHaveBeenCalledWith("Desktop", "mounted");
     matchMedia.useMediaQuery("(min-width: 48rem)");
     await resizeWindow({ width: 768 });
 
-    expect(fn).toHaveBeenNthCalledWith(2, "Desktop", "destroyed");
-    expect(fn).toHaveBeenNthCalledWith(3, "Mobile", "mounted");
+    expect(fn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Desktop",
+          "destroyed",
+        ],
+        [
+          "Mobile",
+          "mounted",
+        ],
+      ]
+    `)
+    fn.mockClear();
+
     matchMedia.useMediaQuery("(min-width: 64rem)");
     await resizeWindow({ width: 1024 });
 
-    expect(fn).toHaveBeenNthCalledWith(4, "Mobile", "destroyed");
-    expect(fn).toHaveBeenNthCalledWith(5, "Desktop", "mounted");
+    expect(fn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Mobile",
+          "destroyed",
+        ],
+        [
+          "Desktop",
+          "mounted",
+        ],
+      ]
+    `)
   });
 });

--- a/packages/tests/decorators/withMountWhenInView.spec.ts
+++ b/packages/tests/decorators/withMountWhenInView.spec.ts
@@ -1,24 +1,17 @@
-import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
 import { Base, withMountWhenInView } from '@studiometa/js-toolkit';
+import { wait } from '@studiometa/js-toolkit/utils';
 import {
   intersectionObserverBeforeAllCallback,
   intersectionObserverAfterEachCallback,
   mockIsIntersecting,
   intersectionMockInstance,
-  useFakeTimers,
-  useRealTimers,
-  advanceTimersByTimeAsync,
 } from '#test-utils';
 
 beforeAll(() => intersectionObserverBeforeAllCallback());
 
-beforeEach(() => {
-  useFakeTimers();
-});
-
 afterEach(() => {
   intersectionObserverAfterEachCallback();
-  useRealTimers();
 });
 
 async function getContext() {
@@ -42,7 +35,7 @@ describe('The withMountWhenInView decorator', () => {
   it('should mount the component when in view', async () => {
     const { div, instance } = await getContext();
     mockIsIntersecting(div, true);
-    await advanceTimersByTimeAsync(1);
+    await wait(16);
     expect(instance.$isMounted).toBe(true);
   });
 
@@ -55,10 +48,10 @@ describe('The withMountWhenInView decorator', () => {
   it('should destroy the component when not in view', async () => {
     const { div, instance } = await getContext();
     mockIsIntersecting(div, true);
-    await advanceTimersByTimeAsync(1);
+    await wait(16);
     expect(instance.$isMounted).toBe(true);
     mockIsIntersecting(div, false);
-    await advanceTimersByTimeAsync(1);
+    await wait(16);
     expect(instance.$isMounted).toBe(false);
   });
 
@@ -66,8 +59,8 @@ describe('The withMountWhenInView decorator', () => {
     const { div, instance } = await getContext();
     const observer = intersectionMockInstance(div);
     const disconnect = vi.spyOn(observer, 'disconnect');
-    instance.$terminate();
-    await advanceTimersByTimeAsync(1);
+    await instance.$terminate();
+    await wait(1);
     expect(disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/tests/decorators/withResponsiveOptions.spec.ts
+++ b/packages/tests/decorators/withResponsiveOptions.spec.ts
@@ -11,7 +11,7 @@ describe('The `withResponsiveOptions` decorator', () => {
       };
     }
 
-    expect(new Foo(h('div')).$options).toBeInstanceOf(ResponsiveOptionsManager);
+    expect(new Foo(h('div')).__options).toBeInstanceOf(ResponsiveOptionsManager);
   });
 
   it('should configure responsive options', () => {

--- a/packages/tests/helpers/importOnMediaQuery.spec.ts
+++ b/packages/tests/helpers/importOnMediaQuery.spec.ts
@@ -1,25 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   Base,
   withExtraConfig,
   importOnMediaQuery,
   getInstanceFromElement,
 } from '@studiometa/js-toolkit';
-import {
-  h,
-  useMatchMedia,
-  useRealTimers,
-  useFakeTimers,
-  advanceTimersByTimeAsync,
-} from '#test-utils';
-
-beforeEach(() => {
-  useFakeTimers();
-});
-
-afterEach(() => {
-  useRealTimers();
-});
+import { h, useMatchMedia } from '#test-utils';
+import { wait } from '#private/utils';
 
 class App extends Base {
   static config = {
@@ -53,12 +40,11 @@ describe('The `importOnMediaQuery` lazy import helper', () => {
     });
 
     matchMedia.useMediaQuery('(prefers-reduced-motion)');
-    new AppOverride(div).$mount();
-    await advanceTimersByTimeAsync(1);
+    await (new AppOverride(div)).$mount();
     expect(fn).not.toHaveBeenCalled();
     expect(getInstanceFromElement(component, Component)).toBeNull();
     matchMedia.useMediaQuery(mediaQuery);
-    await advanceTimersByTimeAsync(1);
+    await wait(1);
     expect(fn).toHaveBeenCalledTimes(1);
     expect(getInstanceFromElement(component, Component)).toBeInstanceOf(Component);
   });
@@ -81,8 +67,7 @@ describe('The `importOnMediaQuery` lazy import helper', () => {
       },
     });
 
-    new AppOverride(div).$mount();
-    await advanceTimersByTimeAsync(1);
+    await (new AppOverride(div)).$mount();
     expect(fn).toHaveBeenCalledTimes(1);
     expect(getInstanceFromElement(component, Component)).toBeInstanceOf(Component);
   });
@@ -104,8 +89,7 @@ describe('The `importOnMediaQuery` lazy import helper', () => {
       },
     });
 
-    new AppOverride(div).$mount();
-    await advanceTimersByTimeAsync(1);
+    await (new AppOverride(div)).$mount();
     expect(fn).toHaveBeenCalledTimes(0);
     expect(getInstanceFromElement(component, Component)).toBeNull();
   });

--- a/packages/tests/helpers/importWhenPrefersMotion.spec.ts
+++ b/packages/tests/helpers/importWhenPrefersMotion.spec.ts
@@ -1,20 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Base, withExtraConfig, importWhenPrefersMotion } from '@studiometa/js-toolkit';
-import {
-  useMatchMedia,
-  useFakeTimers,
-  useRealTimers,
-  advanceTimersByTimeAsync,
-  h,
-} from '#test-utils';
-
-beforeEach(() => {
-  useFakeTimers();
-});
-
-afterEach(() => {
-  useRealTimers();
-});
+import { useMatchMedia, h } from '#test-utils';
+import { wait } from '#private/utils';
 
 class App extends Base {
   static config = {
@@ -47,8 +34,7 @@ describe('The `importWhenPrefersMotion` lazy import helper', () => {
     });
 
     const app = new AppOverride(div);
-    app.$mount();
-    await advanceTimersByTimeAsync(1);
+    await app.$mount();
     expect(fn).toHaveBeenCalledTimes(1);
     expect(app.$children.Component).toHaveLength(1);
     expect(app.$children.Component[0]).toBeInstanceOf(Component);
@@ -71,8 +57,8 @@ describe('The `importWhenPrefersMotion` lazy import helper', () => {
       },
     });
 
-    new AppOverride(div).$mount();
-    await advanceTimersByTimeAsync(1);
+    await (new AppOverride(div)).$mount();
+    await wait(1);
     expect(fn).toHaveBeenCalledTimes(0);
     expect(div.firstElementChild.__base__).toBeUndefined();
   });

--- a/packages/tests/helpers/importWhenVisible.spec.ts
+++ b/packages/tests/helpers/importWhenVisible.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import {
   Base,
   withExtraConfig,
@@ -10,22 +10,15 @@ import {
   intersectionObserverBeforeAllCallback,
   intersectionObserverAfterEachCallback,
   mockIsIntersecting,
-  advanceTimersByTimeAsync,
-  useFakeTimers,
-  useRealTimers,
 } from '#test-utils';
+import { wait } from '#private/utils';
 
 beforeAll(() => {
   intersectionObserverBeforeAllCallback();
 });
 
-beforeEach(() => {
-  useFakeTimers();
-});
-
 afterEach(() => {
   intersectionObserverAfterEachCallback();
-  useRealTimers();
 });
 
 class App extends Base {
@@ -51,14 +44,12 @@ describe('The `importWhenVisible` lazy import helper', () => {
       },
     });
 
-    new AppOverride(div).$mount();
-
-    await advanceTimersByTimeAsync(1);
+    await (new AppOverride(div)).$mount();
     expect(getInstanceFromElement(component, Component)).toBeNull();
     mockIsIntersecting(component, false);
     expect(getInstanceFromElement(component, Component)).toBeNull();
     mockIsIntersecting(component, true);
-    await advanceTimersByTimeAsync(1);
+    await wait(1);
     expect(getInstanceFromElement(component, Component)).toBeInstanceOf(Component);
   });
 
@@ -74,14 +65,13 @@ describe('The `importWhenVisible` lazy import helper', () => {
       },
     });
 
-    new AppOverride(div).$mount();
+    await (new AppOverride(div)).$mount();
 
-    await advanceTimersByTimeAsync(1);
     expect(getInstanceFromElement(component, Component)).toBeNull();
     mockIsIntersecting(btn, false);
     expect(getInstanceFromElement(component, Component)).toBeNull();
     mockIsIntersecting(btn, true);
-    await advanceTimersByTimeAsync(1);
+    await wait(1);
     expect(getInstanceFromElement(component, Component)).toBeInstanceOf(Component);
   });
 
@@ -95,12 +85,10 @@ describe('The `importWhenVisible` lazy import helper', () => {
       },
     });
 
-    new AppOverride(div).$mount();
-
-    await advanceTimersByTimeAsync(1);
+    await (new AppOverride(div)).$mount();
     expect(getInstanceFromElement(component, Component)).toBeNull();
     mockIsIntersecting(document.body, true);
-    await advanceTimersByTimeAsync(1);
+    await wait(1);
     expect(getInstanceFromElement(component, Component)).toBeInstanceOf(Component);
   });
 });

--- a/packages/tests/utils/loadElement.spec.ts
+++ b/packages/tests/utils/loadElement.spec.ts
@@ -7,7 +7,6 @@ import {
   loadScript,
   memo,
 } from '@studiometa/js-toolkit/utils';
-import type { LoadableElementsNames } from '@studiometa/js-toolkit/utils';
 import { h, mockElementLoad } from '#test-utils';
 
 const items = [


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#542 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes the `$mount()` and `$update()` methods never resolving when using async components.
    
Async components were added to the list of component that should be awaited before mounting or updating the parent, creating some long hanging promises that might never resolve. This commit switch back to the previous behavior of not waiting for async components to be resolved before considering all children mounted (which is the point of async components).

It also adds a `$config` property on each `Base` instance to be able to read the resolved and merged configuration of the current component (based on the current class static config as well as its ancestors').

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
