### PR TITLE
Add an automated code review workflow for pull requests

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,31 @@
+name: code-review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: Review pull request
+    runs-on: ubuntu-latest
+    # Same-repo PRs only: fork PRs don't receive secrets on pull_request.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Provider creds (org secrets) + review settings (org variables). The
+    # CODE_REVIEW_ prefix on the credentials is de-prefixed to CLOUDFLARE_* by
+    # the CLI's env shim. Referenced directly here (not via a cross-org reusable
+    # workflow) because `secrets: inherit` does not carry org secrets across orgs.
+    env:
+      CODE_REVIEW_CLOUDFLARE_API_KEY: ${{ secrets.CODE_REVIEW_CLOUDFLARE_API_KEY }}
+      CODE_REVIEW_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CODE_REVIEW_CLOUDFLARE_ACCOUNT_ID }}
+      CODE_REVIEW_CLOUDFLARE_GATEWAY_ID: ${{ secrets.CODE_REVIEW_CLOUDFLARE_GATEWAY_ID }}
+      CODE_REVIEW_DEPTH: ${{ vars.CODE_REVIEW_DEPTH }}
+      CODE_REVIEW_THINKING_LEVEL: ${{ vars.CODE_REVIEW_THINKING_LEVEL }}
+      CODE_REVIEW_VERIFY_MODEL: ${{ vars.CODE_REVIEW_VERIFY_MODEL }}
+    steps:
+      # The composite action checks out the repo itself (checkout: true default).
+      - uses: weareikko/code-review@0.8.5
+        with:
+          model: ${{ vars.CODE_REVIEW_MODEL }}


### PR DESCRIPTION
## Summary

Add the same automated PR code review setup as [studiometa/ui](https://github.com/studiometa/ui/blob/main/.github/workflows/code-review.yml):

- Triggers on `pull_request` (same-repo PRs only — forks don't receive secrets)
- Uses the `weareikko/code-review` composite action
- Org-level Cloudflare AI Gateway credentials (`CODE_REVIEW_CLOUDFLARE_*` secrets) and review settings (`CODE_REVIEW_*` variables) are shared across the org, so no additional configuration is needed

## Difference with studiometa/ui

The action is pinned to `0.8.5` (latest tag) instead of `0.8.2`. Happy to align on `0.8.2` if we prefer strict parity.