### PR TITLE
[Feature] Use the existing `domScheduler` for the `withScrolledInView` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **useResize:** improve types ([4ee26087](https://github.com/studiometa/js-toolkit/commit/4ee26087))
 - **useDrag:** refactor MODES to the service props ([#618](https://github.com/studiometa/js-toolkit/pull/618), [88c8bb54](https://github.com/studiometa/js-toolkit/commit/88c8bb54))
+- Reuse the existing `domScheduler` ([#607](https://github.com/studiometa/js-toolkit/issues/607), [#608](https://github.com/studiometa/js-toolkit/pull/608), [ebf96d2b](https://github.com/studiometa/js-toolkit/commit/ebf96d2b))
 
 ## [v3.0.2](https://github.com/studiometa/js-toolkit/compare/3.0.1..3.0.2) (2025-04-09)
 

--- a/packages/js-toolkit/decorators/withScrolledInView/withScrolledInView.ts
+++ b/packages/js-toolkit/decorators/withScrolledInView/withScrolledInView.ts
@@ -12,11 +12,9 @@ import {
   clamp01,
   getOffsetSizes,
   isFunction,
-  useScheduler,
+  domScheduler as scheduler,
 } from '../../utils/index.js';
 import { normalizeOffset, getEdges } from './utils.js';
-
-const scheduler = useScheduler(['update', 'render']);
 
 export interface WithScrolledInViewProps extends BaseProps {
   $options: {
@@ -226,11 +224,11 @@ export function withScrolledInView<S extends Base = Base>(
       super(element);
 
       const render = () => {
-        scheduler.update(() => {
+        scheduler.read(() => {
           // @ts-ignore
           const renderFn = this.__callMethod('scrolledInView', this.props);
           if (isFunction(renderFn)) {
-            scheduler.render(() => {
+            scheduler.write(() => {
               renderFn(this.__props);
             });
           }

--- a/packages/js-toolkit/services/RafService.ts
+++ b/packages/js-toolkit/services/RafService.ts
@@ -1,6 +1,6 @@
 import type { ServiceInterface } from './AbstractService.js';
 import { AbstractService } from './AbstractService.js';
-import { useScheduler } from '../utils/scheduler.js';
+import { domScheduler } from '../utils/scheduler.js';
 import { isFunction } from '../utils/is.js';
 
 export interface RafServiceProps {
@@ -10,8 +10,15 @@ export interface RafServiceProps {
 export type RafServiceInterface = ServiceInterface<RafServiceProps>;
 
 export class RafService extends AbstractService<RafServiceProps> {
+  /**
+   * @private
+   */
   isTicking = false;
-  scheduler = useScheduler(['update', 'render']);
+
+  /**
+   * @private
+   */
+  scheduler = domScheduler;
 
   props: RafServiceProps = {
     time: performance.now(),
@@ -19,10 +26,10 @@ export class RafService extends AbstractService<RafServiceProps> {
 
   trigger(props: RafServiceProps) {
     for (const callback of this.callbacks.values()) {
-      this.scheduler.update(() => {
+      this.scheduler.read(() => {
         const render = callback(props) as (() => unknown) | void;
         if (isFunction(render)) {
-          this.scheduler.render(() => {
+          this.scheduler.write(() => {
             // @ts-ignore
             render(props);
           });
@@ -46,6 +53,7 @@ export class RafService extends AbstractService<RafServiceProps> {
     this.isTicking = true;
     requestAnimationFrame(() => this.loop());
   }
+
   kill() {
     this.isTicking = false;
   }


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

Fix: #607

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR refactors the `withScrolledInView` decorator to reuse the existing `domScheluder` scheduler instead of a custom one.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
