### PR TITLE
Nest the published build under dist/ to fix subpath resolution on esm.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ coverage/
 /full.d.ts
 /index.d.ts
 /lcov.info
+/tsconfig.build.tsbuildinfo
 /tsconfig.lint.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix every entry point of the package failing to link when served through esm.sh — the per-symbol subpath keys differed from a real module path only by the extension (`./utils/debounce` vs `utils/debounce.js`), so esm.sh gave the same URL to the subpath stub and to the implementation it re-exports and the served module ended up importing itself; the emitted modules are now nested under `dist/` inside the published package, keeping the file paths disjoint from the subpath keys ([#755](https://github.com/studiometa/js-toolkit/pull/755))
+
 ## [v3.8.2](https://github.com/studiometa/js-toolkit/compare/3.8.1..3.8.2) (2026-08-06)
 
 ### Fixed

--- a/scripts/build-dist-pkg.js
+++ b/scripts/build-dist-pkg.js
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
-import { buildDistExports } from './lib/subpath-exports.js';
+import glob from 'fast-glob';
+import { buildDistExports, distDir } from './lib/subpath-exports.js';
 
 const root = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const pkgRoot = resolve(root, 'packages/js-toolkit');
@@ -10,27 +11,28 @@ const distRoot = resolve(root, 'dist');
  * Write the `dist/package.json` consumed when publishing.
  *
  * It mirrors the source manifest but rewrites the entrypoints and the `exports` map to point at the
- * emitted `.js`/`.d.ts` artefacts instead of the `.ts` sources. The grouped entries (`.`, `./utils`,
- * `./package.json`) are rewritten by hand; the per-symbol subpath entries come from the shared
- * enumerator (an explicit, closed surface — no `./*` wildcard).
+ * emitted `.js`/`.d.ts` artefacts instead of the `.ts` sources. Every target sits under `distDir`,
+ * where the build nests the modules. The grouped entries (`.`, `./utils`, `./package.json`) are
+ * rewritten by hand; the per-symbol subpath entries come from the shared enumerator (an explicit,
+ * closed surface — no `./*` wildcard).
  */
 function writeDistPackage() {
   console.log('Writing dist/package.json...');
   const pkg = JSON.parse(readFileSync(resolve(pkgRoot, 'package.json'), 'utf8'));
 
-  pkg.main = './index.js';
-  pkg.module = './index.js';
-  pkg.types = './index.d.ts';
+  pkg.main = `./${distDir}/index.js`;
+  pkg.module = `./${distDir}/index.js`;
+  pkg.types = `./${distDir}/index.d.ts`;
   pkg.exports = {
     '.': {
-      import: './index.js',
-      types: './index.d.ts',
-      default: './index.js',
+      import: `./${distDir}/index.js`,
+      types: `./${distDir}/index.d.ts`,
+      default: `./${distDir}/index.js`,
     },
     './utils': {
-      import: './utils/index.js',
-      types: './utils/index.d.ts',
-      default: './utils/index.js',
+      import: `./${distDir}/utils/index.js`,
+      types: `./${distDir}/utils/index.d.ts`,
+      default: `./${distDir}/utils/index.js`,
     },
     './package.json': './package.json',
     ...buildDistExports(),
@@ -50,4 +52,45 @@ function writeDistPackage() {
   console.log('Done writing dist/package.json!');
 }
 
+/**
+ * Assert no emitted module sits at the path of a subpath key.
+ *
+ * A CDN which names its build output after the requested subpath — esm.sh does — gives the same URL
+ * to the `./utils/debounce` entry and to the `utils/debounce.js` module it re-exports. The stub then
+ * imports itself, and every consumer of that URL dies on
+ * `SyntaxError: Detected cycle while resolving name`. Nesting the build under `distDir` keeps the two
+ * path spaces disjoint; this check fails the build if anything ever breaks that guarantee.
+ */
+function assertNoSubpathShadowing() {
+  console.log('Checking subpath keys against the emitted files...');
+  const files = new Set(
+    glob
+      .globSync('**/*', { cwd: distRoot, onlyFiles: true })
+      .map((file) => file.replace(/\\/g, '/')),
+  );
+  const shadowed = [];
+
+  for (const key of Object.keys(
+    JSON.parse(readFileSync(resolve(distRoot, 'package.json'), 'utf8')).exports,
+  )) {
+    if (key === '.' || key === './package.json') continue;
+    const path = key.slice('./'.length);
+    for (const extension of ['.js', '.mjs', '.d.ts']) {
+      if (files.has(`${path}${extension}`)) shadowed.push(`${key} ↔ ${path}${extension}`);
+    }
+  }
+
+  if (shadowed.length) {
+    console.error(
+      'Subpath keys shadowed by an emitted module — CDNs naming their output after the requested',
+    );
+    console.error('subpath would serve a module which imports itself:');
+    for (const entry of shadowed) console.error(`  ${entry}`);
+    process.exit(1);
+  }
+
+  console.log(`Done, no shadowing among ${files.size} emitted files.`);
+}
+
 writeDistPackage();
+assertNoSubpathShadowing();

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,7 @@
 import { resolve, dirname } from 'node:path';
 import glob from 'fast-glob';
 import esbuild from 'esbuild';
+import { distDir } from './lib/subpath-exports.js';
 
 const root = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const { npm_package_version: version = 'dev' } = process.env;
@@ -11,7 +12,8 @@ const { errors, warnings } = await esbuild.build({
     cwd: root,
   }),
   write: true,
-  outdir: resolve(root, 'dist'),
+  // The modules are nested one level deeper than the package root, see `distDir`.
+  outdir: resolve(root, 'dist', distDir),
   target: 'esnext',
   format: 'esm',
   sourcemap: true,

--- a/scripts/lib/subpath-exports.js
+++ b/scripts/lib/subpath-exports.js
@@ -150,6 +150,19 @@ export function buildSourceExports() {
 }
 
 /**
+ * The directory every emitted module lives in inside the published package.
+ *
+ * Nesting the whole build keeps the file paths of the tarball disjoint from the subpath keys of the
+ * `exports` map: `./utils/debounce` resolves to `dist/subpaths/utils/debounce.js`, and the
+ * implementation it re-exports sits at `dist/utils/debounce.js`. Without that offset the two paths
+ * `utils/debounce` and `utils/debounce.js` differ only by the extension, and CDNs which name their
+ * build output after the requested subpath — esm.sh does — map the stub and its implementation to the
+ * same URL. The served module then imports itself and fails to link with
+ * `SyntaxError: Detected cycle while resolving name`.
+ */
+export const distDir = 'dist';
+
+/**
  * Build the `exports` map fragment for the published `dist/package.json` (object targets pointing at
  * the emitted `.js` module and its `.d.ts` declaration).
  *
@@ -160,14 +173,14 @@ export function buildDistExports() {
   const map = {};
   for (const { exported, fileBase } of root) {
     map[`./${exported}`] = {
-      types: `./subpaths/${fileBase}.d.ts`,
-      import: `./subpaths/${fileBase}.js`,
+      types: `./${distDir}/subpaths/${fileBase}.d.ts`,
+      import: `./${distDir}/subpaths/${fileBase}.js`,
     };
   }
   for (const { exported, fileBase } of utils) {
     map[`./utils/${exported}`] = {
-      types: `./subpaths/utils/${fileBase}.d.ts`,
-      import: `./subpaths/utils/${fileBase}.js`,
+      types: `./${distDir}/subpaths/utils/${fileBase}.d.ts`,
+      import: `./${distDir}/subpaths/utils/${fileBase}.js`,
     };
   }
   return map;

--- a/scripts/utils/set-version.js
+++ b/scripts/utils/set-version.js
@@ -1,5 +1,6 @@
 import { resolve, dirname } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { distDir } from '../lib/subpath-exports.js';
 
 /**
  * Replace the `__VERSION__` placeholder with the real version in the built
@@ -13,7 +14,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 const version = process.env.npm_package_version ?? 'dev';
 const root = resolve(dirname(new URL(import.meta.url).pathname), '../..');
 
-for (const file of ['dist/version.js', 'dist/version.d.ts']) {
+for (const file of [`dist/${distDir}/version.js`, `dist/${distDir}/version.d.ts`]) {
   const path = resolve(root, file);
   const content = readFileSync(path, { encoding: 'UTF-8' });
   if (!content.includes('__VERSION__')) {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,8 @@
     "noEmit": false,
     "declaration": true,
     "rootDir": "./packages/js-toolkit",
-    "outDir": "dist/",
+    "outDir": "dist/dist/",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "emitDeclarationOnly": true,
     "types": []
   },


### PR DESCRIPTION
## Problem

`@studiometa/js-toolkit@3.9.0-beta.0` is unusable on esm.sh. Every entry point fails to link:

```
SyntaxError: Detected cycle while resolving name 'debounce'
```

The served module imports itself:

```js
// https://esm.sh/@studiometa/js-toolkit@3.9.0-beta.0/es2022/utils/debounce.mjs
import{debounce as o,debounce as d}from"./debounce.mjs";export{o as debounce,d as default};
```

## Cause

esm.sh names a subpath **entry** after the requested key, but names every other module after its **path inside the package**. The per-symbol subpath exports added in #753 gave us keys which differ from a real module path only by the extension:

| | |
|---|---|
| `exports["./utils/debounce"]` | → `./subpaths/utils/debounce.js` (stub) |
| the stub re-exports | `../../utils/debounce.js` (implementation) |
| esm.sh URL for the **entry** | `/es2022/utils/debounce.mjs` — from the key |
| esm.sh URL for the **implementation** | `/es2022/utils/debounce.mjs` — from the file path |

Same URL. The stub wins, the implementation loses its URL, and the stub re-exports from itself.

This hits every symbol whose name equals the basename of its origin module — 20 of the 290 subpaths, confirmed by crawling the esm.sh module graph:

`version`, `utils/debounce`, `trapFocus`, `keyCodes`, `memoize`, `nextFrame`, `nextTick`, `nextMicrotask`, `throttle`, `scrollTo`, `getComponentResolver`, `noop`, `tween`, `memo`, `Queue`, `SmartQueue`, `wait`, `random`, `loadElement`, `cache`

Those modules are also in the barrel graphs, so `esm.sh/@studiometa/js-toolkit@3.9.0-beta.0` (via `version`) and `.../utils` are down too — not only the 20 subpaths. The package itself is spec-correct: Node, Vite and jsDelivr all resolve it fine.

## Fix

Nest the emitted modules one level deeper, so the published paths become `@studiometa/js-toolkit/dist/utils/debounce.js`. The file paths of the tarball are then disjoint from the `exports` keys, which is what esm.sh needs:

| | before | after |
|---|---|---|
| key `./utils/debounce` → URL | `/es2022/utils/debounce.mjs` | `/es2022/utils/debounce.mjs` |
| implementation → URL | `/es2022/utils/debounce.mjs` 💥 | `/es2022/dist/utils/debounce.mjs` ✅ |

`assertNoSubpathShadowing` in `scripts/build-dist-pkg.js` fails the build if an emitted file ever lands at a subpath key path again.

The publish flow does not change: `dist/` stays the package root and `npm publish dist/` still publishes the same package — only the files inside moved.

`npm publish` ignores manifest overrides in `publishConfig` (only config values such as `registry`, `tag` and `access` apply), so publishing `packages/js-toolkit` directly would have forced the committed manifest to carry the built `./dist/**/*.js` targets and broken in-repo `.ts` resolution. Keeping the synthesized `dist/package.json` avoids that.

## Verified

- `npm run build` → `Done, no shadowing among 1344 emitted files.`
- Negative test: a decoy `dist/utils/debounce.js` makes the build exit 1 with `./utils/debounce ↔ utils/debounce.js`.
- Installed the built `dist/` in a scratch project — named **and** default imports resolve for `utils/debounce`, `version`, `Base`, `utils/historyPush`, `utils` and the root, and `Base` from the subpath is identical to `Base` from the root barrel.
- 1008 tests pass, lint passes.

The esm.sh side cannot be tested before publish, but the rule is proven by `utils/collide`: its origin is `utils/collide/index.ts`, it never collided, and it is absent from the poisoned list.

## Note

npm versions are immutable and esm.sh caches per version, so `3.9.0-beta.0` stays broken. The fix needs a new publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHLkhve5pKGt1qY4CGZ9M1