### PR TITLE
[Feature] Add support for single key for the `cache` utility function

### DIFF
--- a/packages/docs/utils/cache.md
+++ b/packages/docs/utils/cache.md
@@ -1,6 +1,6 @@
 # cache
 
-Cache the result of a function with a list of keys.
+Cache the result of a function with a single key or a list of keys.
 
 ## Usage
 
@@ -16,11 +16,18 @@ console.log(cache(keys, callback) === cache(keys, callback)); // true
 setTimeout(() => {
   console.log(cache(keys, callback)); // 100
 }, 100);
+
+console.log(cache('key', callback)); // 200
+console.log(cache('key', callback) === cache('key', callback)); // true
+
+setTimeout(() => {
+  console.log(cache('key', callback)); // 200
+}, 100);
 ```
 
 ### Parameters
 
-- `keys` (`Array<any>`): a list of keys to be used to cache the result of the callback
+- `keys` (`any | Array<any>`): a list of keys to be used to cache the result of the callback
 - `callback` (`() => any`): the callback executed to retrieve the value to cache
 
 ### Return value

--- a/packages/js-toolkit/utils/cache.ts
+++ b/packages/js-toolkit/utils/cache.ts
@@ -1,13 +1,16 @@
+import { isArray } from './is.js';
+
 const map = new Map();
 
 /**
  * Cache the result of a callback in map instances.
  */
-export function cache<T extends any>(keys: any[], callback: () => T): T {
+export function cache<T extends any>(keys: any | any[], callback: () => T): T {
+  const normalizedKeys = isArray(keys) ? keys : [keys];
   let value = map;
   let index = 1;
 
-  for (const key of keys) {
+  for (const key of normalizedKeys) {
     if (!value.has(key)) {
       const newValue = index === keys.length ? callback() : new Map();
       value.set(key, newValue);

--- a/packages/tests/utils/cache.spec.ts
+++ b/packages/tests/utils/cache.spec.ts
@@ -7,4 +7,10 @@ describe('cache function', () => {
     const callback = () => new Map();
     expect(cache(keys, callback)).toBe(cache(keys, callback))
   });
+
+  it('caches values with single key', async () => {
+    const key = 'one';
+    const callback = () => new Map();
+    expect(cache(key, callback)).toBe(cache(key, callback))
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `cache(keyOrKeys, callback)` function can be used to cache the result of a function in a deep nested map. It now accepts single keys as well as a list of keys. 

```js
// Before
cache(['key'], callback);
cache(['key', 'key2'], callback);

// After
cache('key', callback);
cache(['key', 'key2'], callback);
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
