### PR TITLE
Release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v3.6.0](https://github.com/studiometa/js-toolkit/compare/3.6.0-beta.2..3.6.0) (2026-07-13)
+
 ### Added
 
 - **ESLint Plugin:** add `prefer-destructured-lookups` rule — warns when `this.$refs`, `this.$options` or `this.$children` members are accessed more than once in the same method without being destructured ([#729](https://github.com/studiometa/js-toolkit/pull/729))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/js-toolkit-workspace",
-      "version": "3.6.0-beta.2",
+      "version": "3.6.0",
       "workspaces": [
         "packages/*"
       ],
@@ -22476,7 +22476,7 @@
     },
     "packages/demo": {
       "name": "@studiometa/js-toolkit-demo",
-      "version": "3.6.0-beta.1",
+      "version": "3.6.0",
       "dependencies": {
         "@studiometa/ui": "1.7.0"
       },
@@ -22531,7 +22531,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/js-toolkit-docs",
-      "version": "3.6.0-beta.1",
+      "version": "3.6.0",
       "devDependencies": {
         "@shikijs/vitepress-twoslash": "4.0.2",
         "@studiometa/tailwind-config": "3.0.0",
@@ -22717,7 +22717,7 @@
     },
     "packages/eslint-plugin-js-toolkit": {
       "name": "@studiometa/eslint-plugin-js-toolkit",
-      "version": "3.6.0-beta.1",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -22732,7 +22732,7 @@
     },
     "packages/js-toolkit": {
       "name": "@studiometa/js-toolkit",
-      "version": "3.6.0-beta.1",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -22741,7 +22741,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/js-toolkit-tests",
-      "version": "3.6.0-beta.1",
+      "version": "3.6.0",
       "dependencies": {
         "@happy-dom/global-registrator": "20.8.8",
         "@vitest/coverage-v8": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-demo",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -111,6 +111,7 @@ function getGuideSidebar() {
       items: [
         { text: 'v1 → v2', link: '/guide/migration/v1-to-v2.html' },
         { text: 'v2 → v3', link: '/guide/migration/v2-to-v3.html' },
+        { text: 'v3 → v4', link: '/guide/migration/v3-to-v4.html' },
       ],
     },
   ];

--- a/packages/docs/api/instance-methods.md
+++ b/packages/docs/api/instance-methods.md
@@ -198,6 +198,10 @@ class Slider extends Base {
 }
 ```
 
+::: tip See also
+`$query` is the sanctioned **parent → child** channel: a parent reads and drives its declared descendants. See [Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components).
+:::
+
 ## `$closest(query)`
 
 Get the closest ancestor component instance matching the given query. This is sugar for `closestComponent(query, { from: this.$el })`.
@@ -229,6 +233,10 @@ class SliderItem extends Base {
   }
 }
 ```
+
+::: tip See also
+`$closest` resolves a dynamic ancestor from the DOM and returns `Base | undefined`. Always guard the result; never dereference it unguarded in `mounted()`. See [Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components).
+:::
 
 ## `$mount()`
 

--- a/packages/docs/api/instance-properties.md
+++ b/packages/docs/api/instance-properties.md
@@ -45,6 +45,10 @@ You can force a ref to be an `Array` even when only one corresponding element ex
 
 ::: warning Deprecated
 `$children` is deprecated and will be removed in v4. Use [`$query(name)`](./instance-methods.html#query-query) instead.
+
+Note that the two shapes differ: `$children` exposes a **name-keyed object** (`{ Figure: Figure[], Slider: Slider[] }`), whereas `$query(name)` returns a **flat `Base[]`** containing every matching descendant. Group by `$options.name` yourself if you need the name-keyed shape.
+
+See [Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components).
 :::
 
 An object containing references to all the children component instances, with each key being the name of the child component, and each value a list of its corresponding instances.
@@ -94,6 +98,10 @@ The resolved configuration based on the current class [static `config` property]
 
 ::: warning Deprecated
 `$parent` is deprecated and will be removed in v4. Use [`$closest(name)`](./instance-methods.html#closest-query) instead.
+
+`$parent` is a **live getter** that walks up the DOM ancestors on every access. It resolves to `null` unless a **live** (mounting or mounted) ancestor both lists the current component in its [`config.components`](./configuration.md#config-components) and DOM-contains this instance. An ancestor that has not started mounting, has been terminated, or that reaches this instance through the DOM without declaring it in `config.components` will not be matched — hence the `null`. Because resolution is dynamic, never dereference `$parent` unguarded.
+
+See [Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components).
 :::
 
 The parent instance when the current instance component is registered as another [component child](./configuration.md#config-components), defaults to `null` otherwise.
@@ -126,6 +134,10 @@ class Parent extends Base {
 
 ::: warning Deprecated
 `$root` is deprecated and will be removed in v4. Use [`$closest(name)`](./instance-methods.html#closest-query) instead.
+
+Unlike the old `$root`, the [`$closest(name)`](./instance-methods.html#closest-query) replacement resolves an ancestor dynamically from the DOM and returns `undefined` when no matching ancestor has been constructed — there is **no self-reference fallback**. Always guard the result; never dereference it unguarded in `mounted()`.
+
+See [Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components).
 :::
 
 The root instance of the application when the current instance has been mounted as a [child component](#components). Defaults to a self reference if the component is stand-alone.

--- a/packages/docs/guide/concepts/component-tree.md
+++ b/packages/docs/guide/concepts/component-tree.md
@@ -60,6 +60,15 @@ Components mount **depth-first, children before parents**. This guarantees that 
 
 The framework uses a queue internally to batch DOM reads and writes, avoiding layout thrashing during mount.
 
+::: warning Do not assume an ancestor exists while mounting
+The children-before-parents guarantee runs **one way**: it covers the children a parent mounts through its own `ChildrenManager` (declared in `config.components` and DOM-contained). Whether the **reverse** works — a child resolving its parent from its own `mounted()` — depends on **how the child was mounted**:
+
+- **Mounted by its parent** — the ancestor is already constructed and registered (from its `before-mounted`, before `mountAll()` runs), so [`$closest`](/api/instance-methods.html#closest-query) and `$parent` resolve, even though the parent is not yet `$isMounted`.
+- **Mounted independently** — globally registered components (`registerComponent` recursively registers declared children) are auto-mounted by a document-wide `MutationObserver`, and lazy/async children mount on their own schedule. On that path the ancestor may not exist yet and `$closest` returns `undefined`.
+
+Application code cannot tell which path mounted a given instance, so never rely on an ancestor in `mounted()`. Route communication through the channels in [Data flow between components](#data-flow-between-components).
+:::
+
 ## Scoping
 
 Each component's scope is bounded by its root element (the `data-component` element). This scoping affects:
@@ -100,6 +109,152 @@ class Child extends Base {
 ::: tip API Reference
 See [Instance methods — $query](/api/instance-methods.html#query-query) and [Instance methods — $closest](/api/instance-methods.html#closest-query).
 :::
+
+## Data flow between components
+
+A component can't assume its parent exists while it is mounting (see [Mounting order](#mounting-order)). Both ancestor lookups are resolved dynamically — by walking the DOM ancestors on every access — but they differ:
+
+- **`$parent`** (deprecated) returns `null` unless a live ancestor both declares this component in its `config.components` and DOM-contains it.
+- **`$closest(name)`** returns any constructed ancestor with that name — including one not yet, or no longer, mounted (e.g. breakpoint-inactive) — and is `undefined` only when no such ancestor has been constructed. Add the `:mounted` state (`$closest('Slider:mounted')`) to require a mounted one, and always guard with `?.`.
+
+Structure communication through the sanctioned channels below. `$closest` element-correctness and the store utilities below require `@studiometa/js-toolkit >= 3.6.0`.
+
+### Parent → child: `$query`
+
+The parent is always mounted when it queries, so reading or commanding children is safe:
+
+```js
+class Slider extends Base {
+  static config = { name: 'Slider', components: { SliderBtn } };
+
+  goTo(index) {
+    this.$query('SliderBtn').forEach((btn) => btn.setActive(index));
+  }
+}
+```
+
+### Child → parent: `$emit`
+
+Children never dereference the parent — they emit, and the parent listens via the `on<Child>` convention:
+
+```js
+class SliderBtn extends Base {
+  // The emitted event name must differ from the DOM event (`click`), otherwise
+  // `$emit` re-dispatches on `$el` and re-triggers `onClick` in a loop.
+  static config = { name: 'SliderBtn', emits: ['go-to-index'] };
+
+  onClick() {
+    this.$emit('go-to-index', this.index);
+  }
+}
+
+class Slider extends Base {
+  static config = { name: 'Slider', components: { SliderBtn } };
+
+  // Child-event handlers receive a single params object; `args` holds the payload.
+  onSliderBtnGoToIndex({ args: [index] }) {
+    this.goTo(index);
+  }
+}
+```
+
+### Dynamic ancestor lookup: `$closest`
+
+When a child genuinely needs the ancestor, resolve it lazily and guard the result with `?.` — never at construction, and **never unguarded in `mounted()`**:
+
+```js
+class SliderBtn extends Base {
+  static config = { name: 'SliderBtn' };
+
+  onClick() {
+    this.$closest('Slider')?.goTo(this.index); // undefined-safe
+  }
+}
+```
+
+### Shared state: a per-instance store
+
+When both sides read and write the same state (e.g. the active `index`), lift it into a store and drop the parent⇄child runtime dependency. Give **each** parent its own store instance so multiple sliders on a page don't share state:
+
+```js
+// Slider/Slider.js
+import { Base } from '@studiometa/js-toolkit';
+import {
+  createStorage,
+  createMemoryStorageProvider,
+} from '@studiometa/js-toolkit/utils';
+import { SliderChild } from './SliderChild.js';
+
+export class Slider extends Base {
+  static config = { name: 'Slider', components: { SliderChild } };
+
+  // One store per Slider instance — the shared `memoryStorageProvider`
+  // singleton would sync every Slider on the page.
+  store = createStorage({ provider: createMemoryStorageProvider() });
+
+  index = 0;
+
+  mounted() {
+    // Runs after `__children.mountAll()`, so every SliderChild is mounted. The
+    // parent reaches its children deterministically regardless of how they were
+    // mounted, so subscribe them from here, then push the current state so every
+    // subscriber receives its initial value. `$query` matches descendants at any
+    // depth; with nested Sliders the idempotent `subscribe()` keeps each child on
+    // the innermost store it already joined.
+    for (const child of this.$query('SliderChild')) {
+      child.subscribe(this.store);
+    }
+    this.store.set('index', this.index);
+  }
+
+  goTo(index) {
+    this.index = index;
+    this.store.set('index', index);
+  }
+}
+```
+
+```js
+// Slider/SliderChild.js
+import { Base } from '@studiometa/js-toolkit';
+import { isFunction } from '@studiometa/js-toolkit/utils';
+
+export class SliderChild extends Base {
+  static config = { name: 'SliderChild' };
+
+  index = 0;
+
+  // Idempotent: safe to call from the parent's handshake and from a late mount.
+  subscribe(store) {
+    if (isFunction(this.unsubscribe)) return;
+    this.index = store.get('index') ?? this.index;
+    this.unsubscribe = store.subscribe('index', (index) => {
+      this.index = index;
+    });
+  }
+
+  mounted() {
+    // A child mounted *after* its Slider (e.g. through `$update()`) can resolve
+    // it here; guard because `$closest` is undefined when it cannot.
+    const slider = this.$closest('Slider');
+    if (slider) this.subscribe(slider.store);
+  }
+
+  destroyed() {
+    if (isFunction(this.unsubscribe)) this.unsubscribe();
+    // Clear it so a destroy → remount cycle can subscribe again.
+    this.unsubscribe = undefined;
+  }
+}
+```
+
+::: warning Two-sided handshake
+Whether a `SliderChild` can resolve its `Slider` from its own `mounted()` depends on the mount path (see [Mounting order](#mounting-order)): when the `Slider` mounts its children, the ancestor is already resolvable; but a child auto-mounted independently (global registry, lazy import) can run `mounted()` before its `Slider` exists, where `$closest('Slider')` is `undefined`. A child that only subscribed through a guarded `$closest('Slider')?.store.subscribe(...)` would then be **silently never subscribed** and would never sync, with no error.
+
+The handshake closes the gap from both sides: the child subscribes itself whenever it _can_ reach the Slider, and the `Slider` subscribes every child from its **own** `mounted()`, which runs after `__children.mountAll()` and reaches them deterministically before pushing the current state. Making `subscribe()` idempotent lets both paths run without double-subscribing.
+:::
+
+For state shared across unrelated components or persisted across reloads, use a module-level store with [`createLocalStorage`/`createSessionStorage`](/utils/storage/createStorage.html) instead of a per-instance memory provider.
 
 ## Dynamic updates
 

--- a/packages/docs/guide/migration/v3-to-v4.md
+++ b/packages/docs/guide/migration/v3-to-v4.md
@@ -1,0 +1,75 @@
+# Migrating from v3 to v4
+
+Read through the following steps before upgrading from v3 to v4 of this package. The tree-traversal properties deprecated in 3.5.0 are removed in v4.
+
+[[toc]]
+
+## Base framework
+
+### `$children` has been removed — use `$query(name)`
+
+The `$children` getter has been removed. Use [`$query(name)`](/api/instance-methods.html#query-query) instead.
+
+```diff
+- this.$children.SliderItem
++ this.$query('SliderItem')
+```
+
+`$query` does not return a keyed object like `$children` did — it returns a flat `Base[]` of **all** matching descendants, at any depth. It takes a query string in the format `ComponentName(.selector):state`, so update any code that indexed into `$children` by component name:
+
+```js
+for (const item of this.$children.SliderItem) { // [!code --]
+for (const item of this.$query('SliderItem')) { // [!code ++]
+  item.setActive();
+}
+```
+
+See [Component Tree — Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components) for the sanctioned parent → child pattern.
+
+### `$parent` has been removed — use `$closest(name)`
+
+The `$parent` getter has been removed. Use [`$closest(name)`](/api/instance-methods.html#closest-query) instead, naming the ancestor component you need.
+
+```diff
+- this.$parent.goTo(index)
++ this.$closest('Parent')?.goTo(index)
+```
+
+::: warning `$closest` is resolved dynamically — always guard it
+Like `$parent` since 3.5.0, `$closest` is resolved dynamically on every access and returns `Base | undefined`. Always guard the result (`this.$closest('Parent')?.method()`) and **never dereference it unguarded in `mounted()`**.
+
+`$closest` walks the DOM ancestors and returns `undefined` only when **no matching ancestor instance has been constructed**. Unlike `$parent`, it ignores `config.components` and still returns an ancestor that is not yet, or no longer, mounted (e.g. breakpoint-inactive) — add the `:mounted` state (`$closest('Parent:mounted')`) when you need a mounted one. Whether an ancestor is resolvable from a child's own `mounted()` depends on the mount path: it is resolvable when the child is mounted by its parent, but a child auto-mounted independently (global registry, lazy import) can run before its ancestor exists. `$closest`'s element-correct behavior shipped in 3.6.0 ([#724](https://github.com/studiometa/js-toolkit/pull/724)); the DOM-based `$parent`/`$query` resolution landed in [#730](https://github.com/studiometa/js-toolkit/pull/730). See [Component Tree — Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components).
+:::
+
+### `$root` has been removed — use `$closest(name)`
+
+The `$root` getter has been removed. Use [`$closest(name)`](/api/instance-methods.html#closest-query) with the name of your actual root component instead.
+
+```diff
+- this.$root.doSomething()
++ this.$closest('App')?.doSomething()
+```
+
+The old self-reference fallback — `$root` pointing at the current instance when it was stand-alone — is gone. Guard the result: `$closest` returns `undefined` when no matching ancestor has been constructed.
+
+## Patterns
+
+### Replacing parent⇄child coupling
+
+The removed properties encouraged instances to reach across the tree and assume the other side exists. Restructure that coupling through the sanctioned channels, in order of preference:
+
+- **parent → child** — the parent reads or commands children with [`$query(name)`](/api/instance-methods.html#query-query) (the parent is reliably mounted when it queries).
+- **child → parent** — children never dereference the parent; they `$emit` and the parent listens via the `on<Child>` convention.
+- **dynamic ancestor lookup** — resolve the ancestor lazily with a guarded `$closest(name)?.…`, never unguarded in `mounted()`.
+- **shared state** — lift state both sides read and write into a per-instance store built with `createStorage` / `createMemoryStorageProvider` (both require `@studiometa/js-toolkit >= 3.6.0`). Give each parent its own provider instance — the shared `memoryStorageProvider` singleton would sync state across every instance on the page.
+
+| Anti-pattern (v3)                                                                                         | Pattern (v4)                                                           |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `this.$children.Item` (keyed object)                                                                      | `this.$query('Item')` (flat `Base[]`)                                  |
+| `this.$parent.method()`                                                                                   | `this.$closest('Parent')?.method()`                                    |
+| `this.$root.method()`                                                                                     | `this.$closest('App')?.method()`                                       |
+| Child dereferences `$parent` in `mounted()`                                                               | Child `$emit`s; parent listens via `on<Child>`                         |
+| Child subscribes via `$closest` in `mounted()` (silently skipped when the ancestor isn't constructed yet) | Two-sided handshake: parent subscribes children in its own `mounted()` |
+| State duplicated on parent and children                                                                   | Per-instance `createStorage` store both sides use                      |
+
+Why `$closest` can be `undefined`: it is resolved dynamically by walking the DOM ancestors and is empty only when no matching ancestor instance has been constructed — which happens when a child is auto-mounted independently of its ancestor (global registry, lazy import). It ignores `config.components` and still returns a destroyed or breakpoint-inactive ancestor, so use `$closest('Parent:mounted')` when you need a mounted one. A child that only subscribes through a guarded `$closest('Parent')?.subscribe(...)` in `mounted()` is **silently never subscribed** when the ancestor is unresolved — no error is thrown. See [Component Tree — Data flow between components](/guide/concepts/component-tree.html#data-flow-between-components) for the full store example, including the two-sided handshake that avoids this pitfall.

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-docs",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/eslint-plugin-js-toolkit/package.json
+++ b/packages/eslint-plugin-js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-js-toolkit",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0",
   "description": "Oxlint/ESLint plugin for @studiometa/js-toolkit best practices",
   "publishConfig": {
     "access": "public"

--- a/packages/js-toolkit/package.json
+++ b/packages/js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0",
   "description": "A set of useful little bits of JavaScript to boost your project! 🚀",
   "publishConfig": {
     "access": "public"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-tests",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Ship **3.6.0 stable** (from the `3.6.0-beta.*` line).

## Included

- **Component tree resolution performance** (#730, already on `main`): DOM-based `__parent`/`$query` resolution.
- **New docs — component data flow**: a "Data flow between components" section on the Component Tree concept page (sanctioned channels: `$query` down, `$emit` up, guarded `$closest`, per-instance `createStorage` store), a corrected "Mounting order" caveat (an ancestor is resolvable from a child's `mounted()` when mounted by its parent, not necessarily on the independent auto-mount path), a new **v3 → v4 migration** page, and expanded `$parent`/`$root`/`$closest`/`$query` API callouts distinguishing `$parent` (config.components-gated) from `$closest` (any constructed ancestor).
- **Release prep**: version bump to `3.6.0` across workspaces + CHANGELOG.

Docs accuracy was verified against the real 3.6.0 API (imports/exports, `$closest` vs `$parent` semantics, per-instance store, two-sided handshake) before landing.

> Addresses the documentation gap around child→parent data flow. The related `@studiometa/ui` Slider refactor is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)