### PR TITLE
[Feature] Add support for auto-updating components on DOM change

### DIFF
--- a/packages/js-toolkit/helpers/createApp.ts
+++ b/packages/js-toolkit/helpers/createApp.ts
@@ -1,8 +1,6 @@
 import type { Base, BaseConstructor, BaseProps } from '../Base/index.js';
 import type { Features } from '../Base/features.js';
-import { getInstances } from '../Base/index.js';
 import { features } from '../Base/features.js';
-import { useMutation } from '../services/index.js';
 import { isBoolean, isObject, isString } from '../utils/index.js';
 
 export type CreateAppOptions = Partial<Features> & {
@@ -41,25 +39,6 @@ export function createApp<S extends BaseConstructor<Base>, T extends BaseProps =
   if (isObject(attributes)) {
     features.set('attributes', attributes);
   }
-
-  // Terminate components whose root element has been removed from the DOM
-  const service = useMutation(document.documentElement, { childList: true, subtree: true });
-  const symbol = Symbol('createApp');
-  service.add(symbol, (props) => {
-    for (const mutation of props.mutations) {
-      if (mutation.type === 'childList') {
-        for (const node of mutation.removedNodes) {
-          if (!node.isConnected) {
-            for (const instance of getInstances()) {
-              if (node === instance.$el || node.contains(instance.$el)) {
-                instance.$terminate();
-              }
-            }
-          }
-        }
-      }
-    }
-  });
 
   async function init() {
     app = new App(root) as S & Base<T>;


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#562

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Auto-trigger the `$update()` method of each existing instances if their subtree changes. 

- [ ] Test performance 
- [ ] Test if $update() can be triggered on attribute change as well (i.e. change in the `data-component` attribute)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
