### PR TITLE
[Feature] Animation utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
+- Add a `smoothTo` utility function ([#660](https://github.com/studiometa/js-toolkit/pull/660), [f4d7b349](https://github.com/studiometa/js-toolkit/commit/f4d7b349))
+- Add a `wrap` utility function ([#660](https://github.com/studiometa/js-toolkit/pull/660), [866ed3a4](https://github.com/studiometa/js-toolkit/commit/866ed3a4))
+- Add a `spring` function ([#660](https://github.com/studiometa/js-toolkit/pull/660), [1e06f792](https://github.com/studiometa/js-toolkit/commit/1e06f792))
+- **tween:** add support for spring physics ([#660](https://github.com/studiometa/js-toolkit/pull/660), [fe079359](https://github.com/studiometa/js-toolkit/commit/fe079359))
+- **animate:** add support for spring physics ([#660](https://github.com/studiometa/js-toolkit/pull/660), [fe079359](https://github.com/studiometa/js-toolkit/commit/fe079359))
 - **useRaf:** add a `delta` property to the props ([#657](https://github.com/studiometa/js-toolkit/pull/657), [ca9fe570](https://github.com/studiometa/js-toolkit/commit/ca9fe570))
 
 ### Fixed

--- a/packages/demo/src/js/components/AnimateTest.js
+++ b/packages/demo/src/js/components/AnimateTest.js
@@ -29,7 +29,11 @@ export default class AnimateTest extends Base {
       steps: Array,
       smooth: {
         type: Number,
-        default: undefined,
+        default: false,
+      },
+      spring: {
+        type: Number,
+        default: false,
       },
       duration: {
         type: Number,
@@ -68,6 +72,7 @@ export default class AnimateTest extends Base {
       {
         duration: this.$options.duration,
         smooth: this.$options.smooth,
+        spring: this.$options.spring,
         easing: ease[this.$options.easing],
         onProgress: (progress) => {
           domScheduler.write(() => {

--- a/packages/demo/src/templates/pages/index.twig
+++ b/packages/demo/src/templates/pages/index.twig
@@ -12,7 +12,25 @@
       {% include '@components/animate-test.twig' %}
       {% include '@components/animate-test.twig' with {
         easing: ' ',
-        smooth: '0.05',
+        attr: {
+          data_option_spring: 0.1,
+          data_option_smooth: 0.6,
+        },
+        steps: [
+          {},
+          {
+            scale: 1.5,
+          },
+          {
+            scale: 1,
+          }
+        ]
+      } %}
+      {% include '@components/animate-test.twig' with {
+        easing: ' ',
+        attr: {
+          data_option_smooth: 0.1,
+        },
         steps: [
           {},
           {

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -361,6 +361,9 @@ function getUtilsSidebar() {
         { text: 'map', link: '/utils/math/map.html' },
         { text: 'mean', link: '/utils/math/mean.html' },
         { text: 'round', link: '/utils/math/round.html' },
+        { text: 'smoothTo', link: '/utils/math/smoothTo.html' },
+        { text: 'spring', link: '/utils/math/spring.html' },
+        { text: 'wrap', link: '/utils/math/wrap.html' },
       ],
     },
     {

--- a/packages/docs/utils/math/smoothTo.md
+++ b/packages/docs/utils/math/smoothTo.md
@@ -1,0 +1,145 @@
+# smoothTo
+
+Create a smoothing function to smooth transitions between values using damping or spring physics.
+
+## Usage
+
+```js twoslash
+import { smoothTo } from '@studiometa/js-toolkit/utils';
+
+const x = smoothTo(0);
+x.subscribe((value) => console.log(value));
+x(100); // Smoothly transition from 0 to 100
+```
+
+### Parameters
+
+- `start` (`number`): The initial value, defaults to `0`
+- `options` (`SmoothToOptions`): Configuration options
+
+### Options
+
+- `damping` (`number`): Damping factor, the smaller the smoother, defaults to `0.6`
+- `precision` (`number`): Precision used to decide when the smoothing should end, defaults to `1 / 1e8`
+- `spring` (`boolean`): Enable spring physics, defaults to `true` if `stiffness` or `mass` is set, `false` otherwise
+- `stiffness` (`number`): Stiffness factor for spring physics, the higher the stiffer, defaults to `0.1`
+- `mass` (`number`): Mass factor when spring is enabled, the higher the heavier, defaults to `1`
+
+### Return value
+
+The `smoothTo` function returns a function with the following methods:
+
+#### `(newValue)`
+
+Call the function with a new value to start transitioning to it, or without arguments to get the current smoothed value.
+
+```js twoslash
+import { smoothTo } from '@studiometa/js-toolkit/utils';
+
+const smooth = smoothTo(0);
+smooth(100); // Start transition to 100
+console.log(smooth()); // Get current smoothed value
+```
+
+#### `subscribe(callback)`
+
+Subscribe a callback to value updates. Returns an unsubscribe function.
+
+```js twoslash
+import { smoothTo } from '@studiometa/js-toolkit/utils';
+
+const smooth = smoothTo(0);
+const unsubscribe = smooth.subscribe((value) => {
+  console.log('New value:', value);
+});
+
+// Later...
+unsubscribe();
+```
+
+#### `unsubscribe(callback)`
+
+Unsubscribe a specific callback from value updates.
+
+#### `raw()`
+
+Get the raw target value (not the smoothed value).
+
+#### `damping(value?)`
+
+Get or set the damping factor.
+
+#### `precision(value?)`
+
+Get or set the precision.
+
+#### `stiffness(value?)`
+
+Get or set the stiffness factor.
+
+#### `spring(value?)`
+
+Get or set the spring option.
+
+### Types
+
+```ts
+type SmoothToOptions = Partial<{
+  damping: number;
+  precision: number;
+  spring: boolean;
+  stiffness: number;
+  mass: number;
+}>;
+
+interface SmoothToFunction {
+  (newValue?: number): number;
+  subscribe: (fn: (value: number) => any) => () => boolean;
+  unsubscribe: (fn: (value: number) => any) => boolean;
+  raw: () => number;
+  damping: (val?: number) => number;
+  precision: (val?: number) => number;
+  stiffness: (val?: number) => number;
+  spring: (val?: boolean) => boolean;
+}
+
+function smoothTo(start?: number, options?: SmoothToOptions): SmoothToFunction;
+```
+
+## Examples
+
+### Basic damping
+
+```js twoslash
+import { smoothTo } from '@studiometa/js-toolkit/utils';
+
+const position = smoothTo(0, { damping: 0.1 });
+
+position.subscribe((value) => {
+  // Called on each frame during the transition
+  element.style.transform = `translateX(${value}px)`;
+});
+
+// Start transition to 300
+position(300);
+```
+
+### Spring physics
+
+```js twoslash
+import { smoothTo } from '@studiometa/js-toolkit/utils';
+
+const springValue = smoothTo(0, {
+  spring: true,
+  stiffness: 0.2,
+  damping: 0.8,
+  mass: 1.5
+});
+
+springValue.subscribe((value) => {
+  element.style.scale = value;
+});
+
+// Animate to 1 with spring physics
+springValue(1);
+```

--- a/packages/docs/utils/math/spring.md
+++ b/packages/docs/utils/math/spring.md
@@ -1,0 +1,91 @@
+# spring
+
+Get the next spring value using velocity and spring physics.
+
+## Usage
+
+```js twoslash
+import { spring } from '@studiometa/js-toolkit/utils';
+
+let currentValue = 0;
+let currentVelocity = 0;
+const targetValue = 100;
+
+[currentValue, currentVelocity] = spring(
+  targetValue,
+  currentValue,
+  currentVelocity,
+  0.1, // stiffness
+  0.6, // damping
+  1,   // mass
+  0.01 // precision
+);
+
+console.log(currentValue, currentVelocity);
+```
+
+### Parameters
+
+- `targetValue` (`number`): The final value
+- `currentValue` (`number`): The current value
+- `currentVelocity` (`number`): The current velocity
+- `stiffness` (`number`): The spring stiffness (or tension) factor, defaults to `0.1`
+- `damping` (`number`): The damping factor (or friction) to reduce oscillation, defaults to `0.6`
+- `mass` (`number`): The mass factor affecting acceleration, defaults to `1`
+- `precision` (`number`): The precision used to calculate the latest value, defaults to `1/1e4`
+
+### Return value
+
+- `[number, number]`: A tuple containing the next value and velocity
+
+The function returns a tuple where:
+- First element: The next position value
+- Second element: The next velocity (set to `0` when the target is reached)
+
+### Physics explanation
+
+The spring function simulates a spring-damper system where:
+
+- **Stiffness**: Controls how quickly the spring tries to reach the target (higher = faster, more rigid)
+- **Damping**: Reduces oscillation and controls energy loss (higher = less bouncy)
+- **Mass**: Affects how the object responds to forces (higher = slower acceleration, more inertia)
+- **Precision**: Determines when the spring is considered "at rest"
+
+### Types
+
+```ts
+function spring(
+  targetValue: number,
+  currentValue: number,
+  currentVelocity: number,
+  stiffness?: number,
+  damping?: number,
+  mass?: number,
+  precision?: number,
+): [number, number];
+```
+
+## Examples
+
+### Animation loop
+
+```js twoslash
+import { spring } from '@studiometa/js-toolkit/utils';
+
+let position = 0;
+let velocity = 0;
+const target = 300;
+
+function animate() {
+  [position, velocity] = spring(target, position, velocity);
+
+  element.style.transform = `translateX(${position}px)`;
+
+  // Continue animating if not at target
+  if (position !== target) {
+    requestAnimationFrame(animate);
+  }
+}
+
+animate();
+```

--- a/packages/docs/utils/math/wrap.md
+++ b/packages/docs/utils/math/wrap.md
@@ -1,0 +1,67 @@
+# wrap
+
+Wrap a value within a specified range, creating a repeating cycle.
+
+## Usage
+
+```js twoslash
+import { wrap } from '@studiometa/js-toolkit/utils';
+
+wrap(5, 0, 3); // 2
+wrap(-1, 0, 3); // 2
+wrap(10, 0, 3); // 1
+```
+
+### Parameters
+
+- `value` (`number`): The value to wrap
+- `min` (`number`): The minimum value of the range
+- `max` (`number`): The maximum value of the range
+
+### Return value
+
+- `number`: The wrapped value within the specified range
+
+### Behavior
+
+The `wrap` function ensures that:
+- Values above `max` wrap around to the beginning of the range
+- Values below `min` wrap around to the end of the range  
+- If `min` equals `max`, the function returns `min`
+- The result is always within `[min, max)` (inclusive of min, exclusive of max)
+
+### Types
+
+```ts
+function wrap(value: number, min: number, max: number): number;
+```
+
+## Examples
+
+### Carousel/slider
+
+```js twoslash
+import { wrap } from '@studiometa/js-toolkit/utils';
+
+let currentIndex = 0;
+const totalSlides = 5;
+
+// Navigate forward
+currentIndex = wrap(currentIndex + 1, 0, totalSlides); // 1, 2, 3, 4, 0, 1...
+
+// Navigate backward
+currentIndex = wrap(currentIndex - 1, 0, totalSlides); // 4, 3, 2, 1, 0, 4...
+```
+
+### Angle wrapping
+
+```js twoslash
+import { wrap } from '@studiometa/js-toolkit/utils';
+
+// Keep angles between 0 and 360 degrees
+let angle = 450;
+angle = wrap(angle, 0, 360); // 90
+
+angle = -45;
+angle = wrap(angle, 0, 360); // 315
+```

--- a/packages/docs/utils/tween.md
+++ b/packages/docs/utils/tween.md
@@ -9,7 +9,7 @@ import { tween, easeInOutExpo } from '@studiometa/js-toolkit/utils';
 
 const tw = tween(
   (progress) => {
-    document.body.innerHTML = progress;
+    console.log(progress); // from 0 to 1
   },
   {
     duration: 10,
@@ -24,6 +24,19 @@ tw.start();
 
 - `callback` (`(progress:number) => void`): the function called for each frame
 - `options` (`Options`): options for the animation
+
+### Options
+
+- `duration` (`number`): The duration in seconds, defaults to `1`
+- `delay` (`number`): The delay in seconds, defaults to `0`
+- `easing` (`EasingFunction | BezierCurve`): The easing function or bezier curve, defaults to linear
+- `smooth` (`true | number`): The smooth factor. Setting this disables the `duration` option. If `true`, uses default damping; if a number, uses that as damping factor
+- `spring` (`true | number`): Enable spring transition. Setting this disables the `duration` option. If `true`, uses default stiffness of `0.1`; if a number, uses that as stiffness
+- `mass` (`number`): When spring physics are enabled, the mass factor, defaults to `1`
+- `precision` (`number`): The precision for when to consider the tween finished, defaults to `0.00001`
+- `onStart` (`(progress: number) => void`): Callback executed on start
+- `onProgress` (`(progress: number) => void`): Callback executed each frame
+- `onFinish` (`(progress: number) => void`): Callback executed when finished
 
 ### Return value
 
@@ -72,6 +85,9 @@ interface Options {
   duration?: number;
   delay?: number;
   smooth?: true | number;
+  spring?: true | number;
+  mass?: number;
+  precision?: number;
   easing?: EasingFunction | BezierCurve;
   onStart?: (progress: number) => void;
   onProgress?: (progress: number) => void;
@@ -90,4 +106,58 @@ function tween(
   callback: (progress: number) => void,
   options?: Options,
 ): Tween;
+```
+
+## Examples
+
+### Cubic bezier easing
+
+```js twoslash {8}
+import { tween } from '@studiometa/js-toolkit/utils';
+
+const easedTween = tween(
+  (progress) => {
+    element.style.transform = `scale(${progress})`;
+  },
+  {
+    easing: [0.19, 1, 0.22, 1],
+  },
+);
+
+easedTween.start();
+```
+
+### Spring physics
+
+```js twoslash {7-10}
+import { tween } from '@studiometa/js-toolkit/utils';
+
+const springTween = tween(
+  (progress) => {
+    element.style.transform = `scale(${progress})`;
+  },
+  {
+    spring: 0.2, // stiffness
+    mass: 1.5, // mass
+  },
+);
+
+springTween.start();
+```
+
+### Smooth damping
+
+```js twoslash {7-9}
+import { tween } from '@studiometa/js-toolkit/utils';
+
+const smoothTween = tween(
+  (progress) => {
+    element.style.opacity = progress;
+  },
+  {
+    smooth: 0.1, // damping factor
+  },
+);
+
+smoothTween.start();
 ```

--- a/packages/js-toolkit/utils/math/index.ts
+++ b/packages/js-toolkit/utils/math/index.ts
@@ -11,3 +11,5 @@ export { lerp } from './lerp.js';
 export { map } from './map.js';
 export { round } from './round.js';
 export { mean } from './mean.js';
+export { smoothTo } from './smoothTo.js';
+export { wrap } from './wrap.js';

--- a/packages/js-toolkit/utils/math/index.ts
+++ b/packages/js-toolkit/utils/math/index.ts
@@ -5,6 +5,7 @@ export { createRange } from './createRange.js';
 export { clamp } from './clamp.js';
 export { clamp01 } from './clamp01.js';
 export { damp } from './damp.js';
+export { spring } from './spring.js';
 export { inertiaFinalValue } from './inertiaFinalValue.js';
 export { lerp } from './lerp.js';
 export { map } from './map.js';

--- a/packages/js-toolkit/utils/math/smoothTo.ts
+++ b/packages/js-toolkit/utils/math/smoothTo.ts
@@ -1,0 +1,139 @@
+import { useRaf } from '../../services/RafService.js';
+import { damp } from './damp.js';
+import { spring } from './spring.js';
+import { isFunction, isDefined } from '../is.js';
+
+export type SmoothToOptions = Partial<{
+  /**
+   * Damping factor, the smaller the smoother, defaults to 0.6.
+   */
+  damping: number;
+  /**
+   * Precision used to decide when the smoothing should end, defaults to 1 / 1e8.
+   */
+  precision: number;
+  /**
+   * Enable spring physics, defaults to `true` if one of `stiffness` or `mass` is set, defaults to `false` otherwise.
+   */
+  spring: boolean;
+  /**
+   * Stiffness factor for spring physics, the higher the stiffer, defaults to 0.1.
+   */
+  stiffness: number;
+  /**
+   * Mass factor when spring is enabled, the higher the heavier, defaults to 1.
+   */
+  mass: number;
+}>;
+
+/**
+ * Create a smoothing function, to smooth transitino between values.
+ * ```js
+ * const x = smoothTo(0);
+ * x.subscribe((value) => console.log(value));
+ * x(100);
+ */
+export function smoothTo(start = 0, options: SmoothToOptions = {}) {
+  const { add, has, remove } = useRaf();
+  const key = Symbol();
+  const fns = new Set<(value: number) => any>();
+
+  let damping = options.damping ?? 0.6;
+  let precision = options.precision ?? 1 / 1e8;
+  let stiffness = options.stiffness ?? 0.1;
+  let mass = options.mass ?? 1;
+  let isSpring = options.spring === true || isDefined(options.stiffness) || isDefined(options.mass);
+
+  let value = start;
+  let smoothed = start;
+  let velocity = 0;
+
+  /**
+   * Callback for the useRaf service.
+   */
+  function tick() {
+    if (isSpring) {
+      [smoothed, velocity] = spring(value, smoothed, velocity, stiffness, damping, mass, precision);
+    } else {
+      smoothed = damp(value, smoothed, damping, precision);
+    }
+
+    for (const fn of fns) {
+      fn(smoothed);
+    }
+
+    if (smoothed === value) remove(key);
+  }
+
+  /**
+   * Subscribe a callback to the value update.
+   */
+  function subscribe(fn: (value: number) => any) {
+    if (isFunction(fn)) {
+      fns.add(fn);
+    }
+
+    return () => unsubscribe(fn);
+  }
+
+  /**
+   * Unsubscribe a callback to the value update.
+   */
+  function unsubscribe(fn: (value: number) => any) {
+    return fns.delete(fn);
+  }
+
+  /**
+   * Update the value if a parameter is given, get the value if no parameter is given.
+   */
+  function update(newValue?: number): number {
+    if (!isDefined(newValue)) {
+      return smoothed;
+    }
+
+    value = newValue;
+
+    if (!has(key)) {
+      add(key, tick);
+    }
+
+    return smoothed;
+  }
+
+  /**
+   * Subscribe a callback to the value update.
+   */
+  update.subscribe = subscribe;
+
+  /**
+   * Unsubscribe a callback from the value update.
+   */
+  update.unsubscribe = unsubscribe;
+
+  /**
+   * Get the raw target value.
+   */
+  update.raw = () => value;
+  /**
+   * Get or set the damping factor.
+   */
+  update.damping = (val?: number) => (damping = val ?? damping);
+
+  /**
+   * Get or set the precision.
+   */
+  update.precision = (val?: number) => (precision = val ?? precision);
+
+  /**
+   * Get or set the stiffness factor.
+   */
+  update.stiffness = (val?: number) => (stiffness = val ?? stiffness);
+
+  /**
+   * Get or set the spring option.
+   */
+  update.spring = (val?: boolean) => (isSpring = val ?? isSpring);
+
+  update(start);
+  return update;
+}

--- a/packages/js-toolkit/utils/math/smoothTo.ts
+++ b/packages/js-toolkit/utils/math/smoothTo.ts
@@ -27,11 +27,16 @@ export type SmoothToOptions = Partial<{
 }>;
 
 /**
- * Create a smoothing function, to smooth transitino between values.
+ * Create a smoothing function that will smoothly tween between two values.
+ * @param {number} [start] The initial value.
+ * @param {SmoothToOptions} [options] Options for the transition.
+ * @see https://js-toolkit.studiometa.dev/utils/math/smoothTo.html
+ * @example
  * ```js
  * const x = smoothTo(0);
  * x.subscribe((value) => console.log(value));
- * x(100);
+ * x(100); // 0.1
+ * ```
  */
 export function smoothTo(start = 0, options: SmoothToOptions = {}) {
   const { add, has, remove } = useRaf();

--- a/packages/js-toolkit/utils/math/spring.ts
+++ b/packages/js-toolkit/utils/math/spring.ts
@@ -1,6 +1,5 @@
 /**
  * Get the next spring value using velocity and spring physics.
- *
  * @param   {number} targetValue The final value.
  * @param   {number} currentValue The current value.
  * @param   {number} currentVelocity The current velocity.
@@ -9,6 +8,7 @@
  * @param   {number} [mass=1] The mass factor affecting acceleration, defaults to 1.
  * @param   {number} [precision=1/1e4] The precision used to calculate the latest value, defaults to 1/1e4.
  * @returns {[number, number]} The next value and velocity.
+ * @see https://js-toolkit.studiometa.dev/utils/math/spring.html
  */
 export function spring(
   targetValue: number,

--- a/packages/js-toolkit/utils/math/spring.ts
+++ b/packages/js-toolkit/utils/math/spring.ts
@@ -1,0 +1,31 @@
+/**
+ * Get the next spring value using velocity and spring physics.
+ *
+ * @param   {number} targetValue The final value.
+ * @param   {number} currentValue The current value.
+ * @param   {number} currentVelocity The current velocity.
+ * @param   {number} [stiffness=0.1] The spring stiffness (or tension) factor, defaults to 0.1.
+ * @param   {number} [damping=0.8] The damping factor (or friction) to reduce oscillation, defaults to 0.6.
+ * @param   {number} [mass=1] The mass factor affecting acceleration, defaults to 1.
+ * @param   {number} [precision=1/1e4] The precision used to calculate the latest value, defaults to 1/1e4.
+ * @returns {[number, number]} The next value and velocity.
+ */
+export function spring(
+  targetValue: number,
+  currentValue: number,
+  currentVelocity: number,
+  stiffness = 0.1,
+  damping = 0.6,
+  mass = 1,
+  precision = 1 / 1e4,
+): [number, number] {
+  const force = (targetValue - currentValue) * stiffness;
+  const acceleration = force / mass;
+  const velocity = currentVelocity * damping + acceleration;
+  const value =
+    Math.abs(targetValue - currentValue) < precision && Math.abs(velocity) < precision
+      ? targetValue
+      : currentValue + velocity;
+
+  return [value, value === targetValue ? 0 : velocity];
+}

--- a/packages/js-toolkit/utils/math/wrap.ts
+++ b/packages/js-toolkit/utils/math/wrap.ts
@@ -1,0 +1,7 @@
+/**
+ * Wrap a value in the min and max range.
+ */
+export function wrap(value: number, min: number, max: number): number {
+  const range = max - min;
+  return min === max ? min : ((range + ((value - min) % range)) % range) + min;
+}

--- a/packages/js-toolkit/utils/tween.ts
+++ b/packages/js-toolkit/utils/tween.ts
@@ -101,6 +101,7 @@ export function normalizeEase(ease: EasingFunction | BezierCurve): EasingFunctio
 
 /**
  * Tween from 0 to 1.
+ * @see https://js-toolkit.studiometa.dev/utils/tween.html
  */
 export function tween(callback: (progress: number) => unknown, options: TweenOptions = {}): Tween {
   const raf = useRaf();

--- a/packages/tests/utils/index.spec.ts
+++ b/packages/tests/utils/index.spec.ts
@@ -98,7 +98,9 @@ describe('@studiometa/js-toolkit/utils exports', () => {
         "round",
         "saveActiveElement",
         "scrollTo",
+        "smoothTo",
         "snakeCase",
+        "spring",
         "startsWith",
         "throttle",
         "toggleClass",
@@ -120,6 +122,7 @@ describe('@studiometa/js-toolkit/utils exports', () => {
         "withoutTrailingCharacters",
         "withoutTrailingCharactersRecursive",
         "withoutTrailingSlash",
+        "wrap",
       ]
     `);
   });

--- a/packages/tests/utils/math/smoothTo.spec.ts
+++ b/packages/tests/utils/math/smoothTo.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { smoothTo, wait } from '@studiometa/js-toolkit/utils';
+
+describe('smoothTo method', () => {
+  it('should create a smooth transition function with default options', () => {
+    const smooth = smoothTo(0);
+    expect(typeof smooth).toBe('function');
+    expect(typeof smooth.subscribe).toBe('function');
+    expect(typeof smooth.unsubscribe).toBe('function');
+    expect(typeof smooth.raw).toBe('function');
+    expect(typeof smooth.damping).toBe('function');
+    expect(typeof smooth.precision).toBe('function');
+    expect(typeof smooth.stiffness).toBe('function');
+    expect(typeof smooth.spring).toBe('function');
+  });
+
+  it('should return current smoothed value when called without parameters', () => {
+    const smooth = smoothTo(5);
+    expect(smooth()).toBe(5);
+  });
+
+  it('should return raw target value', () => {
+    const smooth = smoothTo(0);
+    smooth(10);
+    expect(smooth.raw()).toBe(10);
+    expect(smooth()).toBe(0);
+  });
+
+  it('should subscribe and unsubscribe to value updates', () => {
+    const smooth = smoothTo(0);
+    const callback = vi.fn();
+    
+    const unsubscribe = smooth.subscribe(callback);
+    expect(typeof unsubscribe).toBe('function');
+    
+    expect(smooth.unsubscribe(callback)).toBe(true);
+    expect(smooth.unsubscribe(callback)).toBe(false);
+  });
+
+  it('should allow changing options dynamically', () => {
+    const smooth = smoothTo(0);
+    
+    expect(smooth.damping(0.8)).toBe(0.8);
+    expect(smooth.damping()).toBe(0.8);
+    expect(smooth.precision(0.001)).toBe(0.001);
+    expect(smooth.precision()).toBe(0.001);
+    expect(smooth.stiffness(0.15)).toBe(0.15);
+    expect(smooth.stiffness()).toBe(0.15);
+    expect(smooth.spring(true)).toBe(true);
+    expect(smooth.spring()).toBe(true);
+  });
+
+  it('should ignore non-function subscribers', () => {
+    const smooth = smoothTo(0);
+    
+    expect(() => {
+      smooth.subscribe(null as any);
+      smooth.subscribe(undefined as any);
+      smooth.subscribe('invalid' as any);
+    }).not.toThrow();
+  });
+
+  it('should return false when unsubscribing non-existent callback', () => {
+    const smooth = smoothTo(0);
+    const nonExistentFn = vi.fn();
+    
+    expect(smooth.unsubscribe(nonExistentFn)).toBe(false);
+  });
+
+  it('should handle start value initialization', () => {
+    const smooth = smoothTo(42);
+    expect(smooth()).toBe(42);
+    expect(smooth.raw()).toBe(42);
+  });
+
+  it('should update target value and return smoothed value', () => {
+    const smooth = smoothTo(0);
+    
+    const result = smooth(10);
+    expect(smooth.raw()).toBe(10);
+    expect(typeof result).toBe('number');
+  });
+
+  it('should support different starting values', () => {
+    const smooth1 = smoothTo();
+    const smooth2 = smoothTo(100);
+    const smooth3 = smoothTo(-50);
+    
+    expect(smooth1()).toBe(0);
+    expect(smooth2()).toBe(100);
+    expect(smooth3()).toBe(-50);
+  });
+
+  it('should support different option configurations', () => {
+    const smooth1 = smoothTo(0, { damping: 0.8 });
+    const smooth2 = smoothTo(0, { spring: true });
+    const smooth3 = smoothTo(0, { precision: 0.01 });
+    const smooth4 = smoothTo(0, { stiffness: 0.2 });
+    
+    expect(typeof smooth1).toBe('function');
+    expect(typeof smooth2).toBe('function');
+    expect(typeof smooth3).toBe('function');
+    expect(typeof smooth4).toBe('function');
+  });
+
+  it('should handle subscription management correctly', () => {
+    const smooth = smoothTo(0);
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+    
+    const unsubscribe1 = smooth.subscribe(callback1);
+    const unsubscribe2 = smooth.subscribe(callback2);
+    
+    expect(typeof unsubscribe1).toBe('function');
+    expect(typeof unsubscribe2).toBe('function');
+    
+    unsubscribe1();
+    unsubscribe2();
+  });
+
+  it('should execute subscribed functions correctly', async () => {
+    const smooth = smoothTo(0);
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    const unsubscribe1 = smooth.subscribe(callback1);
+    const unsubscribe2 = smooth.subscribe(callback2);
+
+    smooth(1);
+    await wait(100);
+    expect(callback1).toHaveBeenCalled();
+    expect(callback2).toHaveBeenCalled();
+
+    unsubscribe1();
+    unsubscribe2();
+  });
+
+  it('should work with complex option combinations', () => {
+    const smooth = smoothTo(0, { 
+      damping: 0.7, 
+      spring: true, 
+      stiffness: 0.3, 
+      precision: 0.001 
+    });
+    
+    expect(smooth.damping(0.5)).toBe(0.5);
+    expect(smooth.spring(false)).toBe(false);
+    expect(smooth.stiffness(0.4)).toBe(0.4);
+    expect(smooth.precision(0.01)).toBe(0.01);
+  });
+});

--- a/packages/tests/utils/math/spring.spec.ts
+++ b/packages/tests/utils/math/spring.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { spring } from '@studiometa/js-toolkit/utils';
+
+describe('spring method', () => {
+  it('should give the correct value and velocity', () => {
+    // Starting from rest
+    const result1 = spring(10, 0, 0, 0.1, 0.8);
+    expect(result1[0]).toBe(1);
+    expect(result1[1]).toBe(1);
+
+    // With existing velocity
+    const result2 = spring(10, 5, 2, 0.1, 0.8);
+    expect(result2[0]).toBe(7.1);
+    expect(result2[1]).toBe(2.1);
+
+    // Already at target
+    const result3 = spring(10, 10, 0, 0.1, 0.8);
+    expect(result3[0]).toBe(10);
+    expect(result3[1]).toBe(0);
+
+    // Different stiffness
+    const result4 = spring(10, 0, 0, 0.2, 0.8);
+    expect(result4[0]).toBe(2);
+    expect(result4[1]).toBe(2);
+
+    // Different damping
+    const result5 = spring(10, 5, 2, 0.1, 0.5);
+    expect(result5[0]).toBe(6.5);
+    expect(result5[1]).toBe(1.5);
+  });
+
+  it('should round the result when the difference and velocity are small', () => {
+    const result = spring(10, 9.9999, 0.0001);
+    expect(result[0]).toBe(10);
+    expect(result[1]).toBe(0);
+  });
+
+  it('should handle negative values', () => {
+    const result = spring(-10, 0, 0, 0.1, 0.8);
+    expect(result[0]).toBe(-1);
+    expect(result[1]).toBe(-1);
+  });
+
+  it('should handle oscillation scenarios', () => {
+    // Simulate a bouncing motion
+    let currentValue = 0;
+    let currentVelocity = 0;
+    const targetValue = 10;
+    
+    // First step
+    const step1 = spring(targetValue, currentValue, currentVelocity, 0.2, 0.7);
+    expect(step1[0]).toBeCloseTo(2, 5);
+    expect(step1[1]).toBeCloseTo(2, 5);
+
+    // Second step with the new velocity
+    const step2 = spring(targetValue, step1[0], step1[1], 0.2, 0.7);
+    expect(step2[0]).toBeCloseTo(5, 5);
+    expect(step2[1]).toBeCloseTo(3, 5);
+  });
+});

--- a/packages/tests/utils/math/wrap.spec.ts
+++ b/packages/tests/utils/math/wrap.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { wrap } from '@studiometa/js-toolkit/utils';
+
+describe('wrap method', () => {
+  it('should wrap a value within the given range', () => {
+    expect(wrap(5, 0, 10)).toBe(5);
+    expect(wrap(0, 0, 10)).toBe(0);
+    expect(wrap(10, 0, 10)).toBe(0);
+    expect(wrap(15, 0, 10)).toBe(5);
+    expect(wrap(-5, 0, 10)).toBe(5);
+    expect(wrap(25, 0, 10)).toBe(5);
+  });
+
+  it('should handle negative ranges', () => {
+    expect(wrap(-5, -10, 0)).toBe(-5);
+    expect(wrap(-15, -10, 0)).toBe(-5);
+    expect(wrap(5, -10, 0)).toBe(-5);
+  });
+
+  it('should handle negative min with positive max', () => {
+    expect(wrap(5, -5, 5)).toBe(-5);
+    expect(wrap(-3, -5, 5)).toBe(-3);
+    expect(wrap(12, -5, 5)).toBe(2);
+    expect(wrap(-12, -5, 5)).toBe(-2);
+  });
+
+  it('should handle fractional values', () => {
+    expect(wrap(1.5, 0, 1)).toBeCloseTo(0.5, 10);
+    expect(wrap(2.3, 0, 1)).toBeCloseTo(0.3, 10);
+    expect(wrap(-0.7, 0, 1)).toBeCloseTo(0.3, 10);
+  });
+
+  it('should handle same min and max values', () => {
+    expect(wrap(5, 0, 0)).toBe(0);
+    expect(wrap(-5, 0, 0)).toBe(0);
+    expect(wrap(-5, 5, 5)).toBe(5);
+  });
+
+  it('should handle large ranges', () => {
+    expect(wrap(1005, 0, 100)).toBe(5);
+    expect(wrap(-995, 0, 100)).toBe(5);
+  });
+});

--- a/packages/tests/utils/tween.spec.ts
+++ b/packages/tests/utils/tween.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tween } from '@studiometa/js-toolkit/utils';
+import { useFakeTimers, useRealTimers, advanceTimersByTimeAsync } from '#test-utils';
+
+beforeEach(() => useFakeTimers());
+afterEach(() => useRealTimers());
+
+describe('tween method', () => {
+  it('should create a tween with control methods', () => {
+    const callback = vi.fn();
+    const tw = tween(callback);
+    
+    expect(typeof tw.start).toBe('function');
+    expect(typeof tw.finish).toBe('function');
+    expect(typeof tw.pause).toBe('function');
+    expect(typeof tw.play).toBe('function');
+    expect(typeof tw.progress).toBe('function');
+  });
+
+  it('should execute callback with progress values', () => {
+    const callback = vi.fn();
+    const tw = tween(callback);
+    
+    tw.progress(0.5);
+    expect(callback).toHaveBeenCalledWith(0.5);
+    
+    tw.progress(1);
+    expect(callback).toHaveBeenCalledWith(1);
+  });
+
+  it('should support custom easing function', () => {
+    const callback = vi.fn();
+    const customEase = (t: number) => t * t;
+    const tw = tween(callback, { easing: customEase });
+    
+    tw.progress(0.5);
+    expect(callback).toHaveBeenCalledWith(0.25);
+  });
+
+  it('should support bezier curve easing', () => {
+    const callback = vi.fn();
+    const tw = tween(callback, { easing: [0, 0, 1, 1] });
+    
+    tw.progress(0.5);
+    expect(callback).toHaveBeenCalled();
+    const callValue = callback.mock.calls[0]?.[0];
+    expect(typeof callValue).toBe('number');
+  });
+
+  it('should support smooth mode', () => {
+    const callback = vi.fn();
+    const tw = tween(callback, { smooth: true });
+    
+    tw.progress(1);
+    expect(callback).toHaveBeenCalled();
+    
+    const callValue = callback.mock.calls[0]?.[0];
+    expect(typeof callValue).toBe('number');
+  });
+
+  it('should support smooth mode with custom factor', () => {
+    const callback = vi.fn();
+    const tw = tween(callback, { smooth: 0.2 });
+    
+    tw.progress(1);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should support spring mode', () => {
+    const callback = vi.fn();
+    const tw = tween(callback, { spring: true });
+    
+    tw.progress(1);
+    expect(callback).toHaveBeenCalled();
+    
+    const callValue = callback.mock.calls[0]?.[0];
+    expect(typeof callValue).toBe('number');
+  });
+
+  it('should support spring mode with custom stiffness', () => {
+    const callback = vi.fn();
+    const tw = tween(callback, { spring: 0.2 });
+    
+    tw.progress(1);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should support custom precision', () => {
+    const callback = vi.fn();
+    const tw = tween(callback, { precision: 0.01 });
+    
+    tw.progress(0.999);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should call lifecycle callbacks', () => {
+    const callback = vi.fn();
+    const onStart = vi.fn();
+    const onProgress = vi.fn();
+    
+    const tw = tween(callback, {
+      onStart,
+      onProgress
+    });
+    
+    tw.start();
+    expect(onStart).toHaveBeenCalledWith(0);
+    
+    tw.progress(0.5);
+    expect(onProgress).toHaveBeenCalledWith(0.5);
+  });
+
+  it('should support manual progress control', () => {
+    const callback = vi.fn();
+    const tw = tween(callback);
+    
+    expect(tw.progress()).toBe(0);
+    
+    tw.progress(0.5);
+    expect(callback).toHaveBeenCalledWith(0.5);
+    expect(tw.progress()).toBe(0.5);
+  });
+
+  it('should support finish method', () => {
+    const callback = vi.fn();
+    const tw = tween(callback);
+    
+    tw.finish();
+    expect(callback).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle spring and smooth mode parameters correctly', () => {
+    const callback = vi.fn();
+    
+    const springTween = tween(callback, { spring: 0.3 });
+    springTween.progress(0.5);
+    expect(callback).toHaveBeenCalled();
+    
+    callback.mockClear();
+    
+    const smoothTween = tween(callback, { smooth: 0.4 });
+    smoothTween.progress(0.5);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should work with different precision values', () => {
+    const callback = vi.fn();
+    const tw = tween(callback, { precision: 0.1 });
+    
+    tw.progress(0.95);
+    expect(callback).toHaveBeenCalled();
+    
+    const callValue = callback.mock.calls[0]?.[0];
+    expect(callValue).toBe(1);
+  });
+});


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds some utility functions for animation and add support for [spring physics](https://www.joshwcomeau.com/animation/a-friendly-introduction-to-spring-physics/) to the `tween` and `animate` functions. 

- `spring`: like the `damp` function, but for [spring animations](https://www.joshwcomeau.com/animation/a-friendly-introduction-to-spring-physics/)
- `wrap`: like the `clamp` function, but with a loop 
- `smoothTo`: easier usage of the `damp` and `spring` functions, less boilerplate

**spring**

```js
import { spring } from '@studiometa/js-toolkit/utils';

let value = 0;
let velocity = 0;

[value, velocity] = spring(100, value, velocity);
```

**wrap**

```js
import { wrap } from '@studiometa/js-toolkit/utils';

let value = 0;

window.addEventListener('wheel', (event) => {
  value = wrap(value + event.deltaY, -100, 100);
});
```

**smoothTo**

```js
import { smoothTo } from '@studiometa/js-toolkit/utils';

const smooth = smoothTo(0);
smooth.subscribe((value) => console.log(value));
smooth(100); // will smoothly lerp from 0 to 100 while executing the subscribed callback
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
