### PR TITLE
[Feature] Reduce `smoothTo` export size

### DIFF
--- a/packages/demo/src/js/app.ts
+++ b/packages/demo/src/js/app.ts
@@ -123,30 +123,9 @@ class App extends Base {
       BreakpointObserverDemo: () =>
         importWhenIdle(() => import('./components/BreakpointObserverDemo.js')),
       Cursor: () =>
-        importOnInteraction(
-          async () => {
-            const { Cursor } = await import('@studiometa/ui');
-            return class extends Cursor {
-              static config = {
-                ...Cursor.config,
-                refs: ['inner'],
-              };
-
-              render({ x, y, scale }) {
-                this.$el.style.transform = `translateZ(0) ${matrix({
-                  translateX: x,
-                  translateY: y,
-                })}`;
-                this.$refs.inner.style.transform = `translateZ(0) ${matrix({
-                  scaleX: scale,
-                  scaleY: scale,
-                })}`;
-              }
-            };
-          },
-          document.documentElement,
-          ['mousemove'],
-        ),
+        importOnInteraction(() => import('./components/Cursor.js'), document.documentElement, [
+          'mousemove',
+        ]),
       Draggable: (app) =>
         importWhenVisible(
           async () => {

--- a/packages/demo/src/js/components/Cursor.js
+++ b/packages/demo/src/js/components/Cursor.js
@@ -1,25 +1,43 @@
 import { Base } from '@studiometa/js-toolkit';
+import { smoothTo, transform } from '@studiometa/js-toolkit/utils';
 
 /**
- *
+ * Cursor class.
  */
 export default class Cursor extends Base {
+  /**
+   * Config.
+   * @type {import('@studiometa/js-toolkit').BaseConfig}
+   */
   static config = {
     name: 'Cursor',
-    refs: ['inner'],
   };
 
+  x = smoothTo(window.innerWidth / 2);
+
+  y = smoothTo(window.innerHeight / 2);
+
+  scale = smoothTo(1, { spring: true });
+
   /**
-   *
+   * Moved hook.
+   * Update position and scale based on pointer state.
+   * @param {import('@studiometa/js-toolkit').PointerServiceProps} props
    */
-  moved({ x, y, delta, isDown }) {
-    let transform = `translate3d(${x}px, ${y}px, 0)`;
+  moved({ x, y, isDown }) {
+    this.x(x);
+    this.y(y);
+    this.scale(isDown ? 0.75 : 1);
+  }
 
-    if (isDown) {
-      transform += ' scale(0.75)';
-    }
-
-    this.$el.style.transform = transform;
-    this.$refs.inner.style.transform = `translate3d(${delta.x * -1}px, ${delta.y * -1}px, 0)`;
+  /**
+   * Ticked hook.
+   * Update the element's transform on each frame.
+   * @returns {() => void} A function to be executed on the "write" step of the DOM Scheduler
+   */
+  ticked() {
+    return () => {
+      transform(this.$el, { x: this.x(), y: this.y(), scale: this.scale() });
+    };
   }
 }

--- a/packages/demo/src/templates/pages/index.twig
+++ b/packages/demo/src/templates/pages/index.twig
@@ -585,7 +585,7 @@
     <!-- BEGIN Cursor component -->
     <div data-component="Cursor"
       class="z-goku fixed top-0 left-0 flex items-center justify-center w-8 h-8 -mt-4 -ml-4 rounded-full border pointer-events-none transform -translate-x-16 -translate-y-16">
-      <div data-ref="inner" class="w-2 h-2 rounded-full bg-black"></div>
+      <div class="w-2 h-2 rounded-full bg-black"></div>
     </div>
     <!-- END Cursor component -->
 

--- a/packages/js-toolkit/utils/math/smoothTo.ts
+++ b/packages/js-toolkit/utils/math/smoothTo.ts
@@ -1,4 +1,3 @@
-import { useRaf } from '../../services/RafService.js';
 import { damp } from './damp.js';
 import { spring } from './spring.js';
 import { isFunction, isDefined } from '../is.js';
@@ -39,8 +38,6 @@ export type SmoothToOptions = Partial<{
  * ```
  */
 export function smoothTo(start = 0, options: SmoothToOptions = {}) {
-  const { add, has, remove } = useRaf();
-  const key = Symbol();
   const fns = new Set<(value: number) => any>();
 
   let damping = options.damping ?? 0.6;
@@ -67,7 +64,7 @@ export function smoothTo(start = 0, options: SmoothToOptions = {}) {
       fn(smoothed);
     }
 
-    if (smoothed === value) remove(key);
+    if (smoothed !== value) requestAnimationFrame(tick);
   }
 
   /**
@@ -98,9 +95,7 @@ export function smoothTo(start = 0, options: SmoothToOptions = {}) {
 
     value = newValue;
 
-    if (!has(key)) {
-      add(key, tick);
-    }
+    tick();
 
     return smoothed;
   }

--- a/packages/tests/utils/math/smoothTo.spec.ts
+++ b/packages/tests/utils/math/smoothTo.spec.ts
@@ -21,9 +21,11 @@ describe('smoothTo method', () => {
 
   it('should return raw target value', () => {
     const smooth = smoothTo(0);
+    expect(smooth.raw()).toBe(0);
+    expect(smooth()).toBe(0);
     smooth(10);
     expect(smooth.raw()).toBe(10);
-    expect(smooth()).toBe(0);
+    expect(smooth()).toBe(6);
   });
 
   it('should subscribe and unsubscribe to value updates', () => {


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes usage of the [`useRaf` service](js-toolkit.studiometa.dev/api/services/useRaf.html) as it does not provide much improvements over direct usage of `requestAnimationFrame`.

This reduces the size of the `smoothTo` export when used on its own.  

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
