### PR TITLE
[Bugfix] `withScrolledInView` not rendered when mounting and in view

### DIFF
--- a/packages/js-toolkit/decorators/withScrolledInView/withScrolledInView.ts
+++ b/packages/js-toolkit/decorators/withScrolledInView/withScrolledInView.ts
@@ -238,14 +238,14 @@ export function withScrolledInView<S extends Base = Base>(
       };
 
       const delegate = {
-        handleEvent(event) {
+        handleEvent(event: CustomEvent) {
           delegate[event.type](event.detail[0]);
         },
         resized: () => {
           this.shouldEvaluateProps = true;
           render();
         },
-        scrolled: (props) => {
+        scrolled: (props: ScrollServiceProps) => {
           if (props.changed.y || props.changed.x) {
             this.$services.enable('ticked');
           }

--- a/packages/js-toolkit/decorators/withScrolledInView/withScrolledInView.ts
+++ b/packages/js-toolkit/decorators/withScrolledInView/withScrolledInView.ts
@@ -250,6 +250,7 @@ export function withScrolledInView<S extends Base = Base>(
             this.$services.enable('ticked');
           }
         },
+        mounted: () => render(),
         ticked: () => {
           const { dampFactor, dampPrecision } = this.$options;
           updateProps(this.__props, dampFactor, dampPrecision, 'x');
@@ -267,12 +268,14 @@ export function withScrolledInView<S extends Base = Base>(
       };
 
       this.$on('before-mounted', () => {
+        this.$on('mounted', delegate);
         this.$on('resized', delegate);
         this.$on('scrolled', delegate);
         this.$on('ticked', delegate);
       });
 
       this.$on('destroyed', () => {
+        this.$off('mounted', delegate);
         this.$off('resized', delegate);
         this.$off('scrolled', delegate);
         this.$off('ticked', delegate);

--- a/packages/tests/decorators/withScrolledInView/withScrolledInView.spec.ts
+++ b/packages/tests/decorators/withScrolledInView/withScrolledInView.spec.ts
@@ -103,12 +103,14 @@ describe('The withScrolledInView decorator', () => {
     await advanceTimersByTimeAsync(1);
     expect(foo.$isMounted).toBe(true);
     expect(bar.$isMounted).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn2).toHaveBeenCalledTimes(1);
 
     foo.$emit('scrolled', { changed: { y: true, x: false } });
     bar.$emit('scrolled', { changed: { y: true, x: false } });
     await advanceTimersByTimeAsync(1100);
-    expect(fn).toHaveBeenCalledTimes(1);
-    expect(fn2).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn2).toHaveBeenCalledTimes(2);
   });
 
   it('should reset the damped values when destroyed', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `withScrolledInView` decorator adds support for a `scrolledInView(props)` method on a component, allowing custom behaviors to be triggered only when its root element is in view. 

Previously, the `scrolledInView(props)` method was called only on resize or scroll events, preventing execution of these custom behaviors if the user had not scrolled or resized its browser window. 

This PR fixes this by triggering the method once when the component is mounted. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
