### PR TITLE
[Bugfix] `transform` throws if element is `null` or `undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. The format 
 
 - **useRaf:** add a `delta` property to the props ([#657](https://github.com/studiometa/js-toolkit/pull/657), [ca9fe570](https://github.com/studiometa/js-toolkit/commit/ca9fe570))
 
+### Fixed
+
+- **transform:** do not throw when element is not defined ([#658](https://github.com/studiometa/js-toolkit/issues/658), [#659](https://github.com/studiometa/js-toolkit/pull/659), [11f49a17](https://github.com/studiometa/js-toolkit/commit/11f49a17))
+
 ## [v3.0.5](https://github.com/studiometa/js-toolkit/compare/3.0.4..3.0.5) (2025-07-23)
 
 ### Changed

--- a/packages/js-toolkit/utils/css/transform.ts
+++ b/packages/js-toolkit/utils/css/transform.ts
@@ -43,6 +43,8 @@ export function transform(
   elementOrElements: HTMLElement | HTMLElement[] | NodeListOf<HTMLElement>,
   props: TransformProps,
 ): string {
+  if (!elementOrElements) return
+
   let value = '';
 
   if (isDefined(props.x) || isDefined(props.y) || isDefined(props.z)) {

--- a/packages/tests/utils/css/transform.spec.ts
+++ b/packages/tests/utils/css/transform.spec.ts
@@ -17,6 +17,13 @@ describe('The `transform` utility function', () => {
     expect(div.style.transform.trim()).toBe(result);
   });
 
+  it('should not throw if element is not defined', () => {
+    expect(() => {
+      // @ts-expect-error null is ok here
+      transform(null, { x: 100 });
+    }).not.toThrow();
+  });
+
   for (const [name, value, result] of [
     ['x', 100, 'translate3d(100px, 0px, 0px)'],
     ['y', 100, 'translate3d(0px, 100px, 0px)'],


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#658 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes a bug where the `transform` utility function would throw if it receives `null` or `undefined` as its first parameter. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
