### PR TITLE
Prepare 3.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v3.8.0](https://github.com/studiometa/js-toolkit/compare/3.7.0..3.8.0) (2026-07-23)
+
 ### Added
 
 - Add a `registerComponents(...ctors)` helper to register and mount several components at once, wrapping `registerComponent` and accepting the same component forms — components register independently, so one failure (e.g. a rejected dynamic import) does not block the others

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/js-toolkit-workspace",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "workspaces": [
         "packages/*"
       ],
@@ -22476,7 +22476,7 @@
     },
     "packages/demo": {
       "name": "@studiometa/js-toolkit-demo",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "dependencies": {
         "@studiometa/ui": "1.7.0"
       },
@@ -22531,7 +22531,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/js-toolkit-docs",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "devDependencies": {
         "@shikijs/vitepress-twoslash": "4.0.2",
         "@studiometa/tailwind-config": "3.0.0",
@@ -22717,7 +22717,7 @@
     },
     "packages/eslint-plugin-js-toolkit": {
       "name": "@studiometa/eslint-plugin-js-toolkit",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -22732,7 +22732,7 @@
     },
     "packages/js-toolkit": {
       "name": "@studiometa/js-toolkit",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -22741,7 +22741,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/js-toolkit-tests",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "dependencies": {
         "@happy-dom/global-registrator": "20.8.8",
         "@vitest/coverage-v8": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-demo",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-docs",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/eslint-plugin-js-toolkit/package.json
+++ b/packages/eslint-plugin-js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-js-toolkit",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Oxlint/ESLint plugin for @studiometa/js-toolkit best practices",
   "publishConfig": {
     "access": "public"

--- a/packages/js-toolkit/package.json
+++ b/packages/js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "A set of useful little bits of JavaScript to boost your project! 🚀",
   "publishConfig": {
     "access": "public"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-tests",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release **v3.8.0**.

Bumps all workspace packages `3.7.0 → 3.8.0` and moves the changelog entries under the [v3.8.0] heading.

## Highlights

### Added
- `registerComponents(...ctors)` — register and mount several components at once, wrapping `registerComponent` and accepting the same component forms (constructor, `Promise`, module namespace, or `() => import(...)` factory). Components register independently, so one failure does not block the others ([#746](https://github.com/studiometa/js-toolkit/pull/746)).

### Fixed / Changed
- `registerComponent` no longer throws on a dynamic `import(...)`: the module `default` export is unwrapped automatically, and a `() => import(...)` factory is accepted.
- `registerComponent` now mounts each matching element independently — an element that fails to mount is skipped and logged in development instead of rejecting the whole call.

See [CHANGELOG.md](https://github.com/studiometa/js-toolkit/blob/release/3.8.0/CHANGELOG.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)