### PR TITLE
[Feature] Improve breakpoint performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 
-- **useResize:** improve types ([4ee26087](https://github.com/studiometa/js-toolkit/commit/4ee26087))
+- **useResize:**
+  - improve types ([4ee26087](https://github.com/studiometa/js-toolkit/commit/4ee26087))
+  - improve breakpoint read performance ([#589](https://github.com/studiometa/js-toolkit/pull/589), [4da5ed4c](https://github.com/studiometa/js-toolkit/commit/4da5ed4c))
 - **useDrag:** refactor MODES to the service props ([#618](https://github.com/studiometa/js-toolkit/pull/618), [88c8bb54](https://github.com/studiometa/js-toolkit/commit/88c8bb54))
 - Reuse the existing `domScheduler` ([#607](https://github.com/studiometa/js-toolkit/issues/607), [#608](https://github.com/studiometa/js-toolkit/pull/608), [ebf96d2b](https://github.com/studiometa/js-toolkit/commit/ebf96d2b))
 

--- a/packages/docs/utils/cache.md
+++ b/packages/docs/utils/cache.md
@@ -1,6 +1,10 @@
 # cache
 
-Cache the result of a function with a single key or a list of keys.
+Cache the result of a function with a single key or a list of keys in nested maps.
+
+::: warning
+The `cache` function is global, meaning that keys are share across all `cache` calls in different files for the same runtime. Make sure to use a local context variable as the first key to avoid sharing cache between unrelated contexts.
+:::
 
 ## Usage
 

--- a/packages/js-toolkit/services/ResizeService.ts
+++ b/packages/js-toolkit/services/ResizeService.ts
@@ -3,6 +3,7 @@ import { AbstractService } from './AbstractService.js';
 import type { Features } from '../Base/features.js';
 import { features } from '../Base/features.js';
 import { debounce } from '../utils/debounce.js';
+import { cache } from '../utils/cache.js';
 
 export interface ResizeServiceProps<U extends Features['breakpoints'] = Features['breakpoints']> {
   width: number;
@@ -51,7 +52,10 @@ export class ResizeService<
         for (const [name, breakpoint] of Object.entries(
           this.breakpoints ?? features.get('breakpoints'),
         )) {
-          activeBreakpoints[name] = window.matchMedia(`(min-width: ${breakpoint})`).matches;
+          activeBreakpoints[name] = cache(
+            [this, window.innerWidth, window.innerHeight, breakpoint],
+            () => window.matchMedia(`(min-width: ${breakpoint})`).matches,
+          );
         }
 
         return activeBreakpoints as Record<keyof T, boolean>;

--- a/packages/tests/decorators/withBreakpointObserver.spec.ts
+++ b/packages/tests/decorators/withBreakpointObserver.spec.ts
@@ -93,7 +93,7 @@ describe('The withBreakpointObserver decorator', () => {
   it('should re-mount component when deleting both breakpoint options', async () => {
     const { fooResponsive, matchMedia } = await getContext();
     matchMedia.useMediaQuery('(min-width: 48rem)');
-    await resizeWindow({ width: 768 });
+    await resizeWindow({ width: 766 });
 
     expect(fooResponsive[1].$isMounted).toBe(true);
     matchMedia.useMediaQuery('(min-width: 64rem)');
@@ -103,7 +103,7 @@ describe('The withBreakpointObserver decorator', () => {
     fooResponsive[1].$el.removeAttribute('data-option-active-breakpoints');
     fooResponsive[1].$el.removeAttribute('data-option-inactive-breakpoints');
     matchMedia.useMediaQuery('(min-width: 48rem)');
-    await resizeWindow({ width: 768 });
+    await resizeWindow({ width: 766 });
 
     expect(fooResponsive[1].$isMounted).toBe(true);
   });
@@ -181,7 +181,7 @@ describe('The withBreakpointObserver decorator', () => {
     `;
 
     matchMedia.useMediaQuery('(min-width: 64rem)');
-    await resizeWindow({ width: 1024 });
+    await resizeWindow({ width: 1025 });
 
     await new App1(root).$mount();
     expect(fn.mock.calls).toMatchInlineSnapshot(`
@@ -195,7 +195,7 @@ describe('The withBreakpointObserver decorator', () => {
     fn.mockClear();
 
     matchMedia.useMediaQuery('(min-width: 48rem)');
-    await resizeWindow({ width: 768 });
+    await resizeWindow({ width: 769 });
 
     expect(fn.mock.calls).toMatchInlineSnapshot(`
       [
@@ -212,7 +212,7 @@ describe('The withBreakpointObserver decorator', () => {
     fn.mockClear();
 
     matchMedia.useMediaQuery('(min-width: 64rem)');
-    await resizeWindow({ width: 1024 });
+    await resizeWindow({ width: 1025 });
 
     expect(fn.mock.calls).toMatchInlineSnapshot(`
       [

--- a/packages/tests/services/ResizeService.spec.ts
+++ b/packages/tests/services/ResizeService.spec.ts
@@ -29,11 +29,12 @@ describe('The `useResize` service', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('should return the current active breakpoint', () => {
-    const service = useResize({ s: '0px', m: '1024px', l: '2048px' });
+  it('should return the current active breakpoint', async () => {
+    const service = useResize({ s: '0px', m: '1025px', l: '2048px' });
     expect(service.props().breakpoints).toEqual(['s', 'm', 'l']);
 
-    useMatchMedia('(min-width: 1024px)');
+    await resizeWindow({ width: 1025 });
+    useMatchMedia('(min-width: 1025px)');
     expect(service.props().activeBreakpoints).toEqual({
       s: false,
       m: true,
@@ -41,6 +42,7 @@ describe('The `useResize` service', () => {
     });
     expect(service.props().breakpoint).toBe('m');
 
+    await resizeWindow({ width: 2048 });
     useMatchMedia('(min-width: 2048px)');
     expect(service.props().activeBreakpoints).toEqual({
       s: false,


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `matchMedia` function is really slow in Safari, adding a cache will improve performance when accessing any of the breakpoint props from the resize service. 

See https://jsbench.me/kpm6eyv92r/1 in different browsers.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
