### PR TITLE
Document the terminated marker contract and pin it with tests

### DIFF
--- a/packages/docs/api/instance-methods.md
+++ b/packages/docs/api/instance-methods.md
@@ -277,3 +277,38 @@ Terminate the component. Its instance becomes available for garbage collection.
 :::warning
 A terminated component can not be re-mounted, use with precaution.
 :::
+
+### Removing an element terminates its component
+
+You rarely call `$terminate()` yourself. js-toolkit watches the document and terminates any instance whose root element is no longer connected to the DOM. Removing an element is therefore enough to terminate its component.
+
+Terminating leaves a `'terminated'` marker on the element, and the automatic mount scan skips marked elements. **Re-inserting the very same node does not mount a new component on it.** Patterns that detach and re-attach a node — animated modal teardown, virtual list recycling, view transitions, drag & drop re-parenting — hit this without ever calling `$terminate()`.
+
+```js
+const el = document.querySelector('[data-component="Modal"]');
+
+el.remove(); // The `Modal` instance is terminated.
+document.body.append(el); // Nothing is mounted: the element stays terminated.
+```
+
+Three ways to keep components working across a detach:
+
+1. **Re-parent synchronously.** Moving a node in a single task never leaves it disconnected when the scan runs, so its instance is left untouched and stays mounted.
+
+   ```js
+   el.remove();
+   otherContainer.append(el); // Same task: the instance survives.
+   ```
+
+2. **Insert a new node.** A brand new element has no marker, so the scan mounts a fresh instance on it.
+
+3. **Instantiate explicitly.** [`new Component(el)`](./instantiation.md) overwrites the marker, so `$mount()` mounts the terminated element again.
+
+   ```js
+   document.body.append(el);
+   new Modal(el).$mount();
+   ```
+
+:::tip
+To hide and show a component, prefer [`$destroy()`](#destroy) and [`$mount()`](#mount) on an instance you keep a reference to, and leave the element in the DOM. This is what [`withMountWhenInView`](./decorators/withMountWhenInView.md) does: it mounts and destroys the same instance every time its element enters or leaves the viewport.
+:::

--- a/packages/js-toolkit/src/Base/Base.ts
+++ b/packages/js-toolkit/src/Base/Base.ts
@@ -551,20 +551,37 @@ export class Base<T extends BaseProps = BaseProps> {
   /**
    * Terminate a component instance when it is not needed anymore.
    *
-   * Terminating is **permanent for the underlying DOM element**: the element's
-   * `__base__` entry is stamped with a `'terminated'` marker, and the
-   * document-wide mount scan (see `mutationCallback` in `Base/utils.ts`) reads
-   * that truthy marker as "already has an instance" and skips the element. As a
-   * result, re-inserting the very same node into the DOM does **not** remount it
-   * — the terminated state is one-shot per element by design. The only supported
-   * way to mount again is to replace the element with a brand new node (a fresh
-   * node has no `__base__` marker, so it mounts a fresh instance).
+   * Terminating stamps the element's `__base__` entry with a `'terminated'`
+   * marker instead of deleting it. That is deliberate: commit `9bc6f838` ("Fix
+   * terminated feature", Feb. 2022) changed `__base__.delete(...)` to
+   * `__base__.set(..., 'terminated')` so that the marker survives and keeps the
+   * element excluded from component resolution. `$children`, `$parent` and
+   * `queryComponent()` all read `__base__` and special-case the `'terminated'`
+   * string (see `ChildrenManager.__getChild()` and `helpers/queryComponent.ts`);
+   * with the entry deleted they would instead build a brand new instance for the
+   * element.
    *
-   * This guarantee is intentional: it backs lazy/once components such as
-   * `withMountWhenInView`, which must trigger exactly once when their element
-   * first enters the viewport and must never re-trigger on the same element. Use
-   * `$destroy()` instead when the instance should be able to mount again on the
-   * same element.
+   * The document-wide auto-mount scan (see `mutationCallback` in
+   * `Base/utils.ts`) reads the same marker: it is truthy, so
+   * `getInstanceFromElement()` returns it and the element is treated as already
+   * having an instance. **The auto-mount scan will therefore never mount this
+   * element again**, even when the very same node is re-inserted into the DOM.
+   * Two escape hatches remain: give the component a brand new node (no
+   * `__base__` entry, so a fresh instance is mounted), or instantiate explicitly
+   * — `new Ctor(el).$mount()` overwrites the marker with the new instance and
+   * mounts it.
+   *
+   * Sharp edge: most of the time you never call `$terminate()` yourself. The
+   * second pass of `mutationCallback()` terminates any instance whose element is
+   * no longer connected, so an element detached and re-inserted one mutation
+   * batch later is silently and permanently skipped by the auto-mount scan. This
+   * combination is emergent rather than designed — the marker was added in 2022
+   * and the terminate-on-disconnect pass in 2024 (issue #552), for unrelated
+   * reasons. When a node has to survive a detach/re-attach cycle, either
+   * re-parent it synchronously (it stays connected when the scan runs, so the
+   * instance is left untouched), keep it in the DOM and use `$destroy()` /
+   * `$mount()` on the retained instance, or re-mount it explicitly with
+   * `new Ctor(el).$mount()`.
    *
    * @link https://js-toolkit.studiometa.dev/api/instance-methods.html#terminate
    */

--- a/packages/js-toolkit/src/Base/Base.ts
+++ b/packages/js-toolkit/src/Base/Base.ts
@@ -549,7 +549,23 @@ export class Base<T extends BaseProps = BaseProps> {
   }
 
   /**
-   * Terminate a child instance when it is not needed anymore.
+   * Terminate a component instance when it is not needed anymore.
+   *
+   * Terminating is **permanent for the underlying DOM element**: the element's
+   * `__base__` entry is stamped with a `'terminated'` marker, and the
+   * document-wide mount scan (see `mutationCallback` in `Base/utils.ts`) reads
+   * that truthy marker as "already has an instance" and skips the element. As a
+   * result, re-inserting the very same node into the DOM does **not** remount it
+   * — the terminated state is one-shot per element by design. The only supported
+   * way to mount again is to replace the element with a brand new node (a fresh
+   * node has no `__base__` marker, so it mounts a fresh instance).
+   *
+   * This guarantee is intentional: it backs lazy/once components such as
+   * `withMountWhenInView`, which must trigger exactly once when their element
+   * first enters the viewport and must never re-trigger on the same element. Use
+   * `$destroy()` instead when the instance should be able to mount again on the
+   * same element.
+   *
    * @link https://js-toolkit.studiometa.dev/api/instance-methods.html#terminate
    */
   async $terminate(): Promise<void> {

--- a/packages/js-toolkit/src/Base/utils.spec.ts
+++ b/packages/js-toolkit/src/Base/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Base, withName, getInstances } from '@studiometa/js-toolkit';
+import { Base, BaseConfig, withName, getInstances } from '@studiometa/js-toolkit';
 import { nextTick } from '@studiometa/js-toolkit/utils';
 import {
   getComponentElements,
@@ -271,6 +271,73 @@ describe('The Base utils', () => {
 
       // Clean up
       container.remove();
+    });
+
+    it('should keep a terminated element permanent and only remount on replacement', async () => {
+      // A terminated component is permanent for its DOM element: re-inserting the
+      // very same node must NOT remount it, and the only supported way to mount
+      // again is to replace the element with a brand new node. This pins the
+      // contract that backs lazy/once components such as `withMountWhenInView`.
+      let mountedCount = 0;
+      class PermanentComponent extends Base {
+        static config: BaseConfig = { name: 'PermanentTerminatedComponent' };
+
+        mounted() {
+          mountedCount += 1;
+        }
+      }
+
+      addToRegistry('PermanentTerminatedComponent', PermanentComponent);
+
+      const container = h('div');
+      document.body.appendChild(container);
+
+      const el = h('div', { 'data-component': 'PermanentTerminatedComponent' });
+      container.appendChild(el);
+
+      // Wait for the mutation observer to mount the component.
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(getInstances(PermanentComponent).size).toBe(1);
+      expect(mountedCount).toBe(1);
+      const firstInstance = Array.from(getInstances(PermanentComponent))[0];
+
+      // Remove the element so the terminate scan runs and stamps the marker.
+      el.remove();
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // The instance is gone and the element is now marked `'terminated'`.
+      expect(getInstances(PermanentComponent).size).toBe(0);
+      expect((el as any).__base__.get('PermanentTerminatedComponent')).toBe('terminated');
+
+      // Re-insert the SAME element: it must stay terminated, no fresh mount.
+      container.appendChild(el);
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(getInstances(PermanentComponent).size).toBe(0);
+      expect(mountedCount).toBe(1);
+      expect((el as any).__base__.get('PermanentTerminatedComponent')).toBe('terminated');
+
+      // Replace it with a BRAND NEW element carrying the same `data-component`:
+      // this is the supported path to remount, so a fresh instance is created.
+      el.remove();
+      const freshEl = h('div', { 'data-component': 'PermanentTerminatedComponent' });
+      container.appendChild(freshEl);
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(getInstances(PermanentComponent).size).toBe(1);
+      expect(mountedCount).toBe(2);
+      const freshInstance = Array.from(getInstances(PermanentComponent))[0];
+      expect(freshInstance).not.toBe(firstInstance);
+      expect(freshInstance.$el).toBe(freshEl);
+
+      // Clean up
+      container.remove();
+      await Promise.all(Array.from(getInstances(PermanentComponent)).map((i) => i.$destroy()));
     });
   });
 });

--- a/packages/js-toolkit/src/Base/utils.spec.ts
+++ b/packages/js-toolkit/src/Base/utils.spec.ts
@@ -272,12 +272,15 @@ describe('The Base utils', () => {
       // Clean up
       container.remove();
     });
+  });
 
-    it('should keep a terminated element permanent and only remount on replacement', async () => {
-      // A terminated component is permanent for its DOM element: re-inserting the
-      // very same node must NOT remount it, and the only supported way to mount
-      // again is to replace the element with a brand new node. This pins the
-      // contract that backs lazy/once components such as `withMountWhenInView`.
+  describe('The terminated marker and the auto-mount scan', () => {
+    it('should never auto-mount a terminated element again, even when re-inserted', async () => {
+      // Pins the contract behind the `'terminated'` marker: once an element is
+      // stamped, the document-wide auto-mount scan in `mutationCallback()` skips
+      // it forever. Note the test never calls `$terminate()` — removing the
+      // element from the DOM is enough, the terminate pass of the same scan does
+      // it. That is the sharp edge users actually hit.
       let mountedCount = 0;
       class PermanentComponent extends Base {
         static config: BaseConfig = { name: 'PermanentTerminatedComponent' };
@@ -287,7 +290,17 @@ describe('The Base utils', () => {
         }
       }
 
+      let controlMountedCount = 0;
+      class ControlComponent extends Base {
+        static config: BaseConfig = { name: 'TerminatedControlComponent' };
+
+        mounted() {
+          controlMountedCount += 1;
+        }
+      }
+
       addToRegistry('PermanentTerminatedComponent', PermanentComponent);
+      addToRegistry('TerminatedControlComponent', ControlComponent);
 
       const container = h('div');
       document.body.appendChild(container);
@@ -303,26 +316,35 @@ describe('The Base utils', () => {
       expect(mountedCount).toBe(1);
       const firstInstance = Array.from(getInstances(PermanentComponent))[0];
 
-      // Remove the element so the terminate scan runs and stamps the marker.
+      // Remove the element: the terminate pass of the scan terminates the
+      // instance and stamps the marker. `$terminate()` is never called by hand.
       el.remove();
       await nextTick();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // The instance is gone and the element is now marked `'terminated'`.
       expect(getInstances(PermanentComponent).size).toBe(0);
       expect((el as any).__base__.get('PermanentTerminatedComponent')).toBe('terminated');
 
-      // Re-insert the SAME element: it must stay terminated, no fresh mount.
-      container.appendChild(el);
+      // Re-insert the SAME element, together with a brand new control element in
+      // the same mutation. The control is a positive control: it proves the scan
+      // did run, so the assertions on `el` below are a real "skipped", not a
+      // "the observer never fired".
+      const controlEl = h('div', { 'data-component': 'TerminatedControlComponent' });
+      container.append(el, controlEl);
       await nextTick();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
+      // Positive control: the scan ran during this very mutation batch.
+      expect(controlMountedCount).toBe(1);
+      expect(getInstances(ControlComponent).size).toBe(1);
+
+      // The re-inserted element stayed terminated and was skipped.
       expect(getInstances(PermanentComponent).size).toBe(0);
       expect(mountedCount).toBe(1);
       expect((el as any).__base__.get('PermanentTerminatedComponent')).toBe('terminated');
 
-      // Replace it with a BRAND NEW element carrying the same `data-component`:
-      // this is the supported path to remount, so a fresh instance is created.
+      // Escape hatch #1 — a BRAND NEW node carrying the same `data-component`
+      // has no `__base__` marker, so the scan mounts a fresh instance.
       el.remove();
       const freshEl = h('div', { 'data-component': 'PermanentTerminatedComponent' });
       container.appendChild(freshEl);
@@ -337,7 +359,63 @@ describe('The Base utils', () => {
 
       // Clean up
       container.remove();
-      await Promise.all(Array.from(getInstances(PermanentComponent)).map((i) => i.$destroy()));
+      await Promise.all(
+        [...getInstances(PermanentComponent), ...getInstances(ControlComponent)].map((i) =>
+          i.$destroy(),
+        ),
+      );
+    });
+
+    it('should still mount a terminated element through explicit instantiation', async () => {
+      // The scan skips terminated elements, but nothing makes the element itself
+      // unmountable: the constructor overwrites `__base__` unconditionally
+      // (`Base.ts`), so `new Ctor(el).$mount()` clears the marker and mounts.
+      let mountedCount = 0;
+      class RevivableComponent extends Base {
+        static config: BaseConfig = { name: 'RevivableTerminatedComponent' };
+
+        mounted() {
+          mountedCount += 1;
+        }
+      }
+
+      addToRegistry('RevivableTerminatedComponent', RevivableComponent);
+
+      const container = h('div');
+      document.body.appendChild(container);
+
+      const el = h('div', { 'data-component': 'RevivableTerminatedComponent' });
+      container.appendChild(el);
+
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(mountedCount).toBe(1);
+
+      // Detach + re-attach so the element ends up terminated but connected.
+      el.remove();
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      container.appendChild(el);
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect((el as any).__base__.get('RevivableTerminatedComponent')).toBe('terminated');
+      expect(mountedCount).toBe(1);
+
+      // Explicit instantiation is the documented escape hatch.
+      const revived = new RevivableComponent(el);
+      expect((el as any).__base__.get('RevivableTerminatedComponent')).toBe(revived);
+
+      await revived.$mount();
+
+      expect(revived.$isMounted).toBe(true);
+      expect(mountedCount).toBe(2);
+      expect(getInstances(RevivableComponent).has(revived)).toBe(true);
+
+      // Clean up
+      container.remove();
+      await Promise.all(Array.from(getInstances(RevivableComponent)).map((i) => i.$destroy()));
     });
   });
 });

--- a/packages/js-toolkit/src/Base/utils.ts
+++ b/packages/js-toolkit/src/Base/utils.ts
@@ -188,11 +188,18 @@ function mutationCallback() {
       for (const el of getComponentElements(nameOrSelector)) {
         // Mount scan. A `'terminated'` marker left by `$terminate()` is a truthy
         // value, so `getInstanceFromElement()` returns it and the element is
-        // treated as already having an instance and skipped. This is intentional
-        // and permanent: a terminated element never remounts, even when it is
-        // re-inserted into the DOM. Replacing it with a brand new node (which
-        // has no `__base__` marker) is the supported way to mount a fresh
-        // instance. See `$terminate()` in `Base.ts`.
+        // treated as already having an instance and skipped. The marker is
+        // deliberate (commit `9bc6f838`): it keeps terminated elements excluded
+        // from `$children`, `$parent` and `queryComponent()` resolution.
+        //
+        // The consequence here is that THIS scan never mounts a terminated
+        // element again, even when the very same node is re-inserted into the
+        // DOM. It does not make the element unmountable: a brand new node (no
+        // `__base__` marker) mounts normally, and `new Ctor(el).$mount()`
+        // overwrites the marker and mounts the terminated node as well.
+        // Note that the terminate pass below auto-terminates any disconnected
+        // instance, so users reach this state without calling `$terminate()`.
+        // See `$terminate()` in `Base.ts`.
         if (!getInstanceFromElement(el, ctor)) {
           new ctor(el).$mount();
         }

--- a/packages/js-toolkit/src/Base/utils.ts
+++ b/packages/js-toolkit/src/Base/utils.ts
@@ -186,6 +186,13 @@ function mutationCallback() {
   addToQueue(() => {
     for (const [nameOrSelector, ctor] of registry()) {
       for (const el of getComponentElements(nameOrSelector)) {
+        // Mount scan. A `'terminated'` marker left by `$terminate()` is a truthy
+        // value, so `getInstanceFromElement()` returns it and the element is
+        // treated as already having an instance and skipped. This is intentional
+        // and permanent: a terminated element never remounts, even when it is
+        // re-inserted into the DOM. Replacing it with a brand new node (which
+        // has no `__base__` marker) is the supported way to mount a fresh
+        // instance. See `$terminate()` in `Base.ts`.
         if (!getInstanceFromElement(el, ctor)) {
           new ctor(el).$mount();
         }


### PR DESCRIPTION
## What

Document and pin an unguarded contract in the mount scan, and correct two claims the first version of this branch got wrong.

Docs + tests only. **No behavior change.**

## The contract

`$terminate()` stamps the element's `__base__` entry with a `'terminated'` marker instead of deleting it. That marker is truthy, so `getInstanceFromElement()` returns it and the document-wide auto-mount scan (`mutationCallback` in `Base/utils.ts`) treats the element as already having an instance and skips it — forever, including when the very same node is re-inserted into the DOM.

Before this PR, `packages/js-toolkit/Base/utils.ts:194` — the line that decides this — was guarded by no test at all. Mutating it to ignore the `'terminated'` marker broke exactly **one** test out of the whole suite.

## Why the marker exists

Commit `9bc6f838` ("Fix terminated feature", Feb. 2022) changed `__base__.delete(...)` to `__base__.set(..., 'terminated')`. The one-line change made an *already existing* filter work: `ChildrenManager` was already doing `.filter((instance) => instance !== 'terminated')`, but with the entry deleted, `__getChild()` fell through and constructed a fresh instance instead. The marker is what keeps terminated elements excluded from `$children`, `$parent` and `queryComponent()` resolution.

## The sharp edge

**You rarely call `$terminate()` yourself.** The second pass of `mutationCallback()` terminates any instance whose element is no longer connected. So *removing an element from the DOM* is enough to permanently disable it for the auto-mount scan — animated modal teardown, virtual-list recycling, view transitions and drag & drop re-parenting all hit this without anyone typing `$terminate()`.

This combination is emergent, not designed: the marker landed in Feb. 2022 and the terminate-on-disconnect pass in Dec. 2024 (issue #552), for unrelated reasons. The docs frame it as a sharp edge with stated workarounds, not as intent.

## Changes

- `packages/js-toolkit/Base/Base.ts` — rewrote the `$terminate()` JSDoc: the real (git-supported) rationale, the mount-scan consequence scoped to the *automatic* scan, both escape hatches, and the disconnect scan named as the actual caller.
- `packages/js-toolkit/Base/utils.ts` — comment on the mount-scan site explaining why a truthy marker skips the element and what that does and does not imply.
- `packages/docs/api/instance-methods.md` — new `### Removing an element terminates its component` section under `$terminate()`: the auto-terminate behavior, the re-insertion no-op, and three workarounds (re-parent synchronously, insert a new node, instantiate explicitly), plus a tip pointing at `$destroy()` + `$mount()`.
- `packages/tests/Base/utils.spec.ts` — two regression tests in their own `describe('The terminated marker and the auto-mount scan')` block:
  1. re-inserting a terminated node is never auto-mounted, with a **positive control**: a brand new element inserted in the same mutation batch *does* mount, so the assertions on the terminated node are a real "skipped", not a "the observer never fired";
  2. `new Ctor(el).$mount()` *does* mount a terminated node — pinning the escape hatch the docs now promise.

## Corrections vs. the first version of this branch

Two claims in the initial commit were wrong and are removed:

1. ~~"it backs lazy/once components such as `withMountWhenInView`, which must trigger exactly once … and must never re-trigger on the same element"~~ — the opposite is true. `withMountWhenInView` calls `$mount()` on enter and `$destroy()` on leave on *every* visibility flip, and never calls `$terminate()` (`rg '\$terminate\(' packages/js-toolkit/` hits only the definition and the disconnect scan). Its sole `terminated` reference is a passive listener that disconnects the observer.
2. ~~"The only supported way to mount again is to replace the element with a brand new node."~~ — `Base.ts:441-443` overwrites `__base__` unconditionally, so `new Ctor(el).$mount()` clears the marker and mounts. Verified by running it; now covered by test 2 above.

The initial commit `ee95feb1` still carries the first of these in its message — **squash on merge** so it does not land in history.

## Not addressed here

- The behavior itself is unchanged. Making terminated elements auto-remountable was tried on an earlier branch and rejected as racy.
- Instantiating explicitly on a terminated element leaves the stale instance in `getInstances()` — `$on`/`$emit` use `$el` as the EventTarget, so the old instance's `before-mounted` listener fires too. Pre-existing and separate; the test asserts on the instance, not on the count.

## Verification

- Full suite: 137 files, 958 passed, 2 skipped.
- `packages/tests/Base/utils.spec.ts` run 5× in isolation: 16 passed each time, no flakiness.
- `npm run lint` and `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114BLVFkrWWJAhmamS6NHB3
