### PR TITLE
[Feature] Enable static access to the drag service modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changed
+
+- **useDrag:** enable static access to the drag service modes ([#628](https://github.com/studiometa/js-toolkit/pull/628), [8253e4c9](https://github.com/studiometa/js-toolkit/commit/8253e4c9))
+
 ## [v3.0.3](https://github.com/studiometa/js-toolkit/compare/3.0.2..3.0.3) (2025-05-09)
 
 ### Changed

--- a/packages/js-toolkit/services/DragService.ts
+++ b/packages/js-toolkit/services/DragService.ts
@@ -68,6 +68,14 @@ export interface DragServiceOptions {
 let count = 0;
 
 export class DragService extends AbstractService<DragServiceProps> {
+  static MODES = {
+    START: 'start',
+    DRAG: 'drag',
+    DROP: 'drop',
+    INERTIA: 'inertia',
+    STOP: 'stop',
+  } as const;
+
   static config: ServiceConfig = [
     [
       (instance) => (instance as DragService).props.target,
@@ -97,13 +105,7 @@ export class DragService extends AbstractService<DragServiceProps> {
   props = {
     target: null,
     mode: undefined,
-    MODES: {
-      START: 'start',
-      DRAG: 'drag',
-      DROP: 'drop',
-      INERTIA: 'inertia',
-      STOP: 'stop',
-    },
+    MODES: DragService.MODES,
     isGrabbing: false,
     hasInertia: false,
     x: 0,


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Follow up of #618 to re-add static access to the drag service `MODES`. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
