### PR TITLE
[Feature] Add a `delta` props to the RafService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+
+- **useRaf:** add a `delta` property to the props ([#657](https://github.com/studiometa/js-toolkit/pull/657), [ca9fe570](https://github.com/studiometa/js-toolkit/commit/ca9fe570))
+
 ## [v3.0.5](https://github.com/studiometa/js-toolkit/compare/3.0.4..3.0.5) (2025-07-23)
 
 ### Changed

--- a/packages/docs/api/services/useRaf.md
+++ b/packages/docs/api/services/useRaf.md
@@ -15,6 +15,7 @@ const { add, remove, props } = useRaf();
 
 add('custom-id', (props) => {
   console.log(props.time); // latest `performance.now()`
+  console.log(props.delta); // time elapsed since the last frame
 
   // Read the DOM and compute values...
 
@@ -40,4 +41,14 @@ The time elapsed since the [time origin](https://developer.mozilla.org/en-US/doc
 
 ::: tip
 Read the [`performance.now()` documentation](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) to find out more on the time origin.
+:::
+
+### `delta`
+
+- Type: `Number`
+
+The time elapsed between the current frame and the previous frame in milliseconds. This value is `0` on the first frame and represents the frame duration for subsequent frames.
+
+::: tip
+The `delta` property is useful for creating frame-rate independent animations and calculations. You can use it to scale movement or animations based on the actual time elapsed between frames.
 :::

--- a/packages/js-toolkit/services/RafService.ts
+++ b/packages/js-toolkit/services/RafService.ts
@@ -5,6 +5,7 @@ import { isFunction } from '../utils/is.js';
 
 export interface RafServiceProps {
   time: DOMHighResTimeStamp;
+  delta: number;
 }
 
 export type RafServiceInterface = ServiceInterface<RafServiceProps>;
@@ -22,6 +23,7 @@ export class RafService extends AbstractService<RafServiceProps> {
 
   props: RafServiceProps = {
     time: performance.now(),
+    delta: 0,
   };
 
   trigger(props: RafServiceProps) {
@@ -39,7 +41,9 @@ export class RafService extends AbstractService<RafServiceProps> {
   }
 
   loop() {
-    this.props.time = performance.now();
+    const time = performance.now();
+    this.props.delta = time - this.props.time;
+    this.props.time = time;
     this.trigger(this.props);
 
     if (!this.isTicking) {

--- a/packages/tests/services/RafService.spec.ts
+++ b/packages/tests/services/RafService.spec.ts
@@ -30,6 +30,47 @@ describe('useRaf', () => {
     expect(typeof rafProps.time).toBe('number');
   });
 
+  it('should have a `delta` prop', async () => {
+    await advanceTimersByTimeAsync(16);
+    expect(typeof props().delta).toBe('number');
+    expect(typeof rafProps.delta).toBe('number');
+  });
+
+  it('should initialize delta to 0', () => {
+    expect(props().delta).toBe(0);
+  });
+
+  it('should provide delta in callback props', async () => {
+    await advanceTimersByTimeAsync(16);
+    expect(rafProps).toHaveProperty('delta');
+    expect(typeof rafProps.delta).toBe('number');
+  });
+
+  it('should update delta representing time between frames', async () => {
+    let firstTime, firstDelta, secondTime, secondDelta;
+    
+    const trackValues = vi.fn((p) => {
+      if (!firstTime) {
+        firstTime = p.time;
+        firstDelta = p.delta;
+      } else if (!secondTime) {
+        secondTime = p.time;
+        secondDelta = p.delta;
+      }
+    });
+    
+    add('trackValues', trackValues);
+    
+    await advanceTimersByTimeAsync(16);
+    await advanceTimersByTimeAsync(16);
+    
+    expect(firstDelta).toBeGreaterThanOrEqual(0);
+    expect(secondDelta).toBeGreaterThan(0);
+    expect(secondDelta).toBe(secondTime - firstTime);
+    
+    remove('trackValues');
+  });
+
   it('should trigger the callbacks', async () => {
     await advanceTimersByTimeAsync(16);
     expect(fn).toHaveBeenCalled();


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a new `delta` props to the `useRaf()` service.

```js
import { useRaf } from '@studiometa/js-toolkit';

useRaf().add('key', (props) => {
  console.log(props.delta); // time elapsed since the last call
});
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
