### PR TITLE
Prepare 3.9.0-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v3.9.0-beta.1](https://github.com/studiometa/js-toolkit/compare/3.9.0-beta.0..3.9.0-beta.1) (2026-08-10)
+
 ### Fixed
 
 - Fix every entry point of the package failing to link when served through esm.sh — the per-symbol subpath keys differed from a real module path only by the extension (`./utils/debounce` vs `utils/debounce.js`), so esm.sh gave the same URL to the subpath stub and to the implementation it re-exports and the served module ended up importing itself; the emitted modules are now nested under `dist/` inside the published package, keeping the file paths disjoint from the subpath keys ([#755](https://github.com/studiometa/js-toolkit/pull/755))
+
+## [v3.9.0-beta.0](https://github.com/studiometa/js-toolkit/compare/3.8.2..3.9.0-beta.0) (2026-08-06)
+
+### Added
+
+- Add per-symbol subpath exports: every root barrel export is now reachable at its own top-level subpath (`@studiometa/js-toolkit/Base`) and every util at `@studiometa/js-toolkit/utils/<name>`, each resolving as both the named and the default export, so a single symbol can be imported without going through a barrel ([#753](https://github.com/studiometa/js-toolkit/pull/753))
+- Add a framework-level autoload engine mounting components from a manifest on demand — `autoload`, `defineManifest`, `registerManifest`, `registerManifests`, `composeManifests`, `ComponentLoader`, and the `fromMetaGlob` / `fromWebpackContext` module adapters — with `eager`, `visible`, `idle` and `interaction` load strategies, overridable per element with the `data-load` attribute ([#753](https://github.com/studiometa/js-toolkit/pull/753))
 
 ## [v3.8.2](https://github.com/studiometa/js-toolkit/compare/3.8.1..3.8.2) (2026-08-06)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/js-toolkit-workspace",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "workspaces": [
         "packages/*"
       ],
@@ -23256,7 +23256,7 @@
     },
     "packages/demo": {
       "name": "@studiometa/js-toolkit-demo",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "dependencies": {
         "@studiometa/ui": "1.7.0"
       },
@@ -23311,7 +23311,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/js-toolkit-docs",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "devDependencies": {
         "@shikijs/vitepress-twoslash": "4.0.2",
         "@studiometa/tailwind-config": "3.0.0",
@@ -23344,7 +23344,7 @@
     },
     "packages/eslint-plugin-js-toolkit": {
       "name": "@studiometa/eslint-plugin-js-toolkit",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -23359,7 +23359,7 @@
     },
     "packages/js-toolkit": {
       "name": "@studiometa/js-toolkit",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -23368,7 +23368,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/js-toolkit-tests",
-      "version": "3.9.0-beta.0",
+      "version": "3.9.0-beta.1",
       "dependencies": {
         "@happy-dom/global-registrator": "20.8.8",
         "@vitest/coverage-v8": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-demo",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-docs",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/eslint-plugin-js-toolkit/package.json
+++ b/packages/eslint-plugin-js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-js-toolkit",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "description": "Oxlint/ESLint plugin for @studiometa/js-toolkit best practices",
   "publishConfig": {
     "access": "public"

--- a/packages/js-toolkit/package.json
+++ b/packages/js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "description": "A set of useful little bits of JavaScript to boost your project! 🚀",
   "publishConfig": {
     "access": "public"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-tests",
-  "version": "3.9.0-beta.0",
+  "version": "3.9.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump to `3.9.0-beta.1`, plus the changelog section for `3.9.0-beta.0` which shipped without one.

## Changelog

Two sections added:

- **`v3.9.0-beta.1`** — the esm.sh subpath fix from #755.
- **`v3.9.0-beta.0`** — backfilled, documenting what #753 shipped: the per-symbol subpath exports and the framework-level autoload engine.

Please check the wording of the backfilled `3.9.0-beta.0` entries — I wrote them from the #753 commit message and the autoload reference docs, not from your notes.

## Version bump

`npm version 3.9.0-beta.1 --no-git-tag-version` updated the 6 `package.json` files, then its `postversion` hook failed:

```
Conflicting peer dependency: @studiometa/js-toolkit@3.8.0
peer @studiometa/js-toolkit@"^3.4.0" from @studiometa/ui@1.7.0
```

Bumping **from** a prerelease makes npm re-resolve the demo's `@studiometa/ui@1.7.0` peer range `^3.4.0` against the found version `3.9.0-beta.0`, and a prerelease does not satisfy a plain caret range. The `3.8.2` → `3.9.0-beta.0` bump did not hit this, because the version found at resolve time was then the stable `3.8.2`. **This will happen again on every beta → beta bump.**

The hook died before finishing the lockfile, so I completed it by hand: the 7 `"version"` entries (root ×2 + the 5 workspaces), which is exactly the 14-line shape of the `3.9.0-beta.0` prep commit (d901602c).

I first tried `npm install --package-lock-only --legacy-peer-deps`, but it rewrote 707 lines — dropping the optional platform-specific rollup binaries and flipping `devOptional` to `dev` — which would break `npm ci` on the macOS runners. Reverted.

## Verified

- `npm ci --dry-run` resolves cleanly against the updated lockfile.
- `npm run build` → `Building 3.9.0-beta.1...`, `dist/dist/version.js` carries `"3.9.0-beta.1"`, `dist/package.json` too, and the shadowing check passes (1344 files).
- 1008 tests pass, `CHANGELOG.md` passes Prettier.

Once merged, tag `3.9.0-beta.1` to publish — that is what makes the #755 fix reach esm.sh, since `3.9.0-beta.0` is immutable and cached per version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHLkhve5pKGt1qY4CGZ9M1