### PR TITLE
Harden the task queue against synchronously-throwing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a component whose lifecycle hook throws synchronously wedging the shared task queue and stopping every other component on the page from mounting — the batch was aborted, its remaining tasks orphaned and the scheduling flag left stuck, so no later batch was ever flushed ([#749](https://github.com/studiometa/js-toolkit/pull/749))
+- Fix `Queue.add()` never settling when its task throws synchronously — the returned promise now rejects with the error, exactly like an `async` task whose promise rejects ([#749](https://github.com/studiometa/js-toolkit/pull/749))
+- Fix `registerComponent()` returning an instance that failed to mount as a successful registration — instances that are not mounted are skipped again, as documented in v3.8.0 ([#749](https://github.com/studiometa/js-toolkit/pull/749))
+
+### Changed
+
+- `$mount()`, `$update()`, `$destroy()` and `$terminate()` no longer reject when a lifecycle hook fails: they run detached on a shared queue and are commonly called fire-and-forget, so a rejection had no awaiter. The error is re-thrown from a microtask instead, keeping it visible to `window.onerror` and error monitors, wrapped with the instance `$id` and the failed lifecycle and carrying the original error as its `cause`. `after-mounted` and `after-destroyed` are still not emitted on failure ([#749](https://github.com/studiometa/js-toolkit/pull/749))
+- With the `blocking` feature enabled the lifecycle methods keep rejecting — no queue is involved there, so `try { await createApp(App, { blocking: true }) } catch {}` still catches startup failures ([#749](https://github.com/studiometa/js-toolkit/pull/749))
+
 ## [v3.8.2](https://github.com/studiometa/js-toolkit/compare/3.8.1..3.8.2) (2026-08-06)
 
 ### Fixed

--- a/packages/docs/api/instance-methods.md
+++ b/packages/docs/api/instance-methods.md
@@ -277,3 +277,13 @@ Terminate the component. Its instance becomes available for garbage collection.
 :::warning
 A terminated component can not be re-mounted, use with precaution.
 :::
+
+## Error handling
+
+Lifecycle methods run their work through a shared task queue, and they are commonly called fire-and-forget (`$mount()` from the auto-mounting mutation observer, `$terminate()` when an element leaves the DOM). A rejection there would have no awaiter, so `$mount()`, `$update()`, `$destroy()` and `$terminate()` **resolve even when a lifecycle hook throws**.
+
+The error is not swallowed: it is re-thrown from a microtask, so it reaches `window.onerror` and any error monitor, wrapped in an error naming the instance and the failed lifecycle, with the original error as its `cause`.
+
+A failed lifecycle stops at the point of failure: `after-mounted` and `after-destroyed` are not emitted, and a component whose wiring failed stays unmounted. A component whose `mounted()` hook threw is wired, so `$isMounted` is `true` and `$destroy()` can still tear it down.
+
+With the [`blocking` feature](./helpers/createApp.md) enabled no queue is involved — the work runs synchronously in the caller's stack — so the lifecycle methods keep rejecting and `try { await createApp(App, { blocking: true }) } catch {}` still catches startup failures.

--- a/packages/docs/utils/Queue.md
+++ b/packages/docs/utils/Queue.md
@@ -17,3 +17,30 @@ queue.add(() => console.log('2'));
 
 - `concurrency` (`Number`): the number of tasks to execute at the same time, defaults to `10`
 - `waiter` (`(cb: (...args:unknown[]) => unknown) => unknown`): a scheduler function for the next batch execution, defaults to an immediately invoked function `(cb) => cb()`
+
+## `add(task)`
+
+Add a task to the queue.
+
+**Return value**
+
+- `Promise<unknown>`: a promise resolving with the value returned by the task.
+
+The promise **rejects when the task fails**, whether it throws synchronously or returns a rejected promise. The failure is contained: the other tasks of the batch still run, and the queue keeps scheduling later batches.
+
+:::warning
+A task that can fail must have its rejection observed, otherwise it becomes an unhandled rejection.
+
+```js
+// Fire-and-forget is fine for a task that can not fail.
+queue.add(() => console.log('1'));
+
+// Otherwise, await the promise or attach a `catch`.
+try {
+  await queue.add(() => mightThrow());
+} catch (error) {
+  // Handle the failure.
+}
+```
+
+:::

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -7,7 +7,7 @@ import {
   deleteInstance,
   addToRegistry,
   hasInstance,
-  reportQueuedTaskError,
+  handleLifecycleError,
 } from './utils.js';
 import {
   ChildrenManager,
@@ -489,15 +489,13 @@ export class Base<T extends BaseProps = BaseProps> {
         this.__callMethod('mounted');
       });
     } catch (error) {
-      // A queued mount task failed. Leave the component in an honest state
-      // instead of emitting `after-mounted` as if init completed: `$isMounted`
-      // keeps whatever value it reached (still `false` when the failure happened
-      // during wiring), so the component is not falsely reported as mounted.
-      // The error is surfaced through the log rather than re-thrown — the queued
-      // task ran detached, and most callers ($mount is often fire-and-forget)
-      // would only turn a rejection into an unhandled rejection.
+      // A queued mount task failed. Do not emit `after-mounted` as if init had
+      // completed, and leave `$isMounted` at whatever value it reached: `false`
+      // when the failure happened while wiring, `true` when the `mounted()` hook
+      // itself threw — the component is wired in that case, and `$destroy()`
+      // relies on the flag to tear it down.
       this.__isMounting = false;
-      reportQueuedTaskError(error);
+      handleLifecycleError(this, '$mount', error);
       return this;
     }
 
@@ -531,10 +529,7 @@ export class Base<T extends BaseProps = BaseProps> {
 
       await addToQueue(() => this.__callMethod('updated'));
     } catch (error) {
-      // Surface a failed queued update task instead of rejecting: `$update` is
-      // commonly called fire-and-forget, so a rejection would only produce an
-      // unhandled rejection.
-      reportQueuedTaskError(error);
+      handleLifecycleError(this, '$update', error);
     }
 
     return this;
@@ -567,10 +562,9 @@ export class Base<T extends BaseProps = BaseProps> {
       await addToQueue(() => this.__callMethod('destroyed'));
     } catch (error) {
       // A queued teardown task failed. Do not emit `after-destroyed` (which
-      // removes the instance from the global storage) as if teardown completed;
-      // surface the error instead of re-throwing so fire-and-forget callers do
-      // not produce an unhandled rejection.
-      reportQueuedTaskError(error);
+      // removes the instance from the global storage) as if teardown had
+      // completed.
+      handleLifecycleError(this, '$destroy', error);
       return this;
     }
 
@@ -598,10 +592,7 @@ export class Base<T extends BaseProps = BaseProps> {
         addToQueue(() => this.$el.__base__.set(this.$config.name, 'terminated')),
       ]);
     } catch (error) {
-      // Surface a failed queued termination task instead of rejecting:
-      // `$terminate` is called fire-and-forget (e.g. from `mutationCallback`),
-      // so a rejection would only produce an unhandled rejection.
-      reportQueuedTaskError(error);
+      handleLifecycleError(this, '$terminate', error);
     }
   }
 

--- a/packages/js-toolkit/Base/Base.ts
+++ b/packages/js-toolkit/Base/Base.ts
@@ -7,6 +7,7 @@ import {
   deleteInstance,
   addToRegistry,
   hasInstance,
+  reportQueuedTaskError,
 } from './utils.js';
 import {
   ChildrenManager,
@@ -474,18 +475,31 @@ export class Base<T extends BaseProps = BaseProps> {
       this.__debug('$mount');
     }
 
-    await Promise.all([
-      addToQueue(() => this.__children.registerAll()),
-      addToQueue(() => this.__refs.registerAll()),
-      addToQueue(() => this.__events.bindRootElement()),
-      addToQueue(() => this.__services.enableAll()),
-      addToQueue(() => this.__children.mountAll()),
-    ]);
+    try {
+      await Promise.all([
+        addToQueue(() => this.__children.registerAll()),
+        addToQueue(() => this.__refs.registerAll()),
+        addToQueue(() => this.__events.bindRootElement()),
+        addToQueue(() => this.__services.enableAll()),
+        addToQueue(() => this.__children.mountAll()),
+      ]);
 
-    await addToQueue(() => {
-      this.$isMounted = true;
-      this.__callMethod('mounted');
-    });
+      await addToQueue(() => {
+        this.$isMounted = true;
+        this.__callMethod('mounted');
+      });
+    } catch (error) {
+      // A queued mount task failed. Leave the component in an honest state
+      // instead of emitting `after-mounted` as if init completed: `$isMounted`
+      // keeps whatever value it reached (still `false` when the failure happened
+      // during wiring), so the component is not falsely reported as mounted.
+      // The error is surfaced through the log rather than re-thrown — the queued
+      // task ran detached, and most callers ($mount is often fire-and-forget)
+      // would only turn a rejection into an unhandled rejection.
+      this.__isMounting = false;
+      reportQueuedTaskError(error);
+      return this;
+    }
 
     this.__isMounting = false;
     this.$emit('after-mounted');
@@ -502,19 +516,26 @@ export class Base<T extends BaseProps = BaseProps> {
       this.__debug('$update');
     }
 
-    await Promise.all([
-      // Undo
-      addToQueue(() => this.__refs.unregisterAll()),
-      addToQueue(() => this.__services.disableAll()),
-      // Redo
-      addToQueue(() => this.__children.registerAll()),
-      addToQueue(() => this.__refs.registerAll()),
-      addToQueue(() => this.__services.enableAll()),
-      // Update
-      addToQueue(() => this.__children.updateAll()),
-    ]);
+    try {
+      await Promise.all([
+        // Undo
+        addToQueue(() => this.__refs.unregisterAll()),
+        addToQueue(() => this.__services.disableAll()),
+        // Redo
+        addToQueue(() => this.__children.registerAll()),
+        addToQueue(() => this.__refs.registerAll()),
+        addToQueue(() => this.__services.enableAll()),
+        // Update
+        addToQueue(() => this.__children.updateAll()),
+      ]);
 
-    await addToQueue(() => this.__callMethod('updated'));
+      await addToQueue(() => this.__callMethod('updated'));
+    } catch (error) {
+      // Surface a failed queued update task instead of rejecting: `$update` is
+      // commonly called fire-and-forget, so a rejection would only produce an
+      // unhandled rejection.
+      reportQueuedTaskError(error);
+    }
 
     return this;
   }
@@ -535,14 +556,23 @@ export class Base<T extends BaseProps = BaseProps> {
     this.$emit('before-destroyed');
     this.$isMounted = false;
 
-    await Promise.all([
-      addToQueue(() => this.__events.unbindRootElement()),
-      addToQueue(() => this.__refs.unregisterAll()),
-      addToQueue(() => this.__services.disableAll()),
-      addToQueue(() => this.__children.destroyAll()),
-    ]);
+    try {
+      await Promise.all([
+        addToQueue(() => this.__events.unbindRootElement()),
+        addToQueue(() => this.__refs.unregisterAll()),
+        addToQueue(() => this.__services.disableAll()),
+        addToQueue(() => this.__children.destroyAll()),
+      ]);
 
-    await addToQueue(() => this.__callMethod('destroyed'));
+      await addToQueue(() => this.__callMethod('destroyed'));
+    } catch (error) {
+      // A queued teardown task failed. Do not emit `after-destroyed` (which
+      // removes the instance from the global storage) as if teardown completed;
+      // surface the error instead of re-throwing so fire-and-forget callers do
+      // not produce an unhandled rejection.
+      reportQueuedTaskError(error);
+      return this;
+    }
 
     this.$emit('after-destroyed');
 
@@ -558,14 +588,21 @@ export class Base<T extends BaseProps = BaseProps> {
       this.__debug('$terminate');
     }
 
-    await Promise.all([
-      // First, destroy the component.
-      addToQueue(() => this.$destroy()),
-      // Execute the `terminated` hook if it exists
-      addToQueue(() => this.__callMethod('terminated')),
-      // Delete instance
-      addToQueue(() => this.$el.__base__.set(this.$config.name, 'terminated')),
-    ]);
+    try {
+      await Promise.all([
+        // First, destroy the component.
+        addToQueue(() => this.$destroy()),
+        // Execute the `terminated` hook if it exists
+        addToQueue(() => this.__callMethod('terminated')),
+        // Delete instance
+        addToQueue(() => this.$el.__base__.set(this.$config.name, 'terminated')),
+      ]);
+    } catch (error) {
+      // Surface a failed queued termination task instead of rejecting:
+      // `$terminate` is called fire-and-forget (e.g. from `mutationCallback`),
+      // so a rejection would only produce an unhandled rejection.
+      reportQueuedTaskError(error);
+    }
   }
 
   /**

--- a/packages/js-toolkit/Base/managers/ChildrenManager.ts
+++ b/packages/js-toolkit/Base/managers/ChildrenManager.ts
@@ -1,6 +1,6 @@
 import type { Base, BaseConstructor, BaseAsyncConstructor, BaseEl } from '../index.js';
 import { AbstractManager } from './AbstractManager.js';
-import { getComponentElements, addToQueue } from '../utils.js';
+import { getComponentElements, addToQueue, reportQueuedTaskError } from '../utils.js';
 
 /**
  * Children manager.
@@ -204,9 +204,15 @@ export class ChildrenManager<T> extends AbstractManager<T> {
       for (const name of this.registeredNames) {
         for (const instance of this.props[name]) {
           if (instance instanceof Promise) {
-            instance.then((resolvedInstance) =>
-              addToQueue(() => this.__triggerHook(hook, resolvedInstance, name)),
-            );
+            // Fire-and-forget: this branch does not push into `promises`, so its
+            // result is never awaited. Attach a `.catch()` so a failure in the
+            // async child resolution or its queued hook is logged instead of
+            // becoming an unhandled rejection.
+            instance
+              .then((resolvedInstance) =>
+                addToQueue(() => this.__triggerHook(hook, resolvedInstance, name)),
+              )
+              .catch(reportQueuedTaskError);
           } else {
             promises.push(addToQueue(() => this.__triggerHook(hook, instance, name)));
           }

--- a/packages/js-toolkit/Base/managers/ChildrenManager.ts
+++ b/packages/js-toolkit/Base/managers/ChildrenManager.ts
@@ -206,13 +206,18 @@ export class ChildrenManager<T> extends AbstractManager<T> {
           if (instance instanceof Promise) {
             // Fire-and-forget: this branch does not push into `promises`, so its
             // result is never awaited. Attach a `.catch()` so a failure in the
-            // async child resolution or its queued hook is logged instead of
-            // becoming an unhandled rejection.
+            // async child resolution or its queued hook reaches the global error
+            // handler instead of becoming an unhandled rejection.
             instance
               .then((resolvedInstance) =>
                 addToQueue(() => this.__triggerHook(hook, resolvedInstance, name)),
               )
-              .catch(reportQueuedTaskError);
+              .catch((error) =>
+                reportQueuedTaskError(
+                  error,
+                  `[${this.__base.$id}] The \`${hook}\` hook failed for an async \`${name}\` child.`,
+                ),
+              );
           } else {
             promises.push(addToQueue(() => this.__triggerHook(hook, instance, name)));
           }

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -23,18 +23,37 @@ export function addToQueue(fn: () => unknown) {
 }
 
 /**
- * Report an error raised by a queued task.
+ * Surface an error raised by a queued task.
  *
  * Queued work runs detached from its original call site — fire-and-forget
- * mounts, mutation-driven auto-mounting, async children — so the returned
- * promise is often discarded. When such a task fails, its promise rejects with
- * no awaiter to observe it; routing it here keeps the failure visible instead
- * of turning it into an unhandled rejection or, worse, silently swallowing an
- * initialization error. It is reported unconditionally (not gated behind the
- * `log` option) so a genuine failure is never lost in production.
+ * mounts, mutation-driven auto-mounting, async children — so the promise
+ * returned by `addToQueue` is usually discarded and a rejection would be lost.
+ * Re-throwing from a microtask puts the failure back on the global error
+ * channel (`window.onerror`, `uncaughtException`, error monitors) without
+ * wedging the queue or the caller's control flow. The original error is kept as
+ * the `cause`, so its stack and type survive; `context` adds the component
+ * identity a bare rejection can not carry.
  */
-export function reportQueuedTaskError(error: unknown): void {
-  console.warn('[@studiometa/js-toolkit] A queued task failed:', error);
+export function reportQueuedTaskError(error: unknown, context: string): void {
+  queueMicrotask(() => {
+    throw new Error(context, { cause: error });
+  });
+}
+
+/**
+ * Handle an error raised by a queued lifecycle task.
+ *
+ * In blocking mode `addToQueue` runs the task synchronously in the caller's own
+ * stack — no queue, nothing to wedge — so the error is re-thrown and the
+ * lifecycle promise rejects exactly as it always has. That keeps
+ * `try { await createApp(App, { blocking: true }) } catch` working.
+ */
+export function handleLifecycleError(instance: Base, phase: string, error: unknown): void {
+  if (features.get('blocking')) {
+    throw error;
+  }
+
+  reportQueuedTaskError(error, `[${instance.$id}] The \`${phase}\` lifecycle failed.`);
 }
 
 const selectors = new Map();
@@ -196,10 +215,11 @@ function registry() {
 }
 
 function mutationCallback() {
-  // Fire-and-forget: the returned promise is discarded, so route a rejection
-  // (a synchronously-throwing task) to the log instead of letting it become an
-  // unhandled rejection. `addToQueue` returns `undefined` in blocking mode,
-  // hence the optional chaining.
+  // Fire-and-forget: the returned promise is discarded, so route a rejection (a
+  // constructor throwing while auto-mounting, for instance) to the global error
+  // handler instead of letting it become an unhandled rejection. In blocking
+  // mode `addToQueue` runs the task synchronously and returns `undefined` — the
+  // throw propagates to the mutation observer, hence the optional chaining.
   addToQueue(() => {
     for (const [nameOrSelector, ctor] of registry()) {
       for (const el of getComponentElements(nameOrSelector)) {
@@ -208,7 +228,9 @@ function mutationCallback() {
         }
       }
     }
-  })?.catch(reportQueuedTaskError);
+  })?.catch((error) =>
+    reportQueuedTaskError(error, 'Auto-mounting components after a DOM mutation failed.'),
+  );
 
   addToQueue(() => {
     for (const instance of getInstances()) {
@@ -216,7 +238,9 @@ function mutationCallback() {
         instance.$terminate();
       }
     }
-  })?.catch(reportQueuedTaskError);
+  })?.catch((error) =>
+    reportQueuedTaskError(error, 'Auto-terminating components after a DOM mutation failed.'),
+  );
 }
 
 export function addToRegistry(nameOrSelector: string, ctor: BaseConstructor) {

--- a/packages/js-toolkit/Base/utils.ts
+++ b/packages/js-toolkit/Base/utils.ts
@@ -22,6 +22,21 @@ export function addToQueue(fn: () => unknown) {
   return queue.add(fn);
 }
 
+/**
+ * Report an error raised by a queued task.
+ *
+ * Queued work runs detached from its original call site — fire-and-forget
+ * mounts, mutation-driven auto-mounting, async children — so the returned
+ * promise is often discarded. When such a task fails, its promise rejects with
+ * no awaiter to observe it; routing it here keeps the failure visible instead
+ * of turning it into an unhandled rejection or, worse, silently swallowing an
+ * initialization error. It is reported unconditionally (not gated behind the
+ * `log` option) so a genuine failure is never lost in production.
+ */
+export function reportQueuedTaskError(error: unknown): void {
+  console.warn('[@studiometa/js-toolkit] A queued task failed:', error);
+}
+
 const selectors = new Map();
 
 // Separator used for multi-component declaration in `data-component` attributeS.
@@ -181,6 +196,10 @@ function registry() {
 }
 
 function mutationCallback() {
+  // Fire-and-forget: the returned promise is discarded, so route a rejection
+  // (a synchronously-throwing task) to the log instead of letting it become an
+  // unhandled rejection. `addToQueue` returns `undefined` in blocking mode,
+  // hence the optional chaining.
   addToQueue(() => {
     for (const [nameOrSelector, ctor] of registry()) {
       for (const el of getComponentElements(nameOrSelector)) {
@@ -189,7 +208,7 @@ function mutationCallback() {
         }
       }
     }
-  });
+  })?.catch(reportQueuedTaskError);
 
   addToQueue(() => {
     for (const instance of getInstances()) {
@@ -197,7 +216,7 @@ function mutationCallback() {
         instance.$terminate();
       }
     }
-  });
+  })?.catch(reportQueuedTaskError);
 }
 
 export function addToRegistry(nameOrSelector: string, ctor: BaseConstructor) {

--- a/packages/js-toolkit/helpers/registerComponent.ts
+++ b/packages/js-toolkit/helpers/registerComponent.ts
@@ -11,8 +11,10 @@ import { isDev, isFunction } from '../utils/index.js';
  * - a factory function returning such a promise (`() => import(...)`).
  *
  * Instances are mounted independently: an element that fails to mount is
- * skipped (and logged in development) instead of failing the whole call, so
- * the resolved array contains every instance that mounted successfully.
+ * skipped instead of failing the whole call, so the resolved array contains
+ * every instance that mounted successfully. Mount failures reach the global
+ * error handler through `$mount`; a constructor that throws is logged in
+ * development.
  *
  * @link https://js-toolkit.studiometa.dev/api/helpers/registerComponent.html
  * @param ctor The component constructor, or a way to resolve it.
@@ -45,9 +47,16 @@ export async function registerComponent<T extends BaseConstructor = BaseConstruc
 
   return results.flatMap((result) => {
     if (result.status === 'fulfilled') {
-      return [result.value];
+      // `$mount()` resolves with the instance even when a queued mount task
+      // fails — the error goes to the global handler instead of rejecting, so a
+      // fire-and-forget mount can not become an unhandled rejection. Check the
+      // flag rather than the promise state to keep the documented contract:
+      // only instances that actually mounted are returned.
+      return result.value.$isMounted ? [result.value] : [];
     }
 
+    // The promise still rejects when the instance could not even be
+    // constructed, which no other channel reports.
     if (isDev) {
       console.error(
         '[registerComponent] An instance failed to mount and was skipped.',

--- a/packages/js-toolkit/utils/Queue.ts
+++ b/packages/js-toolkit/utils/Queue.ts
@@ -40,8 +40,23 @@ export class Queue {
    * Add a task to the queue.
    */
   add(task: () => unknown) {
-    const p = new Promise((resolve) => {
-      this.tasks.push(() => resolve(task()));
+    const p = new Promise((resolve, reject) => {
+      this.tasks.push(() => {
+        try {
+          resolve(task());
+        } catch (err) {
+          // Reject the returned promise so a synchronously-throwing task fails
+          // exactly like an asynchronous one whose promise rejects — a caller
+          // doing rollback in `catch` behaves the same regardless of whether the
+          // task was declared `async`. The rejection is the single surfacing
+          // channel for the error: do not also re-throw here, otherwise `run()`
+          // would report the same error a second time via its `queueMicrotask`.
+          // Fire-and-forget callers attach their own `.catch()` (see
+          // `Base/utils.ts` and `ChildrenManager.ts`) so this never becomes an
+          // unhandled rejection.
+          reject(err);
+        }
+      });
     });
     this.scheduleFlush();
     return p;
@@ -56,18 +71,33 @@ export class Queue {
     }
 
     this.isScheduled = true;
-    this.waiter(() => this.flush());
+
+    try {
+      this.waiter(() => this.flush());
+    } catch (err) {
+      // If the scheduler itself throws, reset the flag before re-throwing so a
+      // faulty `waiter` can not leave the queue permanently wedged (the flag
+      // stuck `true` would make every later `scheduleFlush()` early-return and
+      // never re-arm a flush).
+      this.isScheduled = false;
+      throw err;
+    }
   }
 
   /**
    * Flush current batch.
    */
   flush() {
-    this.run(this.tasks.splice(0, this.concurrency));
-    this.isScheduled = false;
+    try {
+      this.run(this.tasks.splice(0, this.concurrency));
+    } finally {
+      // Always reset the scheduling flag and re-arm the next flush, even when a
+      // task throws, so a single faulty task can not permanently wedge the queue.
+      this.isScheduled = false;
 
-    if (this.tasks.length > 0) {
-      this.scheduleFlush();
+      if (this.tasks.length > 0) {
+        this.scheduleFlush();
+      }
     }
   }
 
@@ -78,7 +108,17 @@ export class Queue {
     let task;
     // eslint-disable-next-line no-cond-assign
     while ((task = tasks.shift())) {
-      task();
+      try {
+        task();
+      } catch (err) {
+        // Defence in depth: tasks pushed by `add()` already isolate their own
+        // errors (they reject the returned promise and never throw here), so
+        // this only catches an unexpected throw. Keep draining the batch and
+        // surface the error asynchronously instead of aborting the whole flush.
+        queueMicrotask(() => {
+          throw err;
+        });
+      }
     }
   }
 }

--- a/packages/js-toolkit/utils/Queue.ts
+++ b/packages/js-toolkit/utils/Queue.ts
@@ -45,15 +45,11 @@ export class Queue {
         try {
           resolve(task());
         } catch (err) {
-          // Reject the returned promise so a synchronously-throwing task fails
-          // exactly like an asynchronous one whose promise rejects — a caller
-          // doing rollback in `catch` behaves the same regardless of whether the
-          // task was declared `async`. The rejection is the single surfacing
-          // channel for the error: do not also re-throw here, otherwise `run()`
-          // would report the same error a second time via its `queueMicrotask`.
-          // Fire-and-forget callers attach their own `.catch()` (see
-          // `Base/utils.ts` and `ChildrenManager.ts`) so this never becomes an
-          // unhandled rejection.
+          // Containing the throw here is what keeps the queue alive: left to
+          // escape, it would abort `run()` mid-batch, orphan the remaining
+          // tasks and leave `isScheduled` stuck `true`, wedging the queue for
+          // good. Rejecting the returned promise also makes a synchronous throw
+          // behave exactly like an `async` task whose promise rejects.
           reject(err);
         }
       });
@@ -75,10 +71,13 @@ export class Queue {
     try {
       this.waiter(() => this.flush());
     } catch (err) {
-      // If the scheduler itself throws, reset the flag before re-throwing so a
-      // faulty `waiter` can not leave the queue permanently wedged (the flag
-      // stuck `true` would make every later `scheduleFlush()` early-return and
-      // never re-arm a flush).
+      // `waiter` is a public constructor parameter, so a faulty scheduler is
+      // reachable. Reset the flag before re-throwing: stuck `true`, it would
+      // make every later `scheduleFlush()` early-return and never re-arm a
+      // flush. The task `add()` just pushed stays queued on purpose — it runs on
+      // the next flush that does get scheduled, and its promise never reached
+      // the caller (the throw pre-empts `add()`'s `return`), so rejecting it
+      // here could only produce an unobservable rejection.
       this.isScheduled = false;
       throw err;
     }
@@ -88,16 +87,11 @@ export class Queue {
    * Flush current batch.
    */
   flush() {
-    try {
-      this.run(this.tasks.splice(0, this.concurrency));
-    } finally {
-      // Always reset the scheduling flag and re-arm the next flush, even when a
-      // task throws, so a single faulty task can not permanently wedge the queue.
-      this.isScheduled = false;
+    this.run(this.tasks.splice(0, this.concurrency));
+    this.isScheduled = false;
 
-      if (this.tasks.length > 0) {
-        this.scheduleFlush();
-      }
+    if (this.tasks.length > 0) {
+      this.scheduleFlush();
     }
   }
 
@@ -108,17 +102,7 @@ export class Queue {
     let task;
     // eslint-disable-next-line no-cond-assign
     while ((task = tasks.shift())) {
-      try {
-        task();
-      } catch (err) {
-        // Defence in depth: tasks pushed by `add()` already isolate their own
-        // errors (they reject the returned promise and never throw here), so
-        // this only catches an unexpected throw. Keep draining the batch and
-        // surface the error asynchronously instead of aborting the whole flush.
-        queueMicrotask(() => {
-          throw err;
-        });
-      }
+      task();
     }
   }
 }

--- a/packages/js-toolkit/utils/SmartQueue.ts
+++ b/packages/js-toolkit/utils/SmartQueue.ts
@@ -32,16 +32,11 @@ export class SmartQueue extends Queue {
    * Flush current batch.
    */
   flush() {
-    try {
-      this.run(this.tasks);
-    } finally {
-      // Always reset the scheduling flag and re-arm the next flush, even when a
-      // task throws, so a single faulty task can not permanently wedge the queue.
-      this.isScheduled = false;
+    this.run(this.tasks);
+    this.isScheduled = false;
 
-      if (this.tasks.length > 0) {
-        this.scheduleFlush();
-      }
+    if (this.tasks.length > 0) {
+      this.scheduleFlush();
     }
   }
 
@@ -54,17 +49,7 @@ export class SmartQueue extends Queue {
     let now = start;
     // eslint-disable-next-line no-cond-assign
     while (now - start < LONG_TASK_DURATION && (task = tasks.shift())) {
-      try {
-        task();
-      } catch (err) {
-        // Defence in depth: tasks pushed by `add()` already isolate their own
-        // errors (they reject the returned promise and never throw here), so
-        // this only catches an unexpected throw. Keep draining the batch and
-        // surface the error asynchronously instead of aborting the whole flush.
-        queueMicrotask(() => {
-          throw err;
-        });
-      }
+      task();
       now = performance.now();
     }
   }

--- a/packages/js-toolkit/utils/SmartQueue.ts
+++ b/packages/js-toolkit/utils/SmartQueue.ts
@@ -32,11 +32,16 @@ export class SmartQueue extends Queue {
    * Flush current batch.
    */
   flush() {
-    this.run(this.tasks);
-    this.isScheduled = false;
+    try {
+      this.run(this.tasks);
+    } finally {
+      // Always reset the scheduling flag and re-arm the next flush, even when a
+      // task throws, so a single faulty task can not permanently wedge the queue.
+      this.isScheduled = false;
 
-    if (this.tasks.length > 0) {
-      this.scheduleFlush();
+      if (this.tasks.length > 0) {
+        this.scheduleFlush();
+      }
     }
   }
 
@@ -49,7 +54,17 @@ export class SmartQueue extends Queue {
     let now = start;
     // eslint-disable-next-line no-cond-assign
     while (now - start < LONG_TASK_DURATION && (task = tasks.shift())) {
-      task();
+      try {
+        task();
+      } catch (err) {
+        // Defence in depth: tasks pushed by `add()` already isolate their own
+        // errors (they reject the returned promise and never throw here), so
+        // this only catches an unexpected throw. Keep draining the batch and
+        // surface the error asynchronously instead of aborting the whole flush.
+        queueMicrotask(() => {
+          throw err;
+        });
+      }
       now = performance.now();
     }
   }

--- a/packages/tests/Base/Base.spec.ts
+++ b/packages/tests/Base/Base.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import {
   Base,
   BaseConfig,
@@ -9,7 +9,7 @@ import {
   withName,
 } from '@studiometa/js-toolkit';
 import { nextTick } from '@studiometa/js-toolkit/utils';
-import { h, mount } from '#test-utils';
+import { h, mount, mockFeatures } from '#test-utils';
 
 let mockedIsDev = true;
 
@@ -740,6 +740,38 @@ describe('A Base instance config', () => {
 });
 
 describe('The Base lifecycle error boundaries', () => {
+  let reported: Error[];
+  let microtask: MockInstance<typeof queueMicrotask>;
+
+  beforeEach(() => {
+    reported = [];
+    // A failed queued lifecycle task is re-thrown from a microtask so it reaches
+    // `window.onerror` and error monitors. Intercept that channel here, both to
+    // assert on it and to keep the re-throw from failing the test run.
+    microtask = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        reported.push(error as Error);
+      }
+    });
+  });
+
+  afterEach(() => {
+    microtask.mockRestore();
+  });
+
+  /**
+   * Let the shared queue drain across a few ticks and give any pending
+   * rejection the chance to surface.
+   */
+  async function flushQueue() {
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await nextTick();
+    }
+  }
+
   it('should not falsely mark the component mounted when a queued mount task fails', async () => {
     class Foo extends Base {
       static config: BaseConfig = {
@@ -757,20 +789,136 @@ describe('The Base lifecycle error boundaries', () => {
 
     const afterMounted = vi.fn();
     foo.$on('after-mounted', afterMounted);
-    const warn = vi.spyOn(window.console, 'warn').mockImplementation(() => {});
 
     // `$mount` resolves (never rejects) so a fire-and-forget mount can not turn
     // into an unhandled rejection.
     await expect(foo.$mount()).resolves.toBe(foo);
 
-    // The component is left honestly unmounted...
+    // The wiring never completed, so the component stays unmounted...
     expect(foo.$isMounted).toBe(false);
     // ...`after-mounted` is not emitted as if init had completed...
     expect(afterMounted).not.toHaveBeenCalled();
-    // ...and the failure is surfaced through the log, not swallowed.
-    expect(warn.mock.calls.some((args) => args.includes(error))).toBe(true);
+    // ...and the failure reaches the global error handler, carrying the
+    // component identity and the original error as its cause.
+    expect(reported).toHaveLength(1);
+    expect(reported[0].message).toBe(`[${foo.$id}] The \`$mount\` lifecycle failed.`);
+    expect(reported[0].cause).toBe(error);
+  });
 
-    warn.mockRestore();
+  it('should keep mounting unrelated components after one component fails to mount', async () => {
+    class Failing extends Base {
+      static config: BaseConfig = {
+        name: 'Failing',
+      };
+
+      mounted() {
+        throw new Error('mounted boom');
+      }
+    }
+
+    class Working extends Base {
+      static config: BaseConfig = {
+        name: 'Working',
+      };
+    }
+
+    const failing = new Failing(h('div'));
+    const working = new Working(h('div'));
+
+    // Fire-and-forget, like `mutationCallback` does: the failing component's
+    // tasks are queued on the shared module-level queue first.
+    failing.$mount();
+    // The unrelated component is queued right after, so its tasks land in the
+    // same batch as the failing one.
+    const p = working.$mount();
+
+    await expect(p).resolves.toBe(working);
+    await flushQueue();
+
+    // The unrelated component mounted normally — one bad component no longer
+    // wedges the shared queue and orphans every other component on the page.
+    expect(working.$isMounted).toBe(true);
+    // And the queue keeps accepting work afterwards.
+    const late = new Working(h('div'));
+    await late.$mount();
+    expect(late.$isMounted).toBe(true);
+
+    // The failure was reported once, not swallowed.
+    expect(reported).toHaveLength(1);
+    expect(reported[0].message).toBe(`[${failing.$id}] The \`$mount\` lifecycle failed.`);
+  });
+
+  it('should not emit `after-destroyed` when the `destroyed` hook throws', async () => {
+    const error = new Error('destroyed boom');
+
+    class Foo extends Base {
+      static config: BaseConfig = {
+        name: 'Foo',
+      };
+
+      destroyed() {
+        throw error;
+      }
+    }
+
+    const foo = new Foo(h('div'));
+    await foo.$mount();
+
+    const afterDestroyed = vi.fn();
+    foo.$on('after-destroyed', afterDestroyed);
+
+    await expect(foo.$destroy()).resolves.toBe(foo);
+    expect(afterDestroyed).not.toHaveBeenCalled();
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0].message).toBe(`[${foo.$id}] The \`$destroy\` lifecycle failed.`);
+    expect(reported[0].cause).toBe(error);
+  });
+
+  it('should resolve and report when the `updated` hook throws', async () => {
+    const error = new Error('updated boom');
+
+    class Foo extends Base {
+      static config: BaseConfig = {
+        name: 'Foo',
+      };
+
+      updated() {
+        throw error;
+      }
+    }
+
+    const foo = new Foo(h('div'));
+    await foo.$mount();
+
+    await expect(foo.$update()).resolves.toBe(foo);
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0].message).toBe(`[${foo.$id}] The \`$update\` lifecycle failed.`);
+    expect(reported[0].cause).toBe(error);
+  });
+
+  it('should resolve and report when the `terminated` hook throws', async () => {
+    const error = new Error('terminated boom');
+
+    class Foo extends Base {
+      static config: BaseConfig = {
+        name: 'Foo',
+      };
+
+      terminated() {
+        throw error;
+      }
+    }
+
+    const foo = new Foo(h('div'));
+    await foo.$mount();
+
+    await expect(foo.$terminate()).resolves.toBeUndefined();
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0].message).toBe(`[${foo.$id}] The \`$terminate\` lifecycle failed.`);
+    expect(reported[0].cause).toBe(error);
   });
 
   it('should not produce an unhandled rejection when a fire-and-forget mount fails', async () => {
@@ -784,7 +932,6 @@ describe('The Base lifecycle error boundaries', () => {
       }
     }
 
-    const warn = vi.spyOn(window.console, 'warn').mockImplementation(() => {});
     const rejections: unknown[] = [];
     const onRejection = (reason: unknown) => rejections.push(reason);
     process.on('unhandledRejection', onRejection);
@@ -792,20 +939,39 @@ describe('The Base lifecycle error boundaries', () => {
     // Fire-and-forget: the returned promise is discarded, like `mutationCallback`.
     new Foo(h('div')).$mount();
 
-    // Let the queued mount tasks flush across several ticks and give any
-    // rejection a chance to surface.
-    for (let i = 0; i < 5; i += 1) {
-      // eslint-disable-next-line no-await-in-loop
-      await nextTick();
-    }
+    await flushQueue();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     process.off('unhandledRejection', onRejection);
 
+    // No unhandled rejection: the lifecycle promise resolves...
     expect(rejections).toHaveLength(0);
-    // The failure is still surfaced through the log.
-    expect(warn).toHaveBeenCalled();
+    // ...but the failure is still visible on the global error channel.
+    expect(reported).toHaveLength(1);
+  });
 
-    warn.mockRestore();
+  it('should keep rejecting in blocking mode', async () => {
+    const { unmock } = mockFeatures({ blocking: true });
+    const error = new Error('mounted boom');
+
+    class Foo extends Base {
+      static config: BaseConfig = {
+        name: 'Foo',
+      };
+
+      mounted() {
+        throw error;
+      }
+    }
+
+    const foo = new Foo(h('div'));
+
+    // No queue is involved in blocking mode: the task runs in the caller's own
+    // stack, so `try { await createApp(App, { blocking: true }) } catch` keeps
+    // working and the error is not deferred to a microtask.
+    await expect(foo.$mount()).rejects.toBe(error);
+    expect(reported).toHaveLength(0);
+
+    unmock();
   });
 });

--- a/packages/tests/Base/Base.spec.ts
+++ b/packages/tests/Base/Base.spec.ts
@@ -8,6 +8,7 @@ import {
   withExtraConfig,
   withName,
 } from '@studiometa/js-toolkit';
+import { nextTick } from '@studiometa/js-toolkit/utils';
 import { h, mount } from '#test-utils';
 
 let mockedIsDev = true;
@@ -735,5 +736,76 @@ describe('A Base instance config', () => {
     spy.mockRestore();
     devModeSpy.mockRestore();
     process.env.NODE_ENV = 'test';
+  });
+});
+
+describe('The Base lifecycle error boundaries', () => {
+  it('should not falsely mark the component mounted when a queued mount task fails', async () => {
+    class Foo extends Base {
+      static config: BaseConfig = {
+        name: 'Foo',
+      };
+    }
+
+    const foo = new Foo(h('div'));
+    const error = new Error('enable boom');
+    // Make a queued wiring task throw synchronously, mimicking e.g.
+    // `__services.enableAll()` failing during `$mount`.
+    vi.spyOn(foo.__services, 'enableAll').mockImplementation(() => {
+      throw error;
+    });
+
+    const afterMounted = vi.fn();
+    foo.$on('after-mounted', afterMounted);
+    const warn = vi.spyOn(window.console, 'warn').mockImplementation(() => {});
+
+    // `$mount` resolves (never rejects) so a fire-and-forget mount can not turn
+    // into an unhandled rejection.
+    await expect(foo.$mount()).resolves.toBe(foo);
+
+    // The component is left honestly unmounted...
+    expect(foo.$isMounted).toBe(false);
+    // ...`after-mounted` is not emitted as if init had completed...
+    expect(afterMounted).not.toHaveBeenCalled();
+    // ...and the failure is surfaced through the log, not swallowed.
+    expect(warn.mock.calls.some((args) => args.includes(error))).toBe(true);
+
+    warn.mockRestore();
+  });
+
+  it('should not produce an unhandled rejection when a fire-and-forget mount fails', async () => {
+    class Foo extends Base {
+      static config: BaseConfig = {
+        name: 'Foo',
+      };
+
+      mounted() {
+        throw new Error('mounted boom');
+      }
+    }
+
+    const warn = vi.spyOn(window.console, 'warn').mockImplementation(() => {});
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', onRejection);
+
+    // Fire-and-forget: the returned promise is discarded, like `mutationCallback`.
+    new Foo(h('div')).$mount();
+
+    // Let the queued mount tasks flush across several ticks and give any
+    // rejection a chance to surface.
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await nextTick();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    process.off('unhandledRejection', onRejection);
+
+    expect(rejections).toHaveLength(0);
+    // The failure is still surfaced through the log.
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
   });
 });

--- a/packages/tests/Base/Base.spec.ts
+++ b/packages/tests/Base/Base.spec.ts
@@ -742,6 +742,7 @@ describe('A Base instance config', () => {
 describe('The Base lifecycle error boundaries', () => {
   let reported: Error[];
   let microtask: MockInstance<typeof queueMicrotask>;
+  let restoreFeatures: (() => void) | undefined;
 
   beforeEach(() => {
     reported = [];
@@ -759,6 +760,8 @@ describe('The Base lifecycle error boundaries', () => {
 
   afterEach(() => {
     microtask.mockRestore();
+    restoreFeatures?.();
+    restoreFeatures = undefined;
   });
 
   /**
@@ -951,7 +954,7 @@ describe('The Base lifecycle error boundaries', () => {
   });
 
   it('should keep rejecting in blocking mode', async () => {
-    const { unmock } = mockFeatures({ blocking: true });
+    restoreFeatures = mockFeatures({ blocking: true }).unmock;
     const error = new Error('mounted boom');
 
     class Foo extends Base {
@@ -971,7 +974,5 @@ describe('The Base lifecycle error boundaries', () => {
     // working and the error is not deferred to a microtask.
     await expect(foo.$mount()).rejects.toBe(error);
     expect(reported).toHaveLength(0);
-
-    unmock();
   });
 });

--- a/packages/tests/helpers/registerComponent.spec.ts
+++ b/packages/tests/helpers/registerComponent.spec.ts
@@ -159,4 +159,39 @@ describe('The `registerComponent` lazy import helper', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('should skip an instance whose mount failed', async () => {
+    const failing = h('div', { dataComponent: 'Component' });
+    failing.setAttribute('data-fail', '');
+    document.body.append(failing);
+
+    class Component extends Base {
+      static config = {
+        name: 'Component',
+      };
+
+      constructor(el: HTMLElement) {
+        super(el);
+        if (el.hasAttribute('data-fail')) {
+          // Fail while wiring, so the instance never becomes mounted.
+          this.__services.enableAll = () => {
+            throw new Error('boom');
+          };
+        }
+      }
+    }
+
+    // `$mount()` resolves instead of rejecting, so the failure is reported on
+    // the global error channel. Intercept it here.
+    const microtask = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation(() => {});
+
+    // A never-mounted instance must not be handed back as a successful
+    // registration.
+    const instances = await registerComponent(Component);
+    expect(instances).toHaveLength(1);
+    expect(instances[0].$el).not.toBe(failing);
+    expect(instances[0].$isMounted).toBe(true);
+
+    microtask.mockRestore();
+  });
 });

--- a/packages/tests/utils/Queue.spec.ts
+++ b/packages/tests/utils/Queue.spec.ts
@@ -91,28 +91,6 @@ describe('The `Queue` class', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('should reject the promise of a synchronously-throwing task', async () => {
-    // The re-throw path in `run()` must not fire — the rejection is the single
-    // surfacing channel, so there is no double report.
-    const microtask = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation(() => {});
-    const queue = new Queue(10);
-    const error = new Error('boom');
-
-    const p = queue.add(() => {
-      throw error;
-    });
-
-    // A synchronous throw rejects, exactly like an async task returning a
-    // rejected promise — the completion contract is consistent.
-    await expect(p).rejects.toBe(error);
-
-    // The error is surfaced exactly once (through the rejection), not also via
-    // the global re-throw.
-    expect(microtask).not.toHaveBeenCalled();
-
-    microtask.mockRestore();
-  });
-
   it('should reject consistently for sync and async throws', async () => {
     const queue = new Queue(10);
     const error = new Error('boom');
@@ -143,5 +121,30 @@ describe('The `Queue` class', () => {
 
     // ...but the flag is reset so the queue is not permanently wedged.
     expect(queue.isScheduled).toBe(false);
+  });
+
+  it('should keep the pending task queued when the scheduler throws', () => {
+    let broken = true;
+    const queue = new Queue(10, (cb) => {
+      if (broken) {
+        throw new Error('scheduler boom');
+      }
+      (cb as () => void)();
+    });
+    const spy = vi.fn();
+
+    expect(() => queue.add(spy)).toThrow('scheduler boom');
+    // The task is not dropped: it is still queued, waiting for a flush that
+    // does get scheduled. Rejecting it here would be unobservable, since the
+    // throw pre-empted `add()` returning its promise.
+    expect(queue.tasks).toHaveLength(1);
+    expect(spy).not.toHaveBeenCalled();
+
+    // Once the scheduler works again, the orphaned task runs with the next one.
+    broken = false;
+    const next = vi.fn();
+    queue.add(next);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/tests/utils/Queue.spec.ts
+++ b/packages/tests/utils/Queue.spec.ts
@@ -37,4 +37,111 @@ describe('The `Queue` class', () => {
     await p;
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should keep running the rest of the batch when a task throws', async () => {
+    // Use a manual waiter so all three tasks land in a single pending batch and
+    // one flush drains them together — this is what exercises the same-batch
+    // isolation (an immediate waiter would flush each `add()` on its own).
+    let scheduled: (() => void) | undefined;
+    const queue = new Queue(10, (cb) => {
+      scheduled = cb as () => void;
+    });
+    const before = vi.fn();
+    const after = vi.fn();
+    const error = new Error('boom');
+
+    queue.add(before);
+    // The throwing task's promise rejects; observe it so it is not reported as
+    // an unhandled rejection.
+    const throwing = queue.add(() => {
+      throw error;
+    });
+    throwing.catch(() => {});
+    queue.add(after);
+
+    // Nothing ran yet: all three tasks share the same pending batch.
+    expect(before).not.toHaveBeenCalled();
+
+    // Trigger the single flush that drains the whole batch.
+    scheduled?.();
+
+    // The throwing task must not abort the tasks queued before or after it.
+    expect(before).toHaveBeenCalledTimes(1);
+    expect(after).toHaveBeenCalledTimes(1);
+
+    // The failure is surfaced through the task's own promise, which rejects.
+    await expect(throwing).rejects.toBe(error);
+  });
+
+  it('should not wedge the queue for future flushes when a task throws', () => {
+    const queue = new Queue(10);
+
+    const throwing = queue.add(() => {
+      throw new Error('boom');
+    });
+    // Observe the rejection so it does not surface as an unhandled rejection.
+    throwing.catch(() => {});
+
+    // The scheduling flag must have been reset by the previous flush.
+    expect(queue.isScheduled).toBe(false);
+
+    // A subsequent enqueue must still schedule and run.
+    const spy = vi.fn();
+    queue.add(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject the promise of a synchronously-throwing task', async () => {
+    // The re-throw path in `run()` must not fire — the rejection is the single
+    // surfacing channel, so there is no double report.
+    const microtask = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation(() => {});
+    const queue = new Queue(10);
+    const error = new Error('boom');
+
+    const p = queue.add(() => {
+      throw error;
+    });
+
+    // A synchronous throw rejects, exactly like an async task returning a
+    // rejected promise — the completion contract is consistent.
+    await expect(p).rejects.toBe(error);
+
+    // The error is surfaced exactly once (through the rejection), not also via
+    // the global re-throw.
+    expect(microtask).not.toHaveBeenCalled();
+
+    microtask.mockRestore();
+  });
+
+  it('should reject consistently for sync and async throws', async () => {
+    const queue = new Queue(10);
+    const error = new Error('boom');
+
+    const sync = queue.add(() => {
+      throw error;
+    });
+    const async = queue.add(async () => {
+      throw error;
+    });
+
+    await expect(sync).rejects.toBe(error);
+    await expect(async).rejects.toBe(error);
+  });
+
+  it('should reset the scheduling flag when the scheduler throws', () => {
+    const error = new Error('scheduler boom');
+    const queue = new Queue(1, () => {
+      throw error;
+    });
+
+    // The throw propagates to the caller...
+    expect(() =>
+      queue.add(() => {
+        /* noop */
+      }),
+    ).toThrow(error);
+
+    // ...but the flag is reset so the queue is not permanently wedged.
+    expect(queue.isScheduled).toBe(false);
+  });
 });

--- a/packages/tests/utils/SmartQueue.spec.ts
+++ b/packages/tests/utils/SmartQueue.spec.ts
@@ -25,4 +25,72 @@ describe('The `SmartQueue` class', () => {
     await nextTick();
     expect(spy).toHaveBeenCalledTimes(4);
   });
+
+  it('should keep running the batch when a task throws', async () => {
+    const queue = new SmartQueue();
+    const before = vi.fn();
+    const after = vi.fn();
+    const error = new Error('boom');
+
+    queue.add(before);
+    // The throwing task's promise rejects; observe it so it is not reported as
+    // an unhandled rejection.
+    const throwing = queue.add(() => {
+      throw error;
+    });
+    throwing.catch(() => {});
+    queue.add(after);
+
+    await nextTick();
+
+    // Both the task before and after the throwing one must have run.
+    expect(before).toHaveBeenCalledTimes(1);
+    expect(after).toHaveBeenCalledTimes(1);
+
+    // The failure is surfaced through the task's own promise, which rejects.
+    await expect(throwing).rejects.toBe(error);
+  });
+
+  it('should not wedge the queue for future flushes when a task throws', async () => {
+    const queue = new SmartQueue();
+    const spy = vi.fn();
+
+    const throwing = queue.add(() => {
+      throw new Error('boom');
+    });
+    // Observe the rejection so it does not surface as an unhandled rejection.
+    throwing.catch(() => {});
+    await nextTick();
+
+    // The scheduling flag must have been reset by the previous flush.
+    expect(queue.isScheduled).toBe(false);
+
+    // A subsequent enqueue must still schedule and run.
+    queue.add(spy);
+    await nextTick();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject the promise of a synchronously-throwing task', async () => {
+    // The re-throw path in `run()` must not fire — the rejection is the single
+    // surfacing channel, so there is no double report.
+    const microtask = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation(() => {});
+    const queue = new SmartQueue();
+    const error = new Error('boom');
+
+    const p = queue.add(() => {
+      throw error;
+    });
+    await nextTick();
+
+    // A synchronous throw rejects, exactly like an async task returning a
+    // rejected promise — the completion contract is consistent.
+    await expect(p).rejects.toBe(error);
+
+    // The error is surfaced exactly once (through the rejection), not also via
+    // the global re-throw.
+    expect(microtask).not.toHaveBeenCalled();
+
+    microtask.mockRestore();
+  });
 });

--- a/packages/tests/utils/SmartQueue.spec.ts
+++ b/packages/tests/utils/SmartQueue.spec.ts
@@ -71,26 +71,26 @@ describe('The `SmartQueue` class', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('should reject the promise of a synchronously-throwing task', async () => {
-    // The re-throw path in `run()` must not fire — the rejection is the single
-    // surfacing channel, so there is no double report.
-    const microtask = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation(() => {});
+  it('should inherit the rejection contract for sync and async throws', async () => {
     const queue = new SmartQueue();
     const error = new Error('boom');
 
-    const p = queue.add(() => {
+    // `SmartQueue` overrides neither `add()` nor the error isolation: a
+    // synchronous throw rejects exactly like an `async` task whose promise
+    // rejects. Observe both rejections right away so the flush below can not
+    // report them as unhandled.
+    const sync = queue.add(() => {
       throw error;
     });
+    sync.catch(() => {});
+    const async = queue.add(async () => {
+      throw error;
+    });
+    async.catch(() => {});
+
     await nextTick();
 
-    // A synchronous throw rejects, exactly like an async task returning a
-    // rejected promise — the completion contract is consistent.
-    await expect(p).rejects.toBe(error);
-
-    // The error is surfaced exactly once (through the rejection), not also via
-    // the global re-throw.
-    expect(microtask).not.toHaveBeenCalled();
-
-    microtask.mockRestore();
+    await expect(sync).rejects.toBe(error);
+    await expect(async).rejects.toBe(error);
   });
 });


### PR DESCRIPTION
## Problem

A queued task that throws **synchronously** used to take the whole task queue down with it.

`Queue.add()` pushed `() => resolve(task())` onto `this.tasks`. When `task()` threw, the throw escaped `resolve(...)`, escaped `run()`'s `while` loop, and escaped `flush()` — which meant:

- the rest of the batch never ran, and its tasks stayed in `this.tasks` forever;
- `isScheduled` stayed `true`, so every later `scheduleFlush()` early-returned and no flush was ever re-armed;
- the `add()` promise never settled.

`Base/utils.ts` holds a **single module-global `SmartQueue`** behind `addToQueue`, and every lifecycle method routes its work through it. So one component with a throwing `mounted()` hook permanently killed mounting, updating, destroying and terminating for **every component on the page**.

Reproduced against `main`: `await registerComponent(Boom)` with a wiring failure never resolves.

## Fix

**Contain the throw where the task runs** — `Queue.add()` wraps `resolve(task())` in a try/catch and rejects the returned promise. `run()`, `flush()` and `scheduleFlush()` never see the throw, the batch keeps draining, `isScheduled` is reset normally, and a synchronous throw now settles the promise exactly like an `async` task whose promise rejects. `SmartQueue` inherits this unchanged and is not modified at all.

`scheduleFlush()` also resets `isScheduled` if the `waiter` itself throws. Unlike the task path, this one is genuinely reachable: `waiter` is a public constructor parameter (`new Queue(concurrency, waiter)`). The task already pushed stays queued deliberately — it runs on the next flush that does get scheduled, and its promise never reached the caller (the throw pre-empts `add()`'s `return`), so rejecting it could only produce an unobservable rejection.

**Lifecycle methods no longer reject in queued mode.** `$mount()`, `$update()`, `$destroy()` and `$terminate()` catch a failed queued task and resolve. They run detached on the shared queue and are commonly called fire-and-forget — from the auto-mounting mutation observer, from `$terminate()` when an element leaves the DOM — so a rejection would have had no awaiter and would only have become an unhandled rejection.

The error is **not** swallowed. It is re-thrown from a microtask, so it reaches `window.onerror` and any error monitor, wrapped in an error naming the instance `$id` and the failed lifecycle, carrying the original error as its `cause`.

A failed lifecycle stops at the point of failure: `after-mounted` and `after-destroyed` are not emitted. What `$isMounted` ends up as depends on where the failure happened — `false` if the wiring failed, and **`true` if the `mounted()` hook itself threw**, because `$isMounted` is set immediately before the hook runs. That is deliberate: the component *is* wired in that case, and `$destroy()`'s guard needs the flag to tear it down.

**Blocking mode keeps rejecting.** With `features.get('blocking')` set, `addToQueue` runs the task synchronously in the caller's own stack — no queue, nothing to wedge — so the error is re-thrown and the lifecycle promise rejects as it always has. `try { await createApp(App, { blocking: true }) } catch {}` still catches startup failures.

**`registerComponent()` still skips instances that failed to mount.** Because `$mount()` no longer rejects, `Promise.allSettled` in `registerComponent` would have reported a never-mounted instance as a successful registration, silently undoing the v3.8.0 skip-and-log behaviour. It now checks `$isMounted` on the fulfilled branch. The rejected branch stays and is still reachable — it fires when the instance could not even be constructed, which no other channel reports. `registerComponents` is unaffected: `registerComponent` still rejects on a failed dynamic import.

## Scope

The fix is deliberately minimal. An earlier revision of this branch also added a try/finally in `Queue.flush()`, a try/catch in `Queue.run()` and mirrored both in `SmartQueue`. Those were removed: `Queue.add()` is the only writer to `this.tasks` package-wide, and once its closure cannot throw, none of those guards is reachable through the public API. `SmartQueue.ts` is now byte-identical to `main`, and `Queue.ts` carries about 14 lines of new code.

## Tests

- One component's mount fails and an **unrelated** component queued afterwards still mounts, and the queue keeps accepting work — the headline regression.
- A queued mount task failing leaves the component unmounted, does not emit `after-mounted`, and reports the error with the component identity and the original `cause`.
- Throwing `destroyed()` / `updated()` / `terminated()` hooks: the lifecycle resolves, `after-destroyed` is not emitted, the error is reported.
- Fire-and-forget `$mount()` on a throwing component produces zero unhandled rejections and exactly one global report.
- Blocking mode: `$mount()` rejects with the original error and nothing is deferred to a microtask.
- `registerComponent` skips a never-mounted instance.
- Queue level: same-batch isolation, no wedging across flushes, sync/async rejection parity, the scheduler-throw flag reset, and the orphaned task running on the next successful flush.

All lifecycle tests were checked to fail when the corresponding production change is reverted.

Also fixed `SmartQueue.spec.ts` leaving a rejection unobserved, which made a root-level `vitest run packages/tests/utils/SmartQueue.spec.ts` exit 1 (CI passed only because it runs from `packages/tests`).

## Docs & changelog

- `packages/docs/utils/Queue.md` documents that `add()` rejects on task failure and warns that a failure-capable task must have its rejection observed.
- `packages/docs/api/instance-methods.md` gains an "Error handling" section for the lifecycle contract, the global error channel, and the blocking-mode exception.
- `CHANGELOG.md` covers the queue wedge, `add()` rejecting, the non-rejecting lifecycle methods, blocking mode, and `registerComponent`.

## Related, not addressed here

1. A failed `$destroy()` leaves the instance in the global storage (`after-destroyed` is the only path to `deleteInstance`), so the terminate scan can re-fire `$terminate()` on each mutation. This is **pre-existing on `main`** for async-rejecting teardown; this PR widens the reachable paths while fixing a strictly worse failure. Follow-up.
2. A failed `$mount()` leaves a stale entry in the element storage. Recoverable — the catch resets `__isMounting` — and strictly better than `main`, which hung. Follow-up.

The `'terminated'` marker in the mount scan, which an earlier revision of this description called a latent defect, is intended behaviour — see #750, which documents and pins it.

## Verification

Rebased onto `main` (`a67c3cfc`). From the repo root, after `npm ci && npm run build`:

- `npm run test --workspace=@studiometa/js-toolkit-tests` — 142 files, **1024 passed**, 2 skipped
- `npx vitest run packages/tests/utils/SmartQueue.spec.ts` — 4 passed, exit 0
- `npm run lint` — 0 errors (1 pre-existing `unicorn/no-useless-spread` warning in `autoload/loader.ts`, from `main`)
- `npm run build` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114BLVFkrWWJAhmamS6NHB3
