### PR TITLE
[Release] 3.9.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v3.9.0-beta.2](https://github.com/studiometa/js-toolkit/compare/3.9.0-beta.1..3.9.0-beta.2) (2026-08-10)
+
 ### Changed
 
 - Every per-symbol subpath and every internal import now resolves to the module declaring the symbol instead of going through a barrel, cutting the module graph of an entry point by 85% in both bytes and requests when served by a CDN — unchanged for bundled consumers, which tree-shook the difference away ([#757](https://github.com/studiometa/js-toolkit/pull/757))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/js-toolkit-workspace",
-      "version": "3.9.0-beta.1",
+      "version": "3.9.0-beta.2",
       "workspaces": [
         "packages/*"
       ],
@@ -23256,7 +23256,7 @@
     },
     "packages/demo": {
       "name": "@studiometa/js-toolkit-demo",
-      "version": "3.9.0-beta.1",
+      "version": "3.9.0-beta.2",
       "dependencies": {
         "@studiometa/ui": "1.7.0"
       },
@@ -23311,7 +23311,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/js-toolkit-docs",
-      "version": "3.9.0-beta.1",
+      "version": "3.9.0-beta.2",
       "devDependencies": {
         "@shikijs/vitepress-twoslash": "4.0.2",
         "@studiometa/tailwind-config": "3.0.0",
@@ -23344,7 +23344,7 @@
     },
     "packages/eslint-plugin-js-toolkit": {
       "name": "@studiometa/eslint-plugin-js-toolkit",
-      "version": "3.9.0-beta.1",
+      "version": "3.9.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -23359,7 +23359,7 @@
     },
     "packages/js-toolkit": {
       "name": "@studiometa/js-toolkit",
-      "version": "3.9.0-beta.1",
+      "version": "3.9.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -23368,7 +23368,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/js-toolkit-tests",
-      "version": "3.9.0-beta.1",
+      "version": "3.9.0-beta.2",
       "dependencies": {
         "@happy-dom/global-registrator": "20.8.8",
         "@vitest/coverage-v8": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-workspace",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-demo",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-docs",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/eslint-plugin-js-toolkit/package.json
+++ b/packages/eslint-plugin-js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-js-toolkit",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "description": "Oxlint/ESLint plugin for @studiometa/js-toolkit best practices",
   "publishConfig": {
     "access": "public"

--- a/packages/js-toolkit/package.json
+++ b/packages/js-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "description": "A set of useful little bits of JavaScript to boost your project! 🚀",
   "publishConfig": {
     "access": "public"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/js-toolkit-tests",
-  "version": "3.9.0-beta.1",
+  "version": "3.9.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

Prepares the `3.9.0-beta.2` prerelease: version bump across the 6 workspace manifests and the lockfile, plus the changelog section for what is already on `main`.

Contents — [#757](https://github.com/studiometa/js-toolkit/pull/757), the CDN module graph flattening:

- every per-symbol subpath and every internal import resolves to the declaring module instead of going through a barrel (−85% bytes and requests in an entry point's module graph)
- `no-deep-utils-import` stops reporting, and stops autofixing away, the public per-symbol util subpaths
- new `no-internal-barrel-import` rule and `npm run measure`

Publishing is tag-triggered, so merging this does not publish. Pushing the `3.9.0-beta.2` tag afterwards builds, tests, publishes both packages under the `next` npm tag and cuts the GitHub prerelease.

### 📝 Checklist

- [x] I have updated the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU