### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v3.7.0](https://github.com/studiometa/js-toolkit/compare/3.6.2..3.7.0) (2026-07-20)
+
 ### Added
 
 - Add optional scoped group resolution to the `withGroup` decorator via `getScope`/`getGroup` callbacks, with a new `getScopedGroups(scope)` helper to enumerate a scope's groups ([#739](https://github.com/studiometa/js-toolkit/issues/739), [#741](https://github.com/studiometa/js-toolkit/pull/741))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/js-toolkit-workspace",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "workspaces": [
         "packages/*"
       ],
@@ -22476,7 +22476,7 @@
     },
     "packages/demo": {
       "name": "@studiometa/js-toolkit-demo",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "dependencies": {
         "@studiometa/ui": "1.7.0"
       },
@@ -22531,7 +22531,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/js-toolkit-docs",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "devDependencies": {
         "@shikijs/vitepress-twoslash": "4.0.2",
         "@studiometa/tailwind-config": "3.0.0",
@@ -22717,7 +22717,7 @@
     },
     "packages/eslint-plugin-js-toolkit": {
       "name": "@studiometa/eslint-plugin-js-toolkit",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -22732,7 +22732,7 @@
     },
     "packages/js-toolkit": {
       "name": "@studiometa/js-toolkit",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -22741,7 +22741,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/js-toolkit-tests",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "dependencies": {
         "@happy-dom/global-registrator": "20.8.8",
         "@vitest/coverage-v8": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-demo",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-docs",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/eslint-plugin-js-toolkit/package.json
+++ b/packages/eslint-plugin-js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-js-toolkit",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Oxlint/ESLint plugin for @studiometa/js-toolkit best practices",
   "publishConfig": {
     "access": "public"

--- a/packages/js-toolkit/package.json
+++ b/packages/js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "A set of useful little bits of JavaScript to boost your project! 🚀",
   "publishConfig": {
     "access": "public"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-tests",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Prepare the 3.7.0 release.

### Added

- Add optional scoped group resolution to the `withGroup` decorator via `getScope`/`getGroup` callbacks, with a new `getScopedGroups(scope)` helper to enumerate a scope's groups ([#739](https://github.com/studiometa/js-toolkit/issues/739), [#741](https://github.com/studiometa/js-toolkit/pull/741))
- Add a `fold(value, min, max)` math util reflecting a value back and forth within a range, ping-pong style, completing the `clamp` / `wrap` pair ([#742](https://github.com/studiometa/js-toolkit/issues/742), [#743](https://github.com/studiometa/js-toolkit/pull/743))

### Fixed

- Fix `wrap` returning `NaN` for non-finite ranges — the value is now returned unchanged ([#742](https://github.com/studiometa/js-toolkit/issues/742), [#743](https://github.com/studiometa/js-toolkit/pull/743))

Once merged, tag `3.7.0` on the merge commit and push the tag to trigger the publish workflow.