### PR TITLE
Move the v4 background lane off the frame and bound the phases

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -236,40 +236,49 @@ v3.9 has four independent scheduling mechanisms: `domScheduler` (microtask flush
 
 ### v4 design
 
-One scheduler with four phases per frame:
+One scheduler with **three phases inside the frame — `tick` → `read` → `write` — and one off-frame lane, `background`**:
 
 ```
 frame start (rAF)
-  1. read        — measure: layout reads only
-  2. write       — mutate: DOM writes only
-  3. afterWrite  — follow-up work after mutations
-  4. background  — budgeted lane: mount/update lifecycle work, mutation-record
-                   processing, manifest loading (absorbs SmartQueue)
-paint
+  1. tick        — fan-out to the clock's subscribers
+  2. read        — measure: layout reads only
+  3. write       — mutate: DOM writes only
+style / layout / paint
+
+between frames, on its own turns
+  background     — time-sliced lane: mount/update lifecycle work,
+                   mutation-record processing, manifest loading
+                   (absorbs SmartQueue)
 ```
+
+**Naming.** `read` and `write` are kept exactly as they are — fastdom, framesync and Motion spell them the same way, and they say precisely what they do. `background` becomes _more_ accurate once the lane runs off-frame: it maps literally onto `scheduler.postTask({ priority: 'background' })`. `frame(callback)` is now **`tick(callback)`**, with `TickProps`/`TickCallback`: the component hook is already `ticked()` and GSAP's shared clock is `gsap.ticker`, so `tick` is the word the API and the field already use, while `frame` collided with the `nextFrame()` helper — which keeps its name, since awaiting one frame is exactly what it does.
+
+**`afterWrite` is removed.** It had no consumers — neither in v4 nor in @studiometa/ui — and its name promised something `requestAnimationFrame` cannot deliver: the flush runs in a rAF callback, which the HTML "update the rendering" steps place _before_ style, layout and paint, so nothing scheduled inside the frame can observe post-layout geometry. The only in-frame hook that observes it is a `ResizeObserver` callback, which those same steps run after layout. Anything else that needs post-layout geometry waits a frame and measures in the next `read`, or uses an observer. Renaming a phase nobody called would only have kept the confusion alive under a new spelling.
 
 Properties:
 
-- **Frame alignment.** One flush per frame, at rAF. All reads batch before all writes, once, before paint. `RafService` no longer owns a loop; it subscribes to the scheduler's frame tick. Its `callback` → returned-render-function pattern maps directly to read → write phases (unchanged for users).
+- **Frame alignment.** One flush per frame, at rAF. All reads batch before all writes, once, before paint. `RafService` no longer owns a loop; it subscribes to the scheduler's tick. Its `callback` → returned-render-function pattern maps directly to read → write phases (unchanged for users).
 - **Anti-thrashing by construction.** A `read` scheduled from a `write` runs next frame; a `write` scheduled from a `read` runs in the same frame (fastdom semantics).
+- **Bounded phases — double-buffered queues.** Each phase runs the batch it was handed and nothing else: the queue array is swapped for an empty one when the phase starts, so a task scheduled into the phase that is _currently running_ lands in the next frame's batch. Draining a phase until it was empty (`while (queue.shift())`) let a `read` scheduling a `read` re-enter without end — 100,000 chained reads in one frame, no paint, no yield. Motion's render steps double-buffer for the same reason; Theatre.js instead caps recursion (warn at 10, throw at 100), which was rejected because it needs a limit to tune, surfaces as warnings and throws in the caller's code, and aborts work instead of letting it progress. Swapping the array costs nothing and preserves the cross-phase rule for free: the `write` batch is taken _after_ the reads ran, so a `write` scheduled from a `read` is still in it.
 - **Task handles.** Scheduling returns a cancelable handle whose promise resolves with the task's return value: `const box = await scheduler.read(() => el.getBoundingClientRect())`.
 - **Instance ownership.** Base sugar (`this.$read(fn)` / `this.$write(fn)`) ties tasks to the instance; terminate cancels its pending tasks. This is what makes "lifecycle equals DOM presence" safe — no stale writes to detached elements.
-- **Budgeted background lane.** The `background` phase absorbs `SmartQueue`: time-sliced with a per-frame budget, yielding through `scheduler.yield()` / `scheduler.postTask()` where available, deadline checks (`performance.now()`) as fallback. Registry mount scheduling, mutation-record processing, and lazy-manifest resolution all run here, so heavy hydration never blocks a frame.
+- **The background lane runs outside the frame.** It absorbs `SmartQueue`, and it is _not_ a phase of the flush. rAF callbacks run before style, layout and paint, so non-rendering work placed there competes with the frame no matter what budget guards it — and a budget measured from the top of the flush is spent by the tick callbacks and the render phases before the lane is reached. Measured: one tick subscriber busy 10 ms per frame (one running animation) starved the lane completely — zero background tasks in 400 ms, so nothing mounted while the animation ran. The lane now posts its own turns through `scheduler.postTask({ priority: 'background' })`, falling back to a `MessageChannel` message (`setTimeout` clamps nested timeouts; React's scheduler moved to a message channel for exactly this reason, facebook/react#16214). Each turn runs a 5 ms slice measured from the start of _the drain_, then hands the thread back and posts the next turn, so the work drains across as many turns as it needs. `isInputPending` is deliberately not used — that recommendation has been retracted. Prior art: Motion runs a second batcher on `queueMicrotask`, outside rAF, rather than budgeting inside it. Consequences: background work alone never requests an animation frame, and `whenIdle()` — which still counts background tasks as queued work — now resolves at the end of a background drain as well as at the end of a flush.
+- **Clamped tick delta.** `TickProps.delta` is clamped to `[1, 40]` ms, and the first tick after the loop wakes reports `1000/60`. Raw wall time includes everything a frame is not — a backgrounded tab, a long task, an iOS scroll pause — and every subscriber integrating it jumps by the whole gap. Motion clamps to `[1, 40]`, framesync to 40, rafz to 64; GSAP's `lagSmoothing` is the same idea. `TickProps.time` stays raw on purpose: it is rAF's own timestamp, the clock the Web Animations API and `requestVideoFrameCallback` are expressed in.
 - **Error isolation.** try/catch per task; a throwing task is reported and dropped, the flush continues, the scheduler never deadlocks.
-- **Source compatibility.** `domScheduler.read/write/afterWrite` keeps its shape — all current consumers (Slider children, ScrollAnimation, Draggable, `withScrolledInView`, `animate`) keep working; only flush timing changes. `useScheduler` custom-steps stays for non-DOM use. A synchronous escape (`flushSync`, and the `blocking` feature for tests) remains available.
+- **Source compatibility.** `domScheduler.read/write` keeps its shape — all current consumers (Slider children, ScrollAnimation, Draggable, `withScrolledInView`, `animate`) keep working; only flush timing changes, and `afterWrite` had no consumers to keep. `useScheduler` custom-steps stays for non-DOM use. A synchronous escape (`flushSync`, and the `blocking` feature for tests) remains available.
 
-### Frame subscriptions — `scheduler.frame(callback)` — implemented
+### Tick subscriptions — `scheduler.tick(callback)` — implemented
 
-The clock needs one more verb than `read`/`write`/`afterWrite`/`background`, because a service is not a task: it does not run once, it runs _while somebody is listening_.
+The clock needs one more verb than `read`/`write`/`background`, because a service is not a task: it does not run once, it runs _while somebody is listening_.
 
 ```js
-const unsubscribe = scheduler.frame(({ time, delta }) => { … });
+const unsubscribe = scheduler.tick(({ time, delta }) => { … });
 ```
 
-- Frame callbacks run **at the start of the flush, before `read`**, so anything they schedule belongs to the same frame. That is what preserves v3's `RafService` contract without a second loop: the callback measures in `read`, the render function it returns mutates in `write`, once, before paint.
-- The subscription is the only handle — no keys, no `remove(key)` — and it is what keeps the loop alive. `#schedule()` is called again at the end of a flush when a queue is non-empty **or** a frame subscriber remains, so the rAF loop stops on its own once the last one leaves. This answers the "idle-frame behavior" open point below: there is no permanent loop.
-- Frame subscribers are **not queued work**, so `whenIdle()` ignores them. A page with a live scroll animation would otherwise never be idle, and the test helper `settle()` would never return.
-- A throwing frame callback is reported and skipped, never unsubscribed: the subscription belongs to whoever created it, not to the frame that broke.
+- Tick callbacks run **at the start of the flush, before `read`**, so anything they schedule belongs to the same frame. That is what preserves v3's `RafService` contract without a second loop: the callback measures in `read`, the render function it returns mutates in `write`, once, before paint.
+- The subscription is the only handle — no keys, no `remove(key)` — and it is what keeps the loop alive. `#schedule()` is called again at the end of a flush when an in-frame queue is non-empty **or** a tick subscriber remains, so the rAF loop stops on its own once the last one leaves. This answers the "idle-frame behavior" open point below: there is no permanent loop. Pending `background` work is deliberately not part of that condition — it drains on its own turns and never holds a frame open.
+- Tick subscribers are **not queued work**, so `whenIdle()` ignores them. A page with a live scroll animation would otherwise never be idle, and the test helper `settle()` would never return.
+- A throwing tick callback is reported and skipped, never unsubscribed: the subscription belongs to whoever created it, not to the frame that broke.
 
 ### Native View Transitions move into core
 
@@ -281,11 +290,17 @@ The `viewTransition(update)` helper and its batching scheduler currently live in
 - Base sugar: `this.$viewTransition(fn)`, instance-owned and cancel-aware like `$read`/`$write`.
 - @studiometa/ui keeps only the declarative `ViewTransition` component, rebuilt on the core helper; Toaster/Dialog/Frame consume it unchanged.
 
+### A known future slot: measurement between `read` and `write`
+
+Motion has a phase between read and write — `resolveKeyframes` — that owns the unavoidable write/read/write/read pass some animations need to resolve their keyframes, amortised across every animating component so the whole page pays one layout instead of one each. It is where Framer's measured 2.5–6× came from, and it is the right shape for measurement-heavy mounting.
+
+Nothing in v4 needs it today, so nothing implements it: this project does not add speculative abstractions. It is recorded here as the slot to fill if measurement-heavy mounting ever appears — between `read` and `write`, batched, never as a per-component escape hatch.
+
 ### Open points
 
-- `afterWrite` timing: same frame after `write` (current behavior) vs after paint (double rAF / `requestPostAnimationFrame`-style). Same-frame is the compatible default; an explicit `afterPaint` phase could be added instead of changing `afterWrite`.
-- ~~Idle-frame behavior~~ **Decided:** no permanent rAF loop. The scheduler wakes on the first scheduled task or frame subscription and stops when both are gone.
-- Whether the frame loop keeps ticking during a running view transition (rendering is frozen while the snapshot is captured; long transitions should not starve `background` work).
+- ~~`afterWrite` timing~~ **Decided:** removed. rAF runs before style and layout, so no in-frame phase can observe post-layout geometry; a `ResizeObserver` callback is the only in-frame hook that can, and everything else measures in the next frame's `read`. An "after paint" phase (double rAF / `requestPostAnimationFrame`-style) can be added later on its own merits, under a name that does not promise same-frame layout.
+- ~~Idle-frame behavior~~ **Decided:** no permanent rAF loop. The scheduler wakes on the first scheduled in-frame task or tick subscription and stops when both are gone.
+- Whether the frame loop keeps ticking during a running view transition (rendering is frozen while the snapshot is captured; long transitions should not starve `background` work — less pressing now that the lane runs off-frame).
 
 ## 8. Services — lazy, reference-counted — implemented
 
@@ -296,7 +311,7 @@ A service is a shared source of props components subscribe to: `ticked`, `scroll
 - **Scoped to a target.** `useScroll(target?)` takes an element or the window, `useResize(target?)` an element, `useDrag(el)` its element; `useWindowScroll()` and `useWindowSize()` name the default cases, the split VueUse, solid-primitives, react-use and runed all make. `useRaf()` and `usePointer()` have nothing to scope — the frame is the clock and the pointer is read from the window.
 - **One instance per target,** keyed in a `WeakMap` by `perTarget()`. This is lifecycle bookkeeping rather than throughput: reference counting only means something against a target, so the last subscriber of one element must release that element's observer and leave the others running. Sharing one observer across targets was measured indifferent — the widespread claim traces to a single 2017 measurement, and 500 idle observers now cost ~0.02 ms/frame in total — so nothing tries to group them.
 - **Bound per mount cycle, by a mixin.** `withRaf`/`withScroll`/`withResize`/`withPointer`/`withDrag` override `mounted()`, subscribe the component's `ticked`/`scrolled`/`resized`/`moved`/`dragged` method, and hand the unsubscribe back as a cleanup — so `$destroy()` releases it and a remount subscribes again, with `Base` knowing nothing about services. A hook is sugar for the default target; any other target is an option of the mixin (`target`, `hook`) or an explicit `useX(target).add(…)` in `mounted()`. The mixin is the primitive because it needs no build step; `@withScroll()` is the decorator sugar over it, and both are tree-shakeable: an unimported service cannot make a hook silently do nothing.
-- **No loops of their own.** `RafService` and the drag inertia subscribe to `scheduler.frame()`; `ScrollService` coalesces its events into one `read` per frame instead of debouncing; `ResizeService` is a `ResizeObserver`, which also means a subscriber is told the current size on subscribe rather than on the next resize. `RafService` collects the render functions its callbacks return itself — the shared primitive fans props out and expects nothing back.
+- **No loops of their own.** `RafService` and the drag inertia subscribe to `scheduler.tick()`; `ScrollService` coalesces its events into one `read` per frame instead of debouncing; `ResizeService` is a `ResizeObserver`, which also means a subscriber is told the current size on subscribe rather than on the next resize. `RafService` collects the render functions its callbacks return itself — the shared primitive fans props out and expects nothing back.
 - **Props are flat, one per axis.** `ScrollProps` is `x`/`y`, `changedX`/`changedY`, `lastX`/`lastY`, `deltaX`/`deltaY`, `maxX`/`maxY`, `progressX`/`progressY`, `isUp`/`isRight`/`isDown`/`isLeft` — v3's spelling exactly, so a ported handler reads identically. The grouped objects (`last`, `delta`, `max`, `progress`, `direction`, `changed`) are gone, and with them the `ScrollDirection*` unions: v3 shipped both shapes, v4 ships one. `PointerProps` and `DragProps` follow the same `<name>X`/`<name>Y` convention, which flattens `origin`, `distance` and `final` too. `ResizeProps` was already flat. A handler destructures what it uses — `scrolled({ deltaY, isDown })` — instead of reaching through a group.
 - **What the simplification dropped.** `PointerService` is pointer-events-only and viewport-relative (v3 branched on `TouchEvent` and took a target element); `ResizeService` keeps `width`/`height`/`ratio`/`orientation`/`breakpoint` and drops `breakpoints`/`activeBreakpoints`; `DragService` drops `props.MODES` (the `DragMode` union types it) and fixes the `dragTreshold` spelling.
 - **Breakpoints are configuration, not a constant.** `setBreakpoints()` replaces the named set — the values v3 ships are only the default — and the matching `MediaQueryList` objects are built once instead of once per breakpoint per resize, which measured 5.2× slower. When `defineFeatures` lands it carries the set; this setter is what it will call.

--- a/packages/v4/src/index.ts
+++ b/packages/v4/src/index.ts
@@ -12,10 +12,11 @@
  * 5. Children advertise their existence — bubbling `component:mounted` /
  *    `component:destroyed` announcements, packaged as `$watchChildren()`,
  *    plus a provide/inject context primitive for shared reactive state.
- * 6. One frame-aligned scheduler (read → write → afterWrite → background)
- *    with cancelable handles, error isolation, and a `viewTransition` lane.
- *    It is also the clock: services subscribe to its frame tick instead of
- *    owning a `requestAnimationFrame` loop.
+ * 6. One frame-aligned scheduler — three in-frame phases (tick → read →
+ *    write) plus an off-frame `background` lane — with cancelable handles,
+ *    error isolation, and a `viewTransition` lane. It is also the clock:
+ *    services subscribe to its tick instead of owning a
+ *    `requestAnimationFrame` loop.
  * 7. Lazy, reference-counted services, one instance per observed target —
  *    subscribed by hand, or through the `withRaf`/`withScroll`/`withResize`/
  *    `withPointer`/`withDrag` mixins and their `ticked`, `scrolled`,
@@ -67,10 +68,10 @@ export {
   nextFrame,
   Scheduler,
   scheduler,
-  type FrameCallback,
-  type FrameProps,
   type ScheduledTask,
   type SchedulerPhase,
+  type TickCallback,
+  type TickProps,
 } from './scheduler.js';
 export {
   useDrag,

--- a/packages/v4/src/scheduler.spec.ts
+++ b/packages/v4/src/scheduler.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { nextFrame, scheduler, type FrameProps } from './scheduler.js';
+import { nextFrame, scheduler, type SchedulerPhase, type TickProps } from './scheduler.js';
 
 describe('scheduler (real frames)', () => {
   it('runs reads before writes within one frame, regardless of scheduling order', async () => {
@@ -40,13 +40,129 @@ describe('scheduler (real frames)', () => {
     await expect(kept.promise).resolves.toBe(42);
     await expect(canceled.promise).resolves.toBeUndefined();
   });
+
+  // Regression: `while ((item = queue.shift()))` drained a phase until it
+  // was empty, so a task re-scheduling itself into its own phase re-entered
+  // within the same frame, without end. 100,000 chained reads used to run
+  // in one frame, with no paint and no yield.
+  it('does not loop forever when a read schedules a read', async () => {
+    let runs = 0;
+    // The chain is bounded per frame, so it outlives the test window: the
+    // flag stops it, otherwise the next tests would run against a read
+    // queue that is never empty.
+    let isStopped = false;
+    const tick = () => {
+      runs += 1;
+      if (!isStopped && runs < 100_000) scheduler.read(tick);
+    };
+    scheduler.read(tick);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    isStopped = true;
+    expect(runs).toBeLessThan(100_000);
+    await scheduler.whenIdle();
+  });
+
+  // The anti-thrashing rule the whole design rests on: bounding same-phase
+  // re-entrancy must not cost the cross-phase guarantee.
+  it('still runs a write scheduled from a read in the same frame', async () => {
+    const order: string[] = [];
+    let readTime = 0;
+    let writeTime = 0;
+    scheduler.read(() => {
+      order.push('read');
+      readTime = performance.now();
+      scheduler.write(() => {
+        order.push('write');
+        writeTime = performance.now();
+      });
+    });
+    await scheduler.whenIdle();
+    expect(order).toEqual(['read', 'write']);
+    // Well within one 60 Hz frame: no frame boundary between the two.
+    expect(writeTime - readTime).toBeLessThan(8);
+  });
 });
 
-describe('scheduler.frame', () => {
+describe('scheduler.background', () => {
+  // Regression: the lane used to drain inside the rAF callback, against a
+  // budget measured from the top of the flush. One busy tick subscriber —
+  // a single running animation — spent the whole budget before the lane was
+  // reached, and nothing mounted for as long as the animation ran.
+  it('still drains background work while every frame is busy', async () => {
+    let background = 0;
+    const off = scheduler.tick(() => {
+      const until = performance.now() + 10;
+      while (performance.now() < until) {
+        /* occupy the frame */
+      }
+    });
+    for (let i = 0; i < 5; i += 1) scheduler.background(() => (background += 1));
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    off();
+    expect(background).toBe(5);
+  });
+
+  it('runs between frames, not inside one', async () => {
+    const phases: SchedulerPhase[] = [];
+    let inFrame = false;
+    const off = scheduler.tick(() => {
+      inFrame = true;
+      queueMicrotask(() => {
+        inFrame = false;
+      });
+    });
+    const seen: boolean[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      scheduler.background(() => {
+        phases.push(scheduler.phase);
+        seen.push(inFrame);
+      });
+    }
+    await scheduler.whenIdle();
+    off();
+
+    expect(phases).toEqual(['background', 'background', 'background']);
+    expect(seen).toEqual([false, false, false]);
+  });
+
+  it('yields between turns instead of draining in one go', async () => {
+    let hasYielded = false;
+    let ranBeforeYielding = 0;
+    setTimeout(() => {
+      hasYielded = true;
+    }, 0);
+    // Each task spends most of the time slice, so a turn fits two of them
+    // and the lane has to hand the thread back to finish the six.
+    for (let i = 0; i < 6; i += 1) {
+      scheduler.background(() => {
+        if (!hasYielded) ranBeforeYielding += 1;
+        const until = performance.now() + 4;
+        while (performance.now() < until) {
+          /* spend the slice */
+        }
+      });
+    }
+    await scheduler.whenIdle();
+    expect(ranBeforeYielding).toBeLessThan(6);
+  });
+
+  it('drains without any animation frame being requested', async () => {
+    await scheduler.whenIdle();
+    const spy = vi.spyOn(globalThis, 'requestAnimationFrame');
+    let ran = false;
+    scheduler.background(() => (ran = true));
+    await scheduler.whenIdle();
+    expect(ran).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('scheduler.tick', () => {
   it('ticks once per frame, before the read phase', async () => {
     const phases: string[] = [];
     let ticks = 0;
-    const unsubscribe = scheduler.frame(() => {
+    const unsubscribe = scheduler.tick(() => {
       ticks += 1;
       phases.push(scheduler.phase);
       // Scheduled from the tick, so it belongs to the same frame.
@@ -58,12 +174,12 @@ describe('scheduler.frame', () => {
     unsubscribe();
 
     expect(ticks).toBeGreaterThanOrEqual(1);
-    expect(phases.slice(0, 2)).toEqual(['frame', 'read']);
+    expect(phases.slice(0, 2)).toEqual(['tick', 'read']);
   });
 
   it('reports the time elapsed since the previous tick', async () => {
-    const props: FrameProps[] = [];
-    const unsubscribe = scheduler.frame((frameProps) => props.push(frameProps));
+    const props: TickProps[] = [];
+    const unsubscribe = scheduler.tick((tickProps) => props.push(tickProps));
 
     await nextFrame();
     await nextFrame();
@@ -71,10 +187,37 @@ describe('scheduler.frame', () => {
     unsubscribe();
 
     expect(props.length).toBeGreaterThanOrEqual(2);
-    // The first tick has no previous frame to measure against.
-    expect(props[0].delta).toBe(0);
+    // The first tick has no previous frame to measure against, so it
+    // reports one 60 Hz frame rather than a zero that would freeze anything
+    // integrating it.
+    expect(props[0].delta).toBe(1000 / 60);
     expect(props[1].delta).toBeGreaterThan(0);
     expect(props[1].time).toBeGreaterThan(props[0].time);
+  });
+
+  it('clamps the delta to [1, 40] ms', async () => {
+    const deltas: number[] = [];
+    const unsubscribe = scheduler.tick(({ delta }) => deltas.push(delta));
+
+    await nextFrame();
+    await nextFrame();
+    // A long task between two frames: the wall clock jumps, the delta must
+    // not — a subscriber integrating it would jump with it.
+    const until = performance.now() + 120;
+    while (performance.now() < until) {
+      /* stall the main thread */
+    }
+    await nextFrame();
+    await nextFrame();
+    unsubscribe();
+
+    expect(deltas.length).toBeGreaterThanOrEqual(3);
+    for (const delta of deltas) {
+      expect(delta).toBeGreaterThanOrEqual(1);
+      expect(delta).toBeLessThanOrEqual(40);
+    }
+    // The stall really did produce a gap the clamp had to absorb.
+    expect(Math.max(...deltas)).toBe(40);
   });
 
   it('reports the frame timestamp, shared by every subscriber', async () => {
@@ -84,8 +227,8 @@ describe('scheduler.frame', () => {
     await nextFrame();
 
     const seen: number[] = [];
-    const offOne = scheduler.frame(({ time }) => seen.push(time));
-    const offTwo = scheduler.frame(({ time }) => seen.push(time));
+    const offOne = scheduler.tick(({ time }) => seen.push(time));
+    const offTwo = scheduler.tick(({ time }) => seen.push(time));
     // Requested in the same task as the subscriptions, so this callback and
     // the scheduler's flush are in the same frame batch — and every callback
     // of a batch is handed the very same timestamp.
@@ -105,7 +248,7 @@ describe('scheduler.frame', () => {
 
   it('stops calling a callback once it unsubscribes', async () => {
     let ticks = 0;
-    const unsubscribe = scheduler.frame(() => {
+    const unsubscribe = scheduler.tick(() => {
       ticks += 1;
     });
     await nextFrame();
@@ -119,14 +262,14 @@ describe('scheduler.frame', () => {
   });
 
   it('never keeps whenIdle() waiting', async () => {
-    const unsubscribe = scheduler.frame(() => {});
+    const unsubscribe = scheduler.tick(() => {});
     // The loop runs, but running is not queued work.
     await expect(scheduler.whenIdle()).resolves.toBeUndefined();
     unsubscribe();
   });
 
   it('stops requesting frames when the last subscriber leaves', async () => {
-    const unsubscribe = scheduler.frame(() => {});
+    const unsubscribe = scheduler.tick(() => {});
     await nextFrame();
     unsubscribe();
 

--- a/packages/v4/src/scheduler.ts
+++ b/packages/v4/src/scheduler.ts
@@ -1,22 +1,87 @@
 /**
- * Milliseconds of `background` work allowed per frame.
+ * Milliseconds of `background` work allowed per turn, measured from the
+ * start of the drain — never from the start of a frame, which would charge
+ * rendering work against the lane meant to run beside it.
  */
-const FRAME_BUDGET = 8;
-
-export type SchedulerPhase = 'idle' | 'frame' | 'read' | 'write' | 'afterWrite' | 'background';
-
-type QueueName = 'read' | 'write' | 'afterWrite' | 'background';
+const BACKGROUND_BUDGET = 5;
 
 /**
- * What every frame subscriber is given: the timestamp of the flush and the
- * time elapsed since the previous one.
+ * Bounds for `TickProps.delta`, in milliseconds.
+ *
+ * An unclamped delta is a wall-clock measurement, and wall clock includes
+ * everything a frame is not: a backgrounded tab, a long task, an iOS scroll
+ * pause. A subscriber integrating it — every animation does — jumps by the
+ * whole gap. Clamping trades exactness for continuity, which is what an
+ * animation wants; every comparable library makes the same trade (Motion
+ * `[1, 40]`, framesync `40`, rafz `64`, GSAP's `lagSmoothing`).
  */
-export interface FrameProps {
+const MIN_DELTA = 1;
+const MAX_DELTA = 40;
+
+/**
+ * The delta reported for the first tick after the loop wakes: there is no
+ * previous frame to measure against, and one 60 Hz frame is the honest
+ * guess. `0` would freeze anything that multiplies by it on its first tick.
+ */
+const DEFAULT_DELTA = 1000 / 60;
+
+export type SchedulerPhase = 'idle' | 'tick' | 'read' | 'write' | 'background';
+
+type QueueName = 'read' | 'write' | 'background';
+
+/**
+ * The queued phases flushed inside the animation frame, in order. `tick` is
+ * a fan-out to subscribers rather than a queue, so it is not one of them.
+ */
+const FRAME_PHASES = ['read', 'write'] as const;
+
+/**
+ * What every tick subscriber is given: the frame's own timestamp and the
+ * time elapsed since the previous frame, clamped to `[1, 40]` ms.
+ */
+export interface TickProps {
   time: DOMHighResTimeStamp;
   delta: number;
 }
 
-export type FrameCallback = (props: FrameProps) => void;
+export type TickCallback = (props: TickProps) => void;
+
+/** Pending background turns, and the port that runs them. */
+const turns: Array<() => void> = [];
+let channel: MessageChannel | undefined;
+
+/**
+ * Run a callback outside the animation frame, at the lowest priority the
+ * platform offers.
+ *
+ * `scheduler.postTask({ priority: 'background' })` is the native spelling.
+ * The fallback is a `MessageChannel` message rather than `setTimeout`,
+ * whose nested-timeout clamping (4 ms after five levels) would cap the lane
+ * at a couple of hundred turns per second — the reason React's scheduler
+ * moved off timers too (facebook/react#16214, "Yield many times per frame,
+ * no rAF"). `isInputPending` is deliberately not consulted: the guidance to
+ * use it has been retracted.
+ */
+function postBackgroundTask(run: () => void): void {
+  // The global `scheduler` object, not this module's export — hence the
+  // explicit `globalThis`.
+  const nativeScheduler = globalThis.scheduler;
+  if (typeof nativeScheduler?.postTask === 'function') {
+    nativeScheduler.postTask(run, { priority: 'background' }).catch((error: unknown) => {
+      console.error('[scheduler] Background turn failed:', error);
+    });
+    return;
+  }
+
+  // Opened on demand, never at module scope: importing the framework must
+  // not open a port.
+  if (!channel) {
+    channel = new MessageChannel();
+    channel.port1.onmessage = () => turns.shift()?.();
+  }
+  turns.push(run);
+  channel.port2.postMessage(null);
+}
 
 /**
  * Cancelable handle returned for every scheduled task. The promise resolves
@@ -35,25 +100,47 @@ interface QueueItem {
 }
 
 /**
- * Frame-aligned scheduler: the framework's clock. Each flush runs one
- * `frame` fan-out followed by four phases — read → write → afterWrite →
- * background (budgeted).
+ * Frame-aligned scheduler: the framework's clock.
+ *
+ * Three phases run inside the animation frame — **tick → read → write** —
+ * and one lane, **background**, runs between frames on its own turns.
+ *
+ * ```
+ * frame start (rAF)
+ *   tick   — fan-out to the clock's subscribers
+ *   read   — measure: layout reads only
+ *   write  — mutate: DOM writes only
+ * style / layout / paint
+ *
+ * between frames
+ *   background — time-sliced, off-frame lane
+ * ```
+ *
+ * There is no phase after `write`: the whole flush runs in a
+ * `requestAnimationFrame` callback, which the HTML "update the rendering"
+ * steps place *before* style, layout and paint, so nothing scheduled in the
+ * frame can observe post-layout geometry. The only in-frame hook that can
+ * is a `ResizeObserver` callback, which those steps run after layout;
+ * anything else measures in the next frame's `read`.
  *
  * - One flush per frame, at `requestAnimationFrame`.
- * - A task scheduled during its own phase runs in the same frame.
- * - A task scheduled for an already-flushed phase waits for the next frame,
- *   so a `read` requested from a `write` never forces synchronous layout.
+ * - A task scheduled for a phase that has not run yet in this flush runs in
+ *   the same frame: a `write` requested from a `read` mutates before paint.
+ * - A task scheduled for the phase that is currently running, or for one
+ *   already flushed, waits for the next frame — so a `read` requested from
+ *   a `write` never forces synchronous layout, and a phase can never
+ *   re-enter itself without end.
  * - Every task gets a cancelable handle whose promise resolves with the
  *   task's return value.
  * - A throwing task is reported and dropped; the flush continues.
  * - No frame is requested while there is nothing to do: the loop wakes on
- *   the first scheduled task or frame subscription and stops with the last.
+ *   the first scheduled render task or tick subscription and stops with the
+ *   last. Background work alone never requests a frame.
  */
 export class Scheduler {
   #queues: Record<QueueName, QueueItem[]> = {
     read: [],
     write: [],
-    afterWrite: [],
     background: [],
   };
 
@@ -61,11 +148,16 @@ export class Scheduler {
 
   #isScheduled = false;
 
+  #isBackgroundScheduled = false;
+
   #idleResolvers: Array<() => void> = [];
 
-  #frameCallbacks = new Set<FrameCallback>();
+  #tickCallbacks = new Set<TickCallback>();
 
-  /** `-1` while nothing is subscribed, so the first tick reports no delta. */
+  /**
+   * `-1` while nothing is subscribed, so the first tick after the loop wakes
+   * reports `DEFAULT_DELTA` instead of a measurement it cannot make.
+   */
   #lastFrameTime = -1;
 
   get phase(): SchedulerPhase {
@@ -73,27 +165,30 @@ export class Scheduler {
   }
 
   /**
-   * Subscribe to the frame tick — the clock every continuous service runs
-   * on, so none of them owns a `requestAnimationFrame` loop of its own.
+   * Subscribe to the tick — the clock every continuous service runs on, so
+   * none of them owns a `requestAnimationFrame` loop of its own. It is the
+   * verb the component hook (`ticked()`) and GSAP's shared clock
+   * (`gsap.ticker`) already use; `nextFrame()` keeps the word *frame*,
+   * because awaiting one frame is what it does.
    *
    * Callbacks run at the very start of the flush, before `read`, so work
    * they schedule lands in the same frame: a `useRaf()` callback measures in
    * `read` and its returned render function mutates in `write`, once, before
    * paint.
    *
-   * The loop runs only while it is subscribed to. Frame subscribers are not
+   * The loop runs only while it is subscribed to. Tick subscribers are not
    * queued work, so they never keep `whenIdle()` waiting.
    *
    * @returns Unsubscribe.
    */
-  frame(callback: FrameCallback): () => void {
-    if (this.#frameCallbacks.size === 0) {
+  tick(callback: TickCallback): () => void {
+    if (this.#tickCallbacks.size === 0) {
       this.#lastFrameTime = -1;
     }
-    this.#frameCallbacks.add(callback);
+    this.#tickCallbacks.add(callback);
     this.#schedule();
     return () => {
-      this.#frameCallbacks.delete(callback);
+      this.#tickCallbacks.delete(callback);
     };
   }
 
@@ -105,10 +200,17 @@ export class Scheduler {
     return this.#add('write', fn);
   }
 
-  afterWrite<T>(fn: () => T): ScheduledTask<T> {
-    return this.#add('afterWrite', fn);
-  }
-
+  /**
+   * Schedule low-priority work — mounting, teardown, hydration — on its own
+   * turn **between** frames, never inside one.
+   *
+   * A `requestAnimationFrame` callback runs before style, layout and paint,
+   * so non-rendering work placed there competes with the frame it is trying
+   * to stay out of the way of, whatever budget guards it. The lane posts
+   * itself through `scheduler.postTask({ priority: 'background' })`, or a
+   * `MessageChannel` message, and drains in time slices across as many
+   * turns as the work needs.
+   */
   background<T>(fn: () => T): ScheduledTask<T> {
     return this.#add('background', fn);
   }
@@ -124,7 +226,7 @@ export class Scheduler {
   }
 
   /**
-   * Idleness is about queued tasks only: a frame subscription keeps the loop
+   * Idleness is about queued tasks only: a tick subscription keeps the loop
    * running forever by design, and a live service must not make
    * `whenIdle()` wait for a queue that will never be the reason it resolves.
    */
@@ -144,7 +246,11 @@ export class Scheduler {
     promise.catch(() => {});
     const item: QueueItem = { fn, isCanceled: false, resolve, reject };
     this.#queues[queueName].push(item);
-    this.#schedule();
+    if (queueName === 'background') {
+      this.#scheduleBackground();
+    } else {
+      this.#schedule();
+    }
     return {
       promise: promise as Promise<T | undefined>,
       cancel() {
@@ -166,56 +272,107 @@ export class Scheduler {
     requestAnimationFrame((frameTime) => this.#flush(frameTime));
   }
 
+  #scheduleBackground(): void {
+    if (this.#isBackgroundScheduled) {
+      return;
+    }
+    this.#isBackgroundScheduled = true;
+    postBackgroundTask(() => this.#drainBackground());
+  }
+
+  /**
+   * One background turn: run tasks until the time slice runs out, then hand
+   * the thread back and post the next turn. The slice is measured from the
+   * start of the drain, so a busy frame cannot spend the lane's budget.
+   */
+  #drainBackground(): void {
+    this.#isBackgroundScheduled = false;
+    const start = performance.now();
+    const queue = this.#queues.background;
+
+    this.#phase = 'background';
+    while (queue.length > 0 && performance.now() - start < BACKGROUND_BUDGET) {
+      this.#run(queue.shift() as QueueItem);
+    }
+    this.#phase = 'idle';
+
+    if (queue.length > 0) {
+      this.#scheduleBackground();
+    }
+    this.#resolveIdle();
+  }
+
   #flush(frameTime: DOMHighResTimeStamp): void {
     this.#isScheduled = false;
-    // Wall time from the top of the flush, for the background budget only.
-    const start = performance.now();
 
-    if (this.#frameCallbacks.size > 0) {
-      this.#phase = 'frame';
-      const props: FrameProps = {
+    if (this.#tickCallbacks.size > 0) {
+      this.#phase = 'tick';
+      const props: TickProps = {
         time: frameTime,
-        delta: this.#lastFrameTime < 0 ? 0 : frameTime - this.#lastFrameTime,
+        delta: this.#clampDelta(frameTime),
       };
       this.#lastFrameTime = frameTime;
-      for (const callback of this.#frameCallbacks) {
+      for (const callback of this.#tickCallbacks) {
         try {
           callback(props);
         } catch (error) {
           // Reported and skipped, never unsubscribed: a subscription is
           // owned by whoever created it, not by the frame that broke.
-          console.error('[scheduler] Frame callback failed:', error);
+          console.error('[scheduler] Tick callback failed:', error);
         }
       }
     }
 
-    for (const phase of ['read', 'write', 'afterWrite'] as const) {
+    // Double-buffering, as Motion's render steps do it: each phase runs the
+    // batch it was handed and nothing else. A task scheduled into the phase
+    // that is running lands in the fresh queue and waits for the next
+    // frame, which is what bounds the flush — `while (queue.shift())` let a
+    // `read` scheduling a `read` re-enter without end, taking the page with
+    // it. Swapping the array (rather than counting recursion, as Theatre.js
+    // does) was chosen because it keeps the frame bounded without a limit
+    // to tune, without warnings or throws in the caller's code, and because
+    // the work still makes progress — one batch per frame — instead of
+    // being aborted. It also preserves the anti-thrashing rule for free:
+    // the `write` queue is taken *after* the reads have run, so a `write`
+    // scheduled from a `read` is still in it and runs in the same frame.
+    for (const phase of FRAME_PHASES) {
       this.#phase = phase;
-      const queue = this.#queues[phase];
-      let item;
-      while ((item = queue.shift())) {
+      const batch = this.#queues[phase];
+      this.#queues[phase] = [];
+      for (const item of batch) {
         this.#run(item);
       }
     }
 
-    this.#phase = 'background';
-    const backgroundQueue = this.#queues.background;
-    while (backgroundQueue.length > 0 && performance.now() - start < FRAME_BUDGET) {
-      this.#run(backgroundQueue.shift() as QueueItem);
-    }
-
     this.#phase = 'idle';
 
-    const isIdle = this.#isIdle();
-    if (!isIdle || this.#frameCallbacks.size > 0) {
+    // The rAF loop exists for rendering work only. A pending background
+    // task must not hold a frame open — it drains on its own turns.
+    if (this.#hasFrameWork() || this.#tickCallbacks.size > 0) {
       this.#schedule();
     }
-    if (isIdle && this.#idleResolvers.length > 0) {
-      const resolvers = this.#idleResolvers;
-      this.#idleResolvers = [];
-      for (const resolve of resolvers) {
-        resolve();
-      }
+    this.#resolveIdle();
+  }
+
+  #hasFrameWork(): boolean {
+    return FRAME_PHASES.some((phase) => this.#queues[phase].length > 0);
+  }
+
+  #clampDelta(frameTime: DOMHighResTimeStamp): number {
+    if (this.#lastFrameTime < 0) {
+      return DEFAULT_DELTA;
+    }
+    return Math.min(Math.max(frameTime - this.#lastFrameTime, MIN_DELTA), MAX_DELTA);
+  }
+
+  #resolveIdle(): void {
+    if (this.#idleResolvers.length === 0 || !this.#isIdle()) {
+      return;
+    }
+    const resolvers = this.#idleResolvers;
+    this.#idleResolvers = [];
+    for (const resolve of resolvers) {
+      resolve();
     }
   }
 

--- a/packages/v4/src/services/DragService.ts
+++ b/packages/v4/src/services/DragService.ts
@@ -84,11 +84,11 @@ function createDragService(target: HTMLElement, options: DragOptions): Service<D
   return createService<DragProps>({
     props: () => props,
     start(emit) {
-      let unsubscribeFrames: (() => void) | null = null;
+      let unsubscribeTicks: (() => void) | null = null;
 
       function stopInertia() {
-        unsubscribeFrames?.();
-        unsubscribeFrames = null;
+        unsubscribeTicks?.();
+        unsubscribeTicks = null;
       }
 
       function stop() {
@@ -154,7 +154,7 @@ function createDragService(target: HTMLElement, options: DragOptions): Service<D
         props.finalX = inertiaFinalValue(props.x, props.deltaX, dampFactor);
         props.finalY = inertiaFinalValue(props.y, props.deltaY, dampFactor);
         emit(props);
-        unsubscribeFrames = scheduler.frame(tick);
+        unsubscribeTicks = scheduler.tick(tick);
       }
 
       function onPointerMove(event: Event) {

--- a/packages/v4/src/services/RafService.ts
+++ b/packages/v4/src/services/RafService.ts
@@ -1,12 +1,12 @@
-import { scheduler, type FrameProps } from '../scheduler.js';
+import { scheduler, type TickProps } from '../scheduler.js';
 import { createServiceMixin, type ServiceMixinOptions } from './mixin.js';
 import { createService, type Service } from './Service.js';
 
 /**
- * The scheduler's frame props, verbatim: the raf service is a subscription
+ * The scheduler's tick props, verbatim: the raf service is a subscription
  * to the framework clock, not a source of its own.
  */
-export type RafProps = FrameProps;
+export type RafProps = TickProps;
 
 /**
  * What a `ticked()` callback may return: a function running in the same
@@ -15,7 +15,10 @@ export type RafProps = FrameProps;
 export type RafRender = (props: RafProps) => void;
 
 function createRafService(): Service<RafProps> {
-  let props: RafProps = { time: performance.now(), delta: 0 };
+  // Before the first tick there is nothing measured yet: report one 60 Hz
+  // frame, the same value the scheduler gives its first tick, rather than a
+  // zero outside the documented `[1, 40]` range.
+  let props: RafProps = { time: performance.now(), delta: 1000 / 60 };
   // Collected here rather than through the fan-out: returning a value to the
   // service is this service's own convention, not something the shared
   // primitive knows about.
@@ -24,21 +27,21 @@ function createRafService(): Service<RafProps> {
   const service = createService<RafProps>({
     props: () => props,
     start(emit) {
-      return scheduler.frame((frameProps) => {
-        props = frameProps;
+      return scheduler.tick((tickProps) => {
+        props = tickProps;
         // The read → write split v3 established: every callback measures
         // together, then every returned render mutates together, so a page
         // full of animations costs one layout per frame instead of one per
         // component.
         scheduler.read(() => {
           renders.length = 0;
-          emit(frameProps);
+          emit(tickProps);
           if (renders.length > 0) {
             const batch = [...renders];
             renders.length = 0;
             scheduler.write(() => {
               for (const render of batch) {
-                render(frameProps);
+                render(tickProps);
               }
             });
           }
@@ -50,8 +53,8 @@ function createRafService(): Service<RafProps> {
   return {
     props: service.props,
     add(callback) {
-      return service.add((frameProps) => {
-        const render = callback(frameProps);
+      return service.add((tickProps) => {
+        const render = callback(tickProps);
         if (typeof render === 'function') {
           renders.push(render as RafRender);
         }
@@ -75,7 +78,7 @@ let service: Service<RafProps> | undefined;
  * ```
  *
  * Unlike v3, this owns no `requestAnimationFrame` loop: it subscribes to the
- * scheduler's frame tick, so components ticking, scroll-driven animations
+ * scheduler's tick, so components ticking, scroll-driven animations
  * and lifecycle work share one flush per frame.
  */
 export function useRaf(): Service<RafProps> {


### PR DESCRIPTION
Follows the merged v4 work. Three defects, two of them proven by tests that now guard against their return, plus the phase renames.

## The background lane starved

Its budget was measured from the top of the flush, so every millisecond spent on tick callbacks and render phases was charged against it. With one animation occupying 10 ms a frame, **no background task ran at all** — and since the registry mounts components in that lane, nothing mounted while an animation played. Demonstrated by a test before fixing:

```js
const off = scheduler.tick(() => { /* burn 10ms, i.e. one animation */ });
for (let i = 0; i < 5; i += 1) scheduler.background(() => (background += 1));
await wait(400);
expect(background).toBe(5);   // was 0
```

The lane now leaves the frame entirely, posting its own turns through `scheduler.postTask` at background priority — a `MessageChannel` where that is unavailable — and spending a slice measured from the start of its own drain. Per the HTML spec's rendering steps rAF runs before style, layout and paint, so non-rendering work there competes with the frame whatever the budget says. Motion reaches the same conclusion with a second batcher outside rAF; React's scheduler dropped its rAF path for a message channel.

## Same-phase scheduling could hang the page

Draining a phase until its queue emptied let a `read` that schedules a `read` re-enter without bound — **100,000 chained reads ran in a single frame**, no paint, no yield. Each phase now takes its queue and leaves an empty one, so a frame runs the batch it was handed.

Double-buffering rather than a recursion cap: no limit to tune, nothing aborted, and it preserves the anti-thrashing rule for free, since the write batch is taken after the reads have run. That guarantee has its own test.

## The tick delta was unclamped

A backgrounded tab or a long task made animations jump. Clamped to 1–40 ms — the range Motion and framesync use, and what GSAP's `lagSmoothing` exists for — with `1000/60` for the first tick after the loop wakes. `TickProps.time` is untouched: it stays `requestAnimationFrame`'s own timestamp.

## Naming

`frame` → `tick`, matching the `ticked()` hook a component writes and GSAP's ticker; `nextFrame()` keeps its name since it genuinely means "await one frame". `afterWrite` is **removed** — it had no consumer here or in @studiometa/ui, and its name promised post-layout geometry a pre-layout callback cannot deliver. The model is now three in-frame phases, `tick → read → write`, plus one off-frame lane.

No measurement phase added. Motion's `resolveKeyframes` is the right shape if measurement-heavy mounting arrives, and `DESIGN.md` records it as a known future slot with that rationale — but nothing needs it today.

## Verification

- `npx tsgo --noEmit -p .` clean, `npx oxlint .` 0/0, prettier clean
- **111 tests**, three consecutive runs, no flakes (104 before; 7 new)

## Worth a reviewer's eye

- `whenIdle()` now resolves from two sites, since a drain can finish outside a flush.
- `background` no longer keeps the rAF loop alive — the behavioural change most likely to surprise a consumer.
- One existing assertion changed rather than the code: the first tick's delta was asserted to be `0`, which cannot hold once it is `1000/60`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU