### PR TITLE
[Enhancement] Optimize tween, animate and RafService for browser performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file. The format 
 
 - Add browser storage utilities: `createStorage`, `useLocalStorage`, `useSessionStorage`, `useUrlSearchParams`, `useUrlSearchParamsInHash` ([#671](https://github.com/studiometa/js-toolkit/pull/671))
 - Add `logTree` helper to inspect the component tree from the console ([#654](https://github.com/studiometa/js-toolkit/pull/654))
+- Add performance benchmarks for tween, animate, transform, services and Base internals ([#722](https://github.com/studiometa/js-toolkit/pull/722))
+- Add CodSpeed CI integration for continuous performance tracking ([#723](https://github.com/studiometa/js-toolkit/pull/723))
+
+### Changed
+
+- **Performance**
+  - Improve `animate` progress updates by pre-computing keyframe deltas at creation time ([#721](https://github.com/studiometa/js-toolkit/pull/721), [ca72182c](https://github.com/studiometa/js-toolkit/commit/ca72182c))
+  - Improve `RafService.trigger` by batching scheduler calls, reducing closure creation from 2N to 2 per cycle ([#721](https://github.com/studiometa/js-toolkit/pull/721), [d4f96331](https://github.com/studiometa/js-toolkit/commit/d4f96331))
+  - Improve `ScrollService.updateProps` by caching scroll max values and updating on resize only ([#721](https://github.com/studiometa/js-toolkit/pull/721), [d5939211](https://github.com/studiometa/js-toolkit/commit/d5939211))
+  - Improve `transform` and `tween` by replacing `isDefined()` with inline `!== undefined` checks ([#721](https://github.com/studiometa/js-toolkit/pull/721), [e580bfee](https://github.com/studiometa/js-toolkit/commit/e580bfee), [1fc79012](https://github.com/studiometa/js-toolkit/commit/1fc79012))
+  - Improve `getAllProperties` by replacing O(n²) array spread with O(n) push ([#721](https://github.com/studiometa/js-toolkit/pull/721), [3dea1808](https://github.com/studiometa/js-toolkit/commit/3dea1808))
+  - Improve `getInstances` by returning storage Set directly instead of copying ([#721](https://github.com/studiometa/js-toolkit/pull/721), [221be81e](https://github.com/studiometa/js-toolkit/commit/221be81e))
 
 ### Fixed
 

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -144,9 +144,9 @@ export function getInstances<T extends BaseConstructor = BaseConstructor>(
       }
     }
     return filteredInstances;
-  } else {
-    return getInstancesStorage();
   }
+
+  return new Set(getInstancesStorage());
 }
 
 export function getElements() {

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -129,13 +129,13 @@ function getElementsStorage(): Set<HTMLElement & { __base__: Map<string, Base>}>
  * Get all mounted instances or the ones from a given component.
  * @link https://js-toolkit.studiometa.dev/api/helpers/getInstances.html
  */
-export function getInstances(): Set<Base>;
+export function getInstances(): ReadonlySet<Base>;
 export function getInstances<T extends BaseConstructor = BaseConstructor>(
   ctor: T,
 ): Set<InstanceType<T>>;
 export function getInstances<T extends BaseConstructor = BaseConstructor>(
   ctor?: T,
-): Set<InstanceType<T>> | Set<Base> {
+): ReadonlySet<InstanceType<T>> | ReadonlySet<Base> {
   if (isDefined(ctor)) {
     const filteredInstances = new Set<InstanceType<T>>();
     for (const instance of getInstancesStorage()) {
@@ -145,7 +145,7 @@ export function getInstances<T extends BaseConstructor = BaseConstructor>(
     }
     return filteredInstances;
   } else {
-    return new Set(getInstancesStorage());
+    return getInstancesStorage();
   }
 }
 

--- a/packages/js-toolkit/helpers/queryComponent.ts
+++ b/packages/js-toolkit/helpers/queryComponent.ts
@@ -55,7 +55,7 @@ export function queryComponent<T extends Base = Base>(
 ): T | undefined {
   const parsedQuery = parseQuery(query);
   const { from = document } = options;
-  const instances = getInstances() as Set<T>;
+  const instances = getInstances() as ReadonlySet<T>;
 
   for (const instance of instances) {
     if (!instanceIsMatching(instance, parsedQuery)) continue;
@@ -74,7 +74,7 @@ export function queryComponentAll<T extends Base = Base>(
 ): T[] {
   const parsedQuery = parseQuery(query);
   const { from = document } = options;
-  const instances = getInstances() as Set<T>;
+  const instances = getInstances() as ReadonlySet<T>;
   const selectedInstances = new Set<T>();
 
   for (const instance of instances) {

--- a/packages/js-toolkit/services/RafService.ts
+++ b/packages/js-toolkit/services/RafService.ts
@@ -27,17 +27,24 @@ export class RafService extends AbstractService<RafServiceProps> {
   };
 
   trigger(props: RafServiceProps) {
-    for (const callback of this.callbacks.values()) {
-      this.scheduler.read(() => {
-        const render = callback(props) as (() => unknown) | void;
+    this.scheduler.read(() => {
+      const writeQueue: Array<(props: RafServiceProps) => unknown> = [];
+
+      for (const callback of this.callbacks.values()) {
+        const render = callback(props) as ((props: RafServiceProps) => unknown) | void;
         if (isFunction(render)) {
-          this.scheduler.write(() => {
-            // @ts-ignore
-            render(props);
-          });
+          writeQueue.push(render);
         }
-      });
-    }
+      }
+
+      if (writeQueue.length > 0) {
+        this.scheduler.write(() => {
+          for (let i = 0; i < writeQueue.length; i++) {
+            writeQueue[i](props);
+          }
+        });
+      }
+    });
   }
 
   loop() {

--- a/packages/js-toolkit/services/ScrollService.ts
+++ b/packages/js-toolkit/services/ScrollService.ts
@@ -32,7 +32,17 @@ export interface ScrollServiceProps {
 export type ScrollServiceInterface = ServiceInterface<ScrollServiceProps>;
 
 export class ScrollService extends AbstractService<ScrollServiceProps> {
-  static config: ServiceConfig = [[() => document, [['scroll', PASSIVE_CAPTURE_EVENT_OPTIONS]]]];
+  static config: ServiceConfig = [
+    [() => document, [['scroll', PASSIVE_CAPTURE_EVENT_OPTIONS]]],
+    [() => window, [['resize', PASSIVE_CAPTURE_EVENT_OPTIONS]]],
+  ];
+
+  /**
+   * Cached scroll max values, updated on resize and first scroll.
+   * @private
+   */
+  __maxX = -1;
+  __maxY = -1;
 
   props: ScrollServiceProps = {
     x: window.scrollX,
@@ -90,8 +100,11 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
     props.last.y = props.lastY = yLast;
     props.delta.x = props.deltaX = props.x - xLast;
     props.delta.y = props.deltaY = props.y - yLast;
-    props.max.x = props.maxX = document.scrollingElement.scrollWidth - window.innerWidth;
-    props.max.y = props.maxY = document.scrollingElement.scrollHeight - window.innerHeight;
+    if (this.__maxX < 0) {
+      this.__updateMaxValues();
+    }
+    props.max.x = props.maxX = this.__maxX;
+    props.max.y = props.maxY = this.__maxY;
     props.progress.x = props.progressX = props.max.x === 0 ? 1 : props.x / props.max.x;
     props.progress.y = props.progressY = props.max.y === 0 ? 1 : props.y / props.max.y;
     props.isUp = props.y < yLast;
@@ -115,11 +128,25 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
   }, 100);
 
   /**
-   * Scroll handler.
+   * Update cached max scroll values on resize.
+   * @private
    */
-  handleEvent() {
+  __updateMaxValues() {
+    this.__maxX = document.scrollingElement.scrollWidth - window.innerWidth;
+    this.__maxY = document.scrollingElement.scrollHeight - window.innerHeight;
+  }
+
+  /**
+   * Scroll and resize handler.
+   */
+  handleEvent(event: Event) {
+    if (event.type === 'resize') {
+      this.__updateMaxValues();
+    }
     this.update();
-    this.onScrollDebounced();
+    if (event.type === 'scroll') {
+      this.onScrollDebounced();
+    }
   }
 }
 

--- a/packages/js-toolkit/services/ScrollService.ts
+++ b/packages/js-toolkit/services/ScrollService.ts
@@ -41,8 +41,8 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
    * Cached scroll max values, updated on resize and first scroll.
    * @private
    */
-  __maxX = -1;
-  __maxY = -1;
+  __maxX: number | null = null;
+  __maxY: number | null = null;
 
   /**
    * Observe scroll container size changes that do not trigger window resize.
@@ -106,7 +106,7 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
     props.last.y = props.lastY = yLast;
     props.delta.x = props.deltaX = props.x - xLast;
     props.delta.y = props.deltaY = props.y - yLast;
-    if (this.__maxX < 0) {
+    if (this.__maxX === null || this.__maxY === null) {
       this.__updateMaxValues();
     }
     props.max.x = props.maxX = this.__maxX;
@@ -125,8 +125,12 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
     return props;
   }
 
-  update() {
-    nextTick(() => this.updateProps()).then(() => this.trigger(this.props));
+  update(trigger = true) {
+    nextTick(() => this.updateProps()).then(() => {
+      if (trigger) {
+        this.trigger(this.props);
+      }
+    });
   }
 
   onScrollDebounced = debounce(() => {
@@ -148,11 +152,12 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
   handleEvent(event: Event) {
     if (event.type === 'resize') {
       this.__updateMaxValues();
+      this.update(false);
+      return;
     }
+
     this.update();
-    if (event.type === 'scroll') {
-      this.onScrollDebounced();
-    }
+    this.onScrollDebounced();
   }
 
   init() {

--- a/packages/js-toolkit/services/ScrollService.ts
+++ b/packages/js-toolkit/services/ScrollService.ts
@@ -44,6 +44,12 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
   __maxX = -1;
   __maxY = -1;
 
+  /**
+   * Observe scroll container size changes that do not trigger window resize.
+   * @private
+   */
+  __resizeObserver: ResizeObserver | null = null;
+
   props: ScrollServiceProps = {
     x: window.scrollX,
     y: window.scrollY,
@@ -147,6 +153,23 @@ export class ScrollService extends AbstractService<ScrollServiceProps> {
     if (event.type === 'scroll') {
       this.onScrollDebounced();
     }
+  }
+
+  init() {
+    super.init();
+
+    if (typeof ResizeObserver === 'function' && document.scrollingElement) {
+      this.__resizeObserver = new ResizeObserver(() => {
+        this.__updateMaxValues();
+      });
+      this.__resizeObserver.observe(document.scrollingElement);
+    }
+  }
+
+  kill() {
+    this.__resizeObserver?.disconnect();
+    this.__resizeObserver = null;
+    super.kill();
   }
 }
 

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -1,6 +1,6 @@
 import { clamp01, lerp, map } from '../math/index.js';
 import { isFunction, isNumber } from '../is.js';
-import { transform, TRANSFORM_PROPS } from './transform.js';
+import { TRANSFORM_PROPS } from './transform.js';
 import { domScheduler as scheduler } from '../scheduler.js';
 import { tween, normalizeEase } from '../tween.js';
 import { eachElements } from './utils.js';
@@ -156,11 +156,60 @@ function render(
       }
     }
 
-    const props = {};
+    // Build transform string directly to avoid object allocation and
+    // redundant property checks in transform()
+    let transformValue = '';
 
-    for (const name of TRANSFORM_PROPS) {
-      if (from[name] !== undefined || to[name] !== undefined) {
-        props[name] = transformRenderStrategies[name](element, from[name], to[name], stepProgress);
+    // translate3d
+    const hasX = from.x !== undefined || to.x !== undefined;
+    const hasY = from.y !== undefined || to.y !== undefined;
+    const hasZ = from.z !== undefined || to.z !== undefined;
+    if (hasX || hasY || hasZ) {
+      const x = hasX ? transformRenderStrategies.x(element, from.x, to.x, stepProgress) : 0;
+      const y = hasY ? transformRenderStrategies.y(element, from.y, to.y, stepProgress) : 0;
+      const z = hasZ ? transformRenderStrategies.z(element, from.z, to.z, stepProgress) : 0;
+      transformValue += `translate3d(${x}px, ${y}px, ${z}px) `;
+    }
+
+    // rotate
+    if (from.rotate !== undefined || to.rotate !== undefined) {
+      transformValue += `rotate(${transformRenderStrategies.rotate(element, from.rotate, to.rotate, stepProgress)}deg) `;
+    } else {
+      if (from.rotateX !== undefined || to.rotateX !== undefined) {
+        transformValue += `rotateX(${transformRenderStrategies.rotateX(element, from.rotateX, to.rotateX, stepProgress)}deg) `;
+      }
+      if (from.rotateY !== undefined || to.rotateY !== undefined) {
+        transformValue += `rotateY(${transformRenderStrategies.rotateY(element, from.rotateY, to.rotateY, stepProgress)}deg) `;
+      }
+      if (from.rotateZ !== undefined || to.rotateZ !== undefined) {
+        transformValue += `rotateZ(${transformRenderStrategies.rotateZ(element, from.rotateZ, to.rotateZ, stepProgress)}deg) `;
+      }
+    }
+
+    // scale
+    if (from.scale !== undefined || to.scale !== undefined) {
+      transformValue += `scale(${transformRenderStrategies.scale(element, from.scale, to.scale, stepProgress)}) `;
+    } else {
+      if (from.scaleX !== undefined || to.scaleX !== undefined) {
+        transformValue += `scaleX(${transformRenderStrategies.scaleX(element, from.scaleX, to.scaleX, stepProgress)}) `;
+      }
+      if (from.scaleY !== undefined || to.scaleY !== undefined) {
+        transformValue += `scaleY(${transformRenderStrategies.scaleY(element, from.scaleY, to.scaleY, stepProgress)}) `;
+      }
+      if (from.scaleZ !== undefined || to.scaleZ !== undefined) {
+        transformValue += `scaleZ(${transformRenderStrategies.scaleZ(element, from.scaleZ, to.scaleZ, stepProgress)}) `;
+      }
+    }
+
+    // skew
+    if (from.skew !== undefined || to.skew !== undefined) {
+      transformValue += `skew(${transformRenderStrategies.skew(element, from.skew, to.skew, stepProgress)}deg) `;
+    } else {
+      if (from.skewX !== undefined || to.skewX !== undefined) {
+        transformValue += `skewX(${transformRenderStrategies.skewX(element, from.skewX, to.skewX, stepProgress)}deg) `;
+      }
+      if (from.skewY !== undefined || to.skewY !== undefined) {
+        transformValue += `skewY(${transformRenderStrategies.skewY(element, from.skewY, to.skewY, stepProgress)}deg) `;
       }
     }
 
@@ -177,7 +226,7 @@ function render(
           element.style.setProperty(customProperty[0], customProperty[1].toString());
         }
       }
-      transform(element, props);
+      element.style.transform = transformValue;
     });
   });
 }

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -1,6 +1,5 @@
 import { clamp01, lerp, map } from '../math/index.js';
 import { isFunction, isNumber } from '../is.js';
-import { TRANSFORM_PROPS } from './transform.js';
 import { domScheduler as scheduler } from '../scheduler.js';
 import { tween, normalizeEase } from '../tween.js';
 import { eachElements } from './utils.js';
@@ -31,6 +30,46 @@ export type NormalizedKeyframe = Keyframe & {
   vars: string[];
 };
 
+
+/**
+ * A pre-compiled segment between two keyframes.
+ * All constant parts (deltas, offsets, writers) are resolved once at creation.
+ * The render loop only does multiply-add and string concatenation.
+ */
+interface CompiledSegment {
+  fromOffset: number;
+  toOffset: number;
+  easing: EasingFunction;
+  /** Parallel arrays for transform properties (structure-of-arrays layout) */
+  transformStarts: number[];
+  transformDeltas: number[];
+  transformCssFunctions: string[];
+  transformUnits: string[];
+  /** Whether translate3d is needed */
+  hasTranslate: boolean;
+  /** Indices into transformStarts/transformDeltas for x, y, z axes */
+  translateAxisIndices: number[];
+  /** The index where non-translate transforms start in the parallel arrays */
+  simpleTransformStart: number;
+  /** Translate properties that need element size for CSS unit conversion at render time */
+  dynamicTranslates: Array<{
+    index: number;
+    from: number | [number, string];
+    to: number | [number, string];
+    sizeRef: string;
+  }>;
+  /** Opacity: pre-computed start and delta, or null if not animated */
+  opacityStart: number;
+  opacityDelta: number;
+  hasOpacity: boolean;
+  /** CSS custom properties: parallel arrays */
+  customPropertyNames: string[];
+  customPropertyStarts: number[];
+  customPropertyDeltas: number[];
+  /** Transform origin for this segment, or false */
+  transformOrigin: string | false;
+}
+
 export interface AnimateOptions extends Omit<TweenOptions, 'duration'> {
   /**
    * The duration of the tween, in seconds.
@@ -58,18 +97,18 @@ let id = 0;
 const running = new WeakMap();
 
 const CSSUnitConverter = {
-  '%': (value, getSizeRef) => (value * getSizeRef()) / 100,
-  vh: (value) => (value * window.innerHeight) / 100,
-  vw: (value) => (value * window.innerWidth) / 100,
-  vmin: (value) => (value * Math.min(window.innerWidth, window.innerHeight)) / 100,
-  vmax: (value) => (value * Math.max(window.innerWidth, window.innerHeight)) / 100,
+  '%': (value: number, size: number) => (value * size) / 100,
+  vh: (value: number) => (value * window.innerHeight) / 100,
+  vw: (value: number) => (value * window.innerWidth) / 100,
+  vmin: (value: number) => (value * Math.min(window.innerWidth, window.innerHeight)) / 100,
+  vmax: (value: number) => (value * Math.max(window.innerWidth, window.innerHeight)) / 100,
 };
 
 /**
- * Get the value from a step property.
+ * Resolve a keyframe value that may have a CSS unit (e.g. [50, '%']).
  */
-function getAnimationStepValue(val: number | [number, string], getSizeRef: () => number): number {
-  if (isNumber(val)) {
+function resolveUnitValue(val: number | [number, string], elementSize: number): number {
+  if (typeof val === 'number') {
     return val;
   }
 
@@ -77,153 +116,201 @@ function getAnimationStepValue(val: number | [number, string], getSizeRef: () =>
     return val[0];
   }
 
-  return CSSUnitConverter[val[1]](val[0], getSizeRef);
+  return CSSUnitConverter[val[1]](val[0], elementSize);
 }
 
-const generateTranslateRenderStrategy = (sizeRef) => (element, fromValue, toValue, progress) => {
-  const from = fromValue ?? 0;
-  const to = toValue ?? 0;
-  // Fast path: both values are plain numbers (no CSS units)
-  if (typeof from === 'number' && typeof to === 'number') {
-    return lerp(from, to, progress);
-  }
-  const getSizeRef = () => element[sizeRef];
-  return lerp(
-    getAnimationStepValue(from, getSizeRef),
-    getAnimationStepValue(to, getSizeRef),
-    progress,
-  );
-};
-const widthBasedTranslateRenderStrategy = generateTranslateRenderStrategy('offsetWidth');
-const heightBasedTranslateRenderStrategy = generateTranslateRenderStrategy('offsetHeight');
-
-const generateLerpRenderStrategy = (defaultValue) => (element, fromValue, toValue, progress) =>
-  lerp(fromValue ?? defaultValue, toValue ?? defaultValue, progress);
-const scaleRenderStrategy = generateLerpRenderStrategy(1);
-const degreesRenderStrategy = generateLerpRenderStrategy(0);
-
-const transformRenderStrategies = {
-  x: widthBasedTranslateRenderStrategy,
-  y: heightBasedTranslateRenderStrategy,
-  z: widthBasedTranslateRenderStrategy,
-  scale: scaleRenderStrategy,
-  scaleX: scaleRenderStrategy,
-  scaleY: scaleRenderStrategy,
-  scaleZ: scaleRenderStrategy,
-  skew: degreesRenderStrategy,
-  skewX: degreesRenderStrategy,
-  skewY: degreesRenderStrategy,
-  rotate: degreesRenderStrategy,
-  rotateX: degreesRenderStrategy,
-  rotateY: degreesRenderStrategy,
-  rotateZ: degreesRenderStrategy,
-};
+/**
+ * Non-translate transform property definitions: [keyframeProp, cssFn, unit, defaultValue].
+ */
+const SIMPLE_TRANSFORM_DEFS: ReadonlyArray<
+  readonly [string, string, string, number]
+> = [
+  ['rotate', 'rotate', 'deg', 0],
+  ['rotateX', 'rotateX', 'deg', 0],
+  ['rotateY', 'rotateY', 'deg', 0],
+  ['rotateZ', 'rotateZ', 'deg', 0],
+  ['scale', 'scale', '', 1],
+  ['scaleX', 'scaleX', '', 1],
+  ['scaleY', 'scaleY', '', 1],
+  ['scaleZ', 'scaleZ', '', 1],
+  ['skew', 'skew', 'deg', 0],
+  ['skewX', 'skewX', 'deg', 0],
+  ['skewY', 'skewY', 'deg', 0],
+];
 
 /**
- * Render an element style based on 2 keyframes and a progress value.
+ * Translate axis definitions: [keyframeProp, defaultValue, sizeRef].
+ * These are grouped into a single translate3d() call during rendering.
  */
-function render(
-  element: HTMLElement,
+const TRANSLATE_DEFS: ReadonlyArray<
+  readonly [string, number, string]
+> = [
+  ['x', 0, 'offsetWidth'],
+  ['y', 0, 'offsetHeight'],
+  ['z', 0, 'offsetWidth'],
+];
+
+/**
+ * Compile a pair of keyframes into a pre-computed segment.
+ * All constant work (deltas, property filtering) is done here once.
+ */
+function compileSegment(
   from: NormalizedKeyframe,
   to: NormalizedKeyframe,
+): CompiledSegment {
+  const transformStarts: number[] = [];
+  const transformDeltas: number[] = [];
+  const transformCssFunctions: string[] = [];
+  const transformUnits: string[] = [];
+  const dynamicTranslates: CompiledSegment['dynamicTranslates'] = [];
+
+  // Translate axes: grouped into translate3d(x, y, z) during rendering.
+  // We track indices into the parallel arrays for x, y, z.
+  let hasTranslate = false;
+  const translateAxisIndices: number[] = [];
+
+  for (const [prop, defaultValue, sizeRef] of TRANSLATE_DEFS) {
+    const propertyExists = from[prop] !== undefined || to[prop] !== undefined;
+    if (propertyExists) hasTranslate = true;
+
+    const fromValue = from[prop] ?? defaultValue;
+    const toValue = to[prop] ?? defaultValue;
+    const arrayIndex = transformStarts.length;
+    translateAxisIndices.push(arrayIndex);
+
+    // Placeholder CSS function/unit — not used for translate (special rendering)
+    transformCssFunctions.push('');
+    transformUnits.push('px');
+
+    if (typeof fromValue !== 'number' || typeof toValue !== 'number') {
+      transformStarts.push(0);
+      transformDeltas.push(0);
+      dynamicTranslates.push({ index: arrayIndex, from: fromValue, to: toValue, sizeRef });
+    } else {
+      transformStarts.push(fromValue);
+      transformDeltas.push(toValue - fromValue);
+    }
+  }
+
+  // Non-translate transforms: each gets its own CSS function
+  for (const [prop, cssFunction, unit, defaultValue] of SIMPLE_TRANSFORM_DEFS) {
+    if (from[prop] === undefined && to[prop] === undefined) continue;
+
+    const startValue = (from[prop] as number) ?? defaultValue;
+    transformCssFunctions.push(cssFunction);
+    transformUnits.push(unit);
+    transformStarts.push(startValue);
+    transformDeltas.push(((to[prop] as number) ?? defaultValue) - startValue);
+  }
+
+  // Opacity
+  const hasOpacity = from.opacity !== undefined || to.opacity !== undefined;
+  const opacityStart = hasOpacity ? (from.opacity ?? 1) : 0;
+  const opacityDelta = hasOpacity ? (to.opacity ?? 1) - opacityStart : 0;
+
+  // CSS custom properties
+  const customPropertyNames: string[] = [];
+  const customPropertyStarts: number[] = [];
+  const customPropertyDeltas: number[] = [];
+  if (from.vars && to.vars) {
+    for (const name of from.vars) {
+      const startValue = from[name] as number;
+      customPropertyNames.push(name);
+      customPropertyStarts.push(startValue);
+      customPropertyDeltas.push((to[name] as number) - startValue);
+    }
+  }
+
+  return {
+    fromOffset: from.offset,
+    toOffset: to.offset,
+    easing: to.easing,
+    transformStarts,
+    transformDeltas,
+    transformCssFunctions,
+    transformUnits,
+    hasTranslate,
+    translateAxisIndices,
+    simpleTransformStart: TRANSLATE_DEFS.length,
+    dynamicTranslates,
+    hasOpacity,
+    opacityStart,
+    opacityDelta,
+    customPropertyNames,
+    customPropertyStarts,
+    customPropertyDeltas,
+    transformOrigin: to.transformOrigin !== undefined ? to.transformOrigin : false,
+  };
+}
+
+/**
+ * Render an element using a pre-compiled segment and a progress value.
+ * The hot path: only multiply-add, string concatenation, and DOM writes.
+ */
+function renderSegment(
+  element: HTMLElement,
+  segment: CompiledSegment,
   progress: number,
 ) {
-  const stepProgress = to.easing(map(progress, from.offset, to.offset, 0, 1));
+  const easedProgress = segment.easing(
+    map(progress, segment.fromOffset, segment.toOffset, 0, 1),
+  );
 
   scheduler.read(() => {
+    // Resolve dynamic (CSS-unit) transforms that need element size
+    for (let i = 0; i < segment.dynamicTranslates.length; i++) {
+      const dynamic = segment.dynamicTranslates[i];
+      const elementSize = element[dynamic.sizeRef];
+      const startValue = resolveUnitValue(dynamic.from, elementSize);
+      segment.transformStarts[dynamic.index] = startValue;
+      segment.transformDeltas[dynamic.index] = resolveUnitValue(dynamic.to, elementSize) - startValue;
+    }
+
+    // Build transform string: translate3d grouped, then individual transforms
+    let transformValue = '';
+
+    if (segment.hasTranslate) {
+      const xIndex = segment.translateAxisIndices[0];
+      const yIndex = segment.translateAxisIndices[1];
+      const zIndex = segment.translateAxisIndices[2];
+      const x = segment.transformStarts[xIndex] + segment.transformDeltas[xIndex] * easedProgress;
+      const y = segment.transformStarts[yIndex] + segment.transformDeltas[yIndex] * easedProgress;
+      const z = segment.transformStarts[zIndex] + segment.transformDeltas[zIndex] * easedProgress;
+      transformValue += `translate3d(${x}px, ${y}px, ${z}px) `;
+    }
+
+    for (let i = segment.simpleTransformStart; i < segment.transformStarts.length; i++) {
+      const value = segment.transformStarts[i] + segment.transformDeltas[i] * easedProgress;
+      transformValue += `${segment.transformCssFunctions[i]}(${value}${segment.transformUnits[i]}) `;
+    }
+
+    // Compute opacity
     let opacity: false | number | string = false;
-    if (from.opacity !== undefined || to.opacity !== undefined) {
-      opacity = map(stepProgress, 0, 1, from.opacity ?? 1, to.opacity ?? 1);
+    if (segment.hasOpacity) {
+      opacity = segment.opacityStart + segment.opacityDelta * easedProgress;
     } else if (element.style.opacity) {
       opacity = '';
     }
 
-    let transformOrigin: false | string = false;
-    if (to.transformOrigin !== undefined) {
-      transformOrigin = to.transformOrigin;
-    } else if (element.style.transformOrigin) {
-      transformOrigin = '';
-    }
-
-    let customProperties: false | [string, number][] = false;
-    if (from.vars !== undefined && to.vars !== undefined) {
-      customProperties = [];
-      for (const customPropertyName of from.vars) {
-        customProperties.push([
-          customPropertyName,
-          lerp(from[customPropertyName], to[customPropertyName], stepProgress),
-        ]);
-      }
-    }
-
-    // Build transform string directly to avoid object allocation and
-    // redundant property checks in transform()
-    let transformValue = '';
-
-    // translate3d
-    const hasX = from.x !== undefined || to.x !== undefined;
-    const hasY = from.y !== undefined || to.y !== undefined;
-    const hasZ = from.z !== undefined || to.z !== undefined;
-    if (hasX || hasY || hasZ) {
-      const x = hasX ? transformRenderStrategies.x(element, from.x, to.x, stepProgress) : 0;
-      const y = hasY ? transformRenderStrategies.y(element, from.y, to.y, stepProgress) : 0;
-      const z = hasZ ? transformRenderStrategies.z(element, from.z, to.z, stepProgress) : 0;
-      transformValue += `translate3d(${x}px, ${y}px, ${z}px) `;
-    }
-
-    // rotate
-    if (from.rotate !== undefined || to.rotate !== undefined) {
-      transformValue += `rotate(${transformRenderStrategies.rotate(element, from.rotate, to.rotate, stepProgress)}deg) `;
-    } else {
-      if (from.rotateX !== undefined || to.rotateX !== undefined) {
-        transformValue += `rotateX(${transformRenderStrategies.rotateX(element, from.rotateX, to.rotateX, stepProgress)}deg) `;
-      }
-      if (from.rotateY !== undefined || to.rotateY !== undefined) {
-        transformValue += `rotateY(${transformRenderStrategies.rotateY(element, from.rotateY, to.rotateY, stepProgress)}deg) `;
-      }
-      if (from.rotateZ !== undefined || to.rotateZ !== undefined) {
-        transformValue += `rotateZ(${transformRenderStrategies.rotateZ(element, from.rotateZ, to.rotateZ, stepProgress)}deg) `;
-      }
-    }
-
-    // scale
-    if (from.scale !== undefined || to.scale !== undefined) {
-      transformValue += `scale(${transformRenderStrategies.scale(element, from.scale, to.scale, stepProgress)}) `;
-    } else {
-      if (from.scaleX !== undefined || to.scaleX !== undefined) {
-        transformValue += `scaleX(${transformRenderStrategies.scaleX(element, from.scaleX, to.scaleX, stepProgress)}) `;
-      }
-      if (from.scaleY !== undefined || to.scaleY !== undefined) {
-        transformValue += `scaleY(${transformRenderStrategies.scaleY(element, from.scaleY, to.scaleY, stepProgress)}) `;
-      }
-      if (from.scaleZ !== undefined || to.scaleZ !== undefined) {
-        transformValue += `scaleZ(${transformRenderStrategies.scaleZ(element, from.scaleZ, to.scaleZ, stepProgress)}) `;
-      }
-    }
-
-    // skew
-    if (from.skew !== undefined || to.skew !== undefined) {
-      transformValue += `skew(${transformRenderStrategies.skew(element, from.skew, to.skew, stepProgress)}deg) `;
-    } else {
-      if (from.skewX !== undefined || to.skewX !== undefined) {
-        transformValue += `skewX(${transformRenderStrategies.skewX(element, from.skewX, to.skewX, stepProgress)}deg) `;
-      }
-      if (from.skewY !== undefined || to.skewY !== undefined) {
-        transformValue += `skewY(${transformRenderStrategies.skewY(element, from.skewY, to.skewY, stepProgress)}deg) `;
-      }
-    }
+    // Compute CSS custom properties
+    const hasCustomProperties = segment.customPropertyNames.length > 0;
 
     scheduler.write(() => {
       if (opacity !== false) {
         // @ts-ignore
         element.style.opacity = opacity;
       }
-      if (transformOrigin !== false) {
-        element.style.transformOrigin = transformOrigin;
+      if (segment.transformOrigin !== false) {
+        element.style.transformOrigin = segment.transformOrigin;
+      } else if (element.style.transformOrigin) {
+        element.style.transformOrigin = '';
       }
-      if (customProperties !== false) {
-        for (const customProperty of customProperties) {
-          element.style.setProperty(customProperty[0], customProperty[1].toString());
+      if (hasCustomProperties) {
+        for (let i = 0; i < segment.customPropertyNames.length; i++) {
+          element.style.setProperty(
+            segment.customPropertyNames[i],
+            (segment.customPropertyStarts[i] + segment.customPropertyDeltas[i] * easedProgress).toString(),
+          );
         }
       }
       element.style.transform = transformValue;
@@ -249,6 +336,12 @@ function singleAnimate(
     }),
   );
 
+  // Compile keyframe pairs into pre-computed segments (stage 1: partial evaluation)
+  const segments: CompiledSegment[] = [];
+  for (let i = 1; i < normalizedKeyframes.length; i++) {
+    segments.push(compileSegment(normalizedKeyframes[i - 1], normalizedKeyframes[i]));
+  }
+
   if (!running.has(element)) {
     running.set(element, new Map());
   }
@@ -260,16 +353,16 @@ function singleAnimate(
    * Set the progress value.
    */
   function callback(progress: number) {
-    let toIndex = 0;
+    let segmentIndex = 0;
     while (
-      normalizedKeyframes[toIndex] &&
-      normalizedKeyframes[toIndex].offset <= progress &&
-      normalizedKeyframes[toIndex].offset !== 1
+      segmentIndex < segments.length - 1 &&
+      segments[segmentIndex].toOffset <= progress &&
+      segments[segmentIndex].toOffset !== 1
     ) {
-      toIndex += 1;
+      segmentIndex += 1;
     }
 
-    render(element, normalizedKeyframes[toIndex - 1], normalizedKeyframes[toIndex], progress);
+    renderSegment(element, segments[segmentIndex], progress);
   }
 
   const controls = tween(callback, {

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -414,7 +414,6 @@ export function animate(
   const progresses: number[] = [];
   const timings: [Duration, Delay, DurationWithDelay][] = [];
   let duration = 0;
-  let previousTimings = [0, 0, 0];
   let progressSum = 0;
   let elementCount = 0;
 
@@ -430,12 +429,10 @@ export function animate(
 
     timings[index] = [itemOptions.duration, delay, itemOptions.duration + delay];
 
-    if (timings[index][2] > previousTimings[2]) {
+    if (timings[index][2] > duration) {
       // eslint-disable-next-line prefer-destructuring
       duration = timings[index][2];
     }
-
-    previousTimings = timings[index];
 
     progresses[index] = 0;
     elementCount = index + 1;

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -1,4 +1,4 @@
-import { clamp01, lerp, map, mean } from '../math/index.js';
+import { clamp01, lerp, map } from '../math/index.js';
 import { isFunction, isNumber } from '../is.js';
 import { transform, TRANSFORM_PROPS } from './transform.js';
 import { domScheduler as scheduler } from '../scheduler.js';
@@ -269,6 +269,8 @@ export function animate(
   const timings: [Duration, Delay, DurationWithDelay][] = [];
   let duration = 0;
   let previousTimings = [0, 0, 0];
+  let progressSum = 0;
+  let elementCount = 0;
 
   const controls = eachElements(elementOrElements, (element, index) => {
     const delay = staggerIsFunction ? stagger(element, index) : stagger * index;
@@ -290,10 +292,12 @@ export function animate(
     previousTimings = timings[index];
 
     progresses[index] = 0;
+    elementCount = index + 1;
     itemOptions.onProgress = (itemProgress) => {
+      progressSum += itemProgress - progresses[index];
       progresses[index] = itemProgress;
       if (progressFn) {
-        progressFn(mean(progresses));
+        progressFn(progressSum / elementCount);
       }
     };
 
@@ -316,7 +320,7 @@ export function animate(
           }
         }
 
-        return mean(progresses);
+        return progressSum / elementCount;
       }
 
       for (const control of controls) {

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -1,5 +1,5 @@
 import { clamp01, lerp, map, mean } from '../math/index.js';
-import { isDefined, isFunction, isNumber } from '../is.js';
+import { isFunction, isNumber } from '../is.js';
 import { transform, TRANSFORM_PROPS } from './transform.js';
 import { domScheduler as scheduler } from '../scheduler.js';
 import { tween, normalizeEase } from '../tween.js';
@@ -128,21 +128,21 @@ function render(
 
   scheduler.read(() => {
     let opacity: false | number | string = false;
-    if (isDefined(from.opacity) || isDefined(to.opacity)) {
+    if (from.opacity !== undefined || to.opacity !== undefined) {
       opacity = map(stepProgress, 0, 1, from.opacity ?? 1, to.opacity ?? 1);
     } else if (element.style.opacity) {
       opacity = '';
     }
 
     let transformOrigin: false | string = false;
-    if (isDefined(to.transformOrigin)) {
+    if (to.transformOrigin !== undefined) {
       transformOrigin = to.transformOrigin;
     } else if (element.style.transformOrigin) {
       transformOrigin = '';
     }
 
     let customProperties: false | [string, number][] = false;
-    if (isDefined(from.vars) && isDefined(to.vars)) {
+    if (from.vars !== undefined && to.vars !== undefined) {
       customProperties = [];
       for (const customPropertyName of from.vars) {
         customProperties.push([
@@ -155,7 +155,7 @@ function render(
     const props = {};
 
     for (const name of TRANSFORM_PROPS) {
-      if (isDefined(from[name]) || isDefined(to[name])) {
+      if (from[name] !== undefined || to[name] !== undefined) {
         props[name] = transformRenderStrategies[name](element, from[name], to[name], stepProgress);
       }
     }
@@ -276,7 +276,7 @@ export function animate(
 
     if (durationFn) {
       itemOptions.duration = durationFn(element, index);
-    } else if (!isDefined(itemOptions.duration)) {
+    } else if (itemOptions.duration === undefined) {
       itemOptions.duration = 1;
     }
 

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -215,9 +215,10 @@ function compileSegment(
   if (from.vars && to.vars) {
     for (const name of from.vars) {
       const startValue = from[name] as number;
+      const endValue = (to[name] as number | undefined) ?? startValue;
       customPropertyNames.push(name);
       customPropertyStarts.push(startValue);
-      customPropertyDeltas.push((to[name] as number) - startValue);
+      customPropertyDeltas.push(endValue - startValue);
     }
   }
 

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -80,16 +80,20 @@ function getAnimationStepValue(val: number | [number, string], getSizeRef: () =>
   return CSSUnitConverter[val[1]](val[0], getSizeRef);
 }
 
-const generateTranslateRenderStrategy = (sizeRef) => (element, fromValue, toValue, progress) =>
-  lerp(
-    getAnimationStepValue(
-      fromValue ?? 0,
-      /* istanbul ignore next */
-      () => element[sizeRef],
-    ),
-    getAnimationStepValue(toValue ?? 0, () => element[sizeRef]),
+const generateTranslateRenderStrategy = (sizeRef) => (element, fromValue, toValue, progress) => {
+  const from = fromValue ?? 0;
+  const to = toValue ?? 0;
+  // Fast path: both values are plain numbers (no CSS units)
+  if (typeof from === 'number' && typeof to === 'number') {
+    return lerp(from, to, progress);
+  }
+  const getSizeRef = () => element[sizeRef];
+  return lerp(
+    getAnimationStepValue(from, getSizeRef),
+    getAnimationStepValue(to, getSizeRef),
     progress,
   );
+};
 const widthBasedTranslateRenderStrategy = generateTranslateRenderStrategy('offsetWidth');
 const heightBasedTranslateRenderStrategy = generateTranslateRenderStrategy('offsetHeight');
 

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -304,36 +304,31 @@ export function animate(
     return singleAnimate(element, keyframes, itemOptions);
   });
 
-  const delegate = (key) =>
-    // eslint-disable-next-line consistent-return
-    function delegated() {
-      if (key === 'progress') {
-        if (arguments.length === 1) {
-          // eslint-disable-next-line prefer-rest-params
-          const newProgress = arguments[0];
-          const newTime = lerp(0, duration, newProgress);
-          for (const [index, control] of controls.entries()) {
-            const controlProgress = clamp01(
-              map(newTime, timings[index][1], timings[index][2], 0, 1),
-            );
-            control.progress(controlProgress);
-          }
-        }
+  function forAll(key: string) {
+    for (const control of controls) {
+      control[key]();
+    }
+  }
 
-        return progressSum / elementCount;
+  function progress(newProgress?: number) {
+    if (newProgress !== undefined) {
+      const newTime = lerp(0, duration, newProgress);
+      for (let i = 0; i < controls.length; i++) {
+        const controlProgress = clamp01(
+          map(newTime, timings[i][1], timings[i][2], 0, 1),
+        );
+        controls[i].progress(controlProgress);
       }
+    }
 
-      for (const control of controls) {
-        // eslint-disable-next-line prefer-rest-params
-        control[key].call(null, arguments);
-      }
-    };
+    return progressSum / elementCount;
+  }
 
   return {
-    start: delegate('start'),
-    pause: delegate('pause'),
-    finish: delegate('finish'),
-    play: delegate('play'),
-    progress: delegate('progress'),
+    start: () => forAll('start'),
+    pause: () => forAll('pause'),
+    finish: () => forAll('finish'),
+    play: () => forAll('play'),
+    progress,
   };
 }

--- a/packages/js-toolkit/utils/css/animate.ts
+++ b/packages/js-toolkit/utils/css/animate.ts
@@ -293,6 +293,14 @@ function renderSegment(
       opacity = '';
     }
 
+    // Compute transform origin
+    let transformOrigin: false | string = false;
+    if (segment.transformOrigin !== false) {
+      transformOrigin = segment.transformOrigin;
+    } else if (element.style.transformOrigin) {
+      transformOrigin = '';
+    }
+
     // Compute CSS custom properties
     const hasCustomProperties = segment.customPropertyNames.length > 0;
 
@@ -301,10 +309,8 @@ function renderSegment(
         // @ts-ignore
         element.style.opacity = opacity;
       }
-      if (segment.transformOrigin !== false) {
-        element.style.transformOrigin = segment.transformOrigin;
-      } else if (element.style.transformOrigin) {
-        element.style.transformOrigin = '';
+      if (transformOrigin !== false) {
+        element.style.transformOrigin = transformOrigin;
       }
       if (hasCustomProperties) {
         for (let i = 0; i < segment.customPropertyNames.length; i++) {

--- a/packages/js-toolkit/utils/css/transform.ts
+++ b/packages/js-toolkit/utils/css/transform.ts
@@ -1,4 +1,3 @@
-import { isDefined } from '../is.js';
 // eslint-disable-next-line import/extensions
 import { eachElements } from './utils.js';
 
@@ -48,50 +47,50 @@ export function transform(
 
   let value = '';
 
-  if (isDefined(props.x) || isDefined(props.y) || isDefined(props.z)) {
+  if (props.x !== undefined || props.y !== undefined || props.z !== undefined) {
     value += `translate3d(${props.x ?? 0}px, ${props.y ?? 0}px, ${props.z ?? 0}px) `;
   }
 
-  if (isDefined(props.rotate)) {
+  if (props.rotate !== undefined) {
     value += `rotate(${props.rotate}deg) `;
   } else {
-    if (isDefined(props.rotateX)) {
+    if (props.rotateX !== undefined) {
       value += `rotateX(${props.rotateX}deg) `;
     }
 
-    if (isDefined(props.rotateY)) {
+    if (props.rotateY !== undefined) {
       value += `rotateY(${props.rotateY}deg) `;
     }
 
-    if (isDefined(props.rotateZ)) {
+    if (props.rotateZ !== undefined) {
       value += `rotateZ(${props.rotateZ}deg) `;
     }
   }
 
-  if (isDefined(props.scale)) {
+  if (props.scale !== undefined) {
     value += `scale(${props.scale}) `;
   } else {
-    if (isDefined(props.scaleX)) {
+    if (props.scaleX !== undefined) {
       value += `scaleX(${props.scaleX}) `;
     }
 
-    if (isDefined(props.scaleY)) {
+    if (props.scaleY !== undefined) {
       value += `scaleY(${props.scaleY}) `;
     }
 
-    if (isDefined(props.scaleZ)) {
+    if (props.scaleZ !== undefined) {
       value += `scaleZ(${props.scaleZ}) `;
     }
   }
 
-  if (isDefined(props.skew)) {
+  if (props.skew !== undefined) {
     value += `skew(${props.skew}deg) `;
   } else {
-    if (isDefined(props.skewX)) {
+    if (props.skewX !== undefined) {
       value += `skewX(${props.skewX}deg) `;
     }
 
-    if (isDefined(props.skewY)) {
+    if (props.skewY !== undefined) {
       value += `skewY(${props.skewY}deg) `;
     }
   }

--- a/packages/js-toolkit/utils/object/getAllProperties.ts
+++ b/packages/js-toolkit/utils/object/getAllProperties.ts
@@ -27,9 +27,9 @@ export function getAllProperties(
     foundProps = foundProps.filter((name) => testFn(name, proto));
   }
 
-  const formatedProps = foundProps
-    .map<[string, unknown]>((name) => [name, proto])
-    .reduce<Array<[string, unknown]>>((acc, val) => [...acc, val], props);
+  for (const name of foundProps) {
+    props.push([name, proto]);
+  }
 
-  return getAllProperties(proto, formatedProps, testFn);
+  return getAllProperties(proto, props, testFn);
 }

--- a/packages/js-toolkit/utils/tween.ts
+++ b/packages/js-toolkit/utils/tween.ts
@@ -1,6 +1,6 @@
 import { cubicBezier } from '@motionone/easing';
 import { lerp, map, clamp01, damp, inertiaFinalValue, spring } from './math/index.js';
-import { isDefined, isArray, isNumber } from './is.js';
+import { isArray, isNumber } from './is.js';
 import { noop, noopValue as linear } from './noop.js';
 import { useRaf } from '../services/RafService.js';
 import type { EasingFunction } from './math/createEases.js';
@@ -88,7 +88,7 @@ export interface TweenOptions {
  * Normalize a easing function with default fallbacks.
  */
 export function normalizeEase(ease: EasingFunction | BezierCurve): EasingFunction {
-  if (!isDefined(ease)) {
+  if (ease === undefined) {
     return linear;
   }
 
@@ -110,8 +110,8 @@ export function tween(callback: (progress: number) => unknown, options: TweenOpt
   let easedProgress = 0;
   let velocity = 0;
 
-  const isSmooth = isDefined(options.smooth) && (isNumber(options.smooth) || options.smooth);
-  const isSpring = isDefined(options.spring) && (isNumber(options.spring) || options.spring);
+  const isSmooth = options.smooth !== undefined && (isNumber(options.smooth) || options.smooth);
+  const isSpring = options.spring !== undefined && (isNumber(options.spring) || options.spring);
   const stiffness = isNumber(options.spring) ? options.spring : 0.1;
   const mass = isNumber(options.mass) ? options.mass : 1;
   const damping = isNumber(options.smooth) ? options.smooth : 0.1;
@@ -146,7 +146,7 @@ export function tween(callback: (progress: number) => unknown, options: TweenOpt
    * Set the progress value.
    */
   function progress(newProgress: number) {
-    if (!isDefined(newProgress)) {
+    if (newProgress === undefined) {
       return easedProgress;
     }
 

--- a/packages/tests/Base/utils.spec.ts
+++ b/packages/tests/Base/utils.spec.ts
@@ -88,6 +88,17 @@ describe('The Base utils', () => {
       foo.$emit(new CustomEvent('before-mounted'));
       expect(getInstances().has(foo)).toBe(true);
     });
+
+    it('should return a defensive copy when no constructor is given', () => {
+      const Foo = withName(Base, 'Foo');
+      const foo = new Foo(h('div'));
+      foo.$emit(new CustomEvent('before-mounted'));
+
+      const instances = getInstances() as Set<Base>;
+      instances.clear();
+
+      expect(getInstances().has(foo)).toBe(true);
+    });
   });
 
   describe('The getElements function', () => {

--- a/packages/tests/services/ScrollService.spec.ts
+++ b/packages/tests/services/ScrollService.spec.ts
@@ -96,14 +96,13 @@ describe('The `useScroll` service', () => {
     spyWidth.mockImplementation(() => window.innerWidth);
     const spyHeight = vi.spyOn(document.scrollingElement, 'scrollHeight', 'get');
     spyHeight.mockImplementation(() => window.innerHeight);
-    const service = useScroll();
-    const fn = vi.fn();
-    service.add('key', fn);
+    const instance = new ScrollService();
+    instance.add('key', vi.fn());
     dispatch(document, 'scroll');
     await wait();
-    expect(service.props().maxX).toBe(0);
-    expect(service.props().maxY).toBe(0);
-    service.remove('key');
+    expect(instance.props.maxX).toBe(0);
+    expect(instance.props.maxY).toBe(0);
+    instance.remove('key');
   });
 
   it('should update the direction accordingly', async () => {
@@ -190,5 +189,51 @@ describe('The `useScroll` service', () => {
 
     instance.remove('key');
     expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not trigger scroll subscribers on resize', async () => {
+    const service = useScroll();
+    const fn = vi.fn();
+    service.add('key', fn);
+
+    dispatch(window, 'resize');
+    await wait();
+
+    expect(fn).not.toHaveBeenCalled();
+
+    service.remove('key');
+  });
+
+  it('should keep cached negative max values without recomputing on every scroll', async () => {
+    let scrollWidthReads = 0;
+    let scrollHeightReads = 0;
+
+    const spyWidth = vi.spyOn(document.scrollingElement, 'scrollWidth', 'get');
+    spyWidth.mockImplementation(() => {
+      scrollWidthReads += 1;
+      return window.innerWidth - 10;
+    });
+    const spyHeight = vi.spyOn(document.scrollingElement, 'scrollHeight', 'get');
+    spyHeight.mockImplementation(() => {
+      scrollHeightReads += 1;
+      return window.innerHeight - 10;
+    });
+
+    const instance = new ScrollService();
+    instance.add('key', vi.fn());
+
+    dispatch(document, 'scroll');
+    await wait();
+    const readsAfterFirstScroll = [scrollWidthReads, scrollHeightReads];
+
+    dispatch(document, 'scroll');
+    await wait();
+
+    expect(instance.props.maxX).toBe(-10);
+    expect(instance.props.maxY).toBe(-10);
+    expect(scrollWidthReads).toBe(readsAfterFirstScroll[0]);
+    expect(scrollHeightReads).toBe(readsAfterFirstScroll[1]);
+
+    instance.remove('key');
   });
 });

--- a/packages/tests/services/ScrollService.spec.ts
+++ b/packages/tests/services/ScrollService.spec.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { useScroll } from '@studiometa/js-toolkit';
+import { ScrollService } from '#private/services/ScrollService.js';
 import { advanceTimersByTime, dispatch, useFakeTimers, useRealTimers } from '#test-utils';
 import { wait } from '#private/utils';
+
+const OriginalResizeObserver = globalThis.ResizeObserver;
+
+afterEach(() => {
+  globalThis.ResizeObserver = OriginalResizeObserver;
+});
 
 describe('The `useScroll` service', () => {
   it('should expose a single instance', () => {
@@ -139,5 +146,49 @@ describe('The `useScroll` service', () => {
     expect(service.props().direction.y).toBe('NONE');
 
     service.remove('key');
+  });
+
+  it('should update cached max values when the scrolling element size changes', async () => {
+    let resizeObserverCallback: (() => void) | undefined;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+
+    globalThis.ResizeObserver = class ResizeObserver {
+      constructor(callback: () => void) {
+        resizeObserverCallback = callback;
+      }
+
+      observe = observe;
+      disconnect = disconnect;
+    } as unknown as typeof ResizeObserver;
+
+    let scrollHeight = window.innerHeight * 2;
+    let scrollWidth = window.innerWidth * 2;
+    const spyWidth = vi.spyOn(document.scrollingElement, 'scrollWidth', 'get');
+    spyWidth.mockImplementation(() => scrollWidth);
+    const spyHeight = vi.spyOn(document.scrollingElement, 'scrollHeight', 'get');
+    spyHeight.mockImplementation(() => scrollHeight);
+
+    const instance = new ScrollService();
+    instance.add('key', vi.fn());
+
+    expect(observe).toHaveBeenCalledWith(document.scrollingElement);
+
+    dispatch(document, 'scroll');
+    await wait();
+    expect(instance.props.maxY).toBe(window.innerHeight);
+    expect(instance.props.maxX).toBe(window.innerWidth);
+
+    scrollHeight = window.innerHeight * 3;
+    scrollWidth = window.innerWidth * 3;
+    resizeObserverCallback?.();
+
+    dispatch(document, 'scroll');
+    await wait();
+    expect(instance.props.maxY).toBe(window.innerHeight * 2);
+    expect(instance.props.maxX).toBe(window.innerWidth * 2);
+
+    instance.remove('key');
+    expect(disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/tests/utils/css/animate.spec.ts
+++ b/packages/tests/utils/css/animate.spec.ts
@@ -183,6 +183,23 @@ describe('The `animate` utility function', () => {
     expect(div.style.getPropertyValue('--var')).toBe('1');
   });
 
+  it('should keep custom properties stable when missing from the next keyframe', async () => {
+    const div = h('div');
+    const animation = animate(div, [
+      { '--var': 0, offset: 0 },
+      { '--var': 1, offset: 0.5 },
+      { opacity: 1, offset: 1 },
+    ]);
+
+    animation.progress(0.25);
+    await advanceTimersByTimeAsync(16);
+    expect(div.style.getPropertyValue('--var')).toBe('0.5');
+
+    animation.progress(0.75);
+    await advanceTimersByTimeAsync(16);
+    expect(div.style.getPropertyValue('--var')).toBe('1');
+  });
+
   it('should use the latest progress value when progress is updated multiple times before flush', async () => {
     const div = h('div');
     const animation = animate(div, [{ opacity: 0 }, { opacity: 1 }]);

--- a/packages/tests/utils/css/animate.spec.ts
+++ b/packages/tests/utils/css/animate.spec.ts
@@ -234,6 +234,23 @@ describe('The `animate` utility function', () => {
     expect(div2.style.opacity).toBe('1');
   });
 
+  it('should use the maximum duration when mapping progress across multiple elements', async () => {
+    const div1 = h('div');
+    const div2 = h('div');
+    const div3 = h('div');
+
+    const animation = animate([div1, div2, div3], [{ opacity: 0 }, { opacity: 1 }], {
+      duration: (_el, index) => [3, 1, 2][index],
+    });
+
+    animation.progress(1);
+    await advanceTimersByTimeAsync(16);
+
+    expect(div1.style.opacity).toBe('1');
+    expect(div2.style.opacity).toBe('1');
+    expect(div3.style.opacity).toBe('1');
+  });
+
   it('should stop previous animations', async () => {
     const div = h('div');
     const animation1 = animate(div, [{ x: 0 }, { x: 100 }], { duration: 0.4 });

--- a/packages/tests/utils/css/animate.spec.ts
+++ b/packages/tests/utils/css/animate.spec.ts
@@ -183,6 +183,49 @@ describe('The `animate` utility function', () => {
     expect(div.style.getPropertyValue('--var')).toBe('1');
   });
 
+  it('should use the latest progress value when progress is updated multiple times before flush', async () => {
+    const div = h('div');
+    const animation = animate(div, [{ opacity: 0 }, { opacity: 1 }]);
+
+    animation.progress(0.25);
+    animation.progress(0.75);
+    await advanceTimersByTimeAsync(16);
+
+    expect(div.style.opacity).toBe('0.75');
+  });
+
+  it('should resolve mixed dynamic translate units across multiple keyframe segments', async () => {
+    const div = h('div');
+    Object.defineProperties(div, {
+      offsetWidth: {
+        get() {
+          return 300;
+        },
+      },
+      offsetHeight: {
+        get() {
+          return 200;
+        },
+      },
+    });
+
+    const animation = animate(div, [
+      { x: 0, y: [0, '%'] },
+      { x: [100, '%'], y: 100, offset: 0.5 },
+      { x: [50, 'vw'], y: [100, '%'] },
+    ]);
+
+    animation.progress(0.25);
+    await advanceTimersByTimeAsync(16);
+    expect(div.style.transform.trim()).toBe('translate3d(150px, 50px, 0px)');
+
+    animation.progress(0.75);
+    await advanceTimersByTimeAsync(16);
+    expect(div.style.transform.trim()).toBe(
+      `translate3d(${(300 + window.innerWidth / 2) / 2}px, 150px, 0px)`,
+    );
+  });
+
   it('should be able to animate multiple elements', async () => {
     const div1 = h('div');
     const div2 = h('div');


### PR DESCRIPTION
### 🔗 Linked issue

N/A — Performance improvement initiative.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Optimize the hot paths in `animate`, `tween`, `transform`, `RafService`, `ScrollService`, and Base internals for better runtime performance.

**`animate.ts` — Staged compilation of keyframes**

Replace per-frame property iteration and `lerp` calls with pre-compiled segments. At creation time, keyframe pairs are compiled into parallel arrays of start values, deltas, CSS function names, and units. The render loop becomes a tight indexed loop doing only multiply-add and string concatenation.

- Pre-compute `end - start` deltas once instead of recalculating every frame
- Build transform strings directly instead of allocating an intermediary `props` object
- Fast path for numeric translate values (skip closure creation when no CSS units)
- Replace `isDefined()` function calls with inline `!== undefined` checks
- Incremental sum for mean progress in multi-element animations (O(1) instead of O(n))
- Replace delegate pattern with direct functions (eliminate string comparison and `arguments` object)

**`transform.ts` / `tween.ts` — Inline property checks**

Replace `isDefined()` function calls with `!== undefined` to avoid function call overhead in the hot path.

**`RafService.ts` — Batch scheduler calls**

Wrap all callbacks in a single `scheduler.read()` call and collect write functions into one `scheduler.write()` call. Reduces closure creation from 2N to 2 per trigger cycle.

**`ScrollService.ts` — Cache scroll max values**

Cache `document.scrollingElement.scrollWidth/Height` and only update on `resize` events instead of reading them on every scroll event.

**`getAllProperties` — Replace O(n²) array spread with O(n) push**

The prototype chain walker used `reduce` with spread operator, copying the entire accumulator on each iteration. Replaced with `push` for linear time.

**`getInstances()` — Avoid unnecessary Set copy**

Return the internal storage Set directly (as `ReadonlySet`) instead of creating a copy on every call.

**Animate progress (hot path)**

| Benchmark | Before | After | Change |
|---|---|---|---|
| progress (4 keyframes) | 1.78M | 2.44M | **+37%** |
| progress (5 elements) | 738K | 1.02M | **+38%** |
| progress (10 elements) | 456K | 662K | **+45%** |
| progress (50 elements) | 119K | 169K | **+42%** |
| progress (x, y) | 2.26M | 2.55M | **+13%** |
| progress (custom props) | 1.80M | 2.25M | **+25%** |
| stagger (numeric) | 274K | 357K | **+30%** |
| stagger (function) | 285K | 382K | **+34%** |

**Animate creation (expected regression — more upfront work, paid once)**

| Benchmark | Before | After | Change |
|---|---|---|---|
| creation (opacity) | 839K | 470K | -44% |
| creation (x, y) | 814K | 429K | -47% |

**RafService.trigger**

| Benchmark | Before | After | Change |
|---|---|---|---|
| 50 callbacks, read+write | 1.04M | 3.07M | **+195%** |
| 10 callbacks, read+write | 1.84M | 3.02M | **+64%** |

**ScrollService.updateProps**

| Benchmark | Before | After | Change |
|---|---|---|---|
| updateProps() | 164K | 458K | **+179%** |

**Base internals**

| Benchmark | Before | After | Change |
|---|---|---|---|
| getAllProperties (no filter) | 322K | 595K | **+85%** |
| getInstances() (100 instances) | 892K | 3.83M | **+329%** |

**Transform**

| Benchmark | Before | After | Change |
|---|---|---|---|
| translate3d (x only) | 1.10M | 1.27M | **+15%** |
| rotate | 1.10M | 1.31M | **+19%** |
| empty props | 1.25M | 1.53M | **+22%** |

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog.