### PR TITLE
Port four @studiometa/ui component families onto v4 (migration test)

### DIFF
--- a/packages/v4/migration/Accordion/Accordion.spec.ts
+++ b/packages/v4/migration/Accordion/Accordion.spec.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerComponent } from '../../src/index.js';
+import { getInstance, resetDom, settle } from '../../src/test-utils.js';
+import { Accordion } from './Accordion.js';
+import { AccordionItem } from './AccordionItem.js';
+
+registerComponent(Accordion);
+
+afterEach(resetDom);
+
+function render(): HTMLElement {
+  const root = document.createElement('div');
+  root.setAttribute('data-component', 'Accordion');
+  root.innerHTML = ['a', 'b', 'c']
+    .map(
+      (name) => `
+      <div data-component="AccordionItem" data-option-is-open="${name === 'a'}">
+        <button type="button" data-ref="btn">${name}</button>
+        <div data-ref="container"><div data-ref="content">content ${name}</div></div>
+      </div>`,
+    )
+    .join('');
+  document.body.append(root);
+  return root;
+}
+
+function items(root: HTMLElement): AccordionItem[] {
+  return [...root.querySelectorAll('[data-component="AccordionItem"]')].map((el) =>
+    getInstance<AccordionItem>(el, 'AccordionItem'),
+  );
+}
+
+describe('Accordion', () => {
+  it('mounts its items without being their owner', async () => {
+    const root = render();
+    await settle();
+
+    const accordion = getInstance<Accordion>(root, 'Accordion');
+    expect(accordion.items.size).toBe(3);
+    expect(accordion.items.items.every((item) => item instanceof AccordionItem)).toBe(true);
+  });
+
+  it('wires the ARIA attributes both ways', async () => {
+    const root = render();
+    await settle();
+
+    const [first, second] = items(root);
+    const btn = first.$refs.btn;
+    const content = first.$refs.content;
+
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(btn.getAttribute('aria-controls')).toBe(content.id);
+    expect(content.getAttribute('aria-labelledby')).toBe(btn.id);
+    expect(content.getAttribute('aria-hidden')).toBe('false');
+
+    expect(second.$refs.btn.getAttribute('aria-expanded')).toBe('false');
+    expect(second.$refs.content.getAttribute('aria-hidden')).toBe('true');
+    expect(second.$refs.container.style.height).toBe('0px');
+  });
+
+  it('toggles on a real click and keeps ARIA in sync', async () => {
+    const root = render();
+    await settle();
+
+    const [, second] = items(root);
+    second.$refs.btn.click();
+    await settle();
+
+    expect(second.isOpen).toBe(true);
+    expect(second.$refs.btn.getAttribute('aria-expanded')).toBe('true');
+
+    second.$refs.btn.click();
+    await settle();
+    expect(second.isOpen).toBe(false);
+    expect(second.$refs.btn.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('autocloses the other items through the delegated open event', async () => {
+    const root = render();
+    root.setAttribute('data-option-autoclose', '');
+    await settle();
+
+    const [first, second] = items(root);
+    expect(first.isOpen).toBe(true);
+
+    second.$refs.btn.click();
+    await settle();
+
+    expect(second.isOpen).toBe(true);
+    expect(first.isOpen).toBe(false);
+  });
+
+  it('re-emits open and close with the item and its index', async () => {
+    const root = render();
+    await settle();
+
+    const seen: Array<[string, number]> = [];
+    for (const type of ['open', 'close']) {
+      root.addEventListener(type, (event) => {
+        const detail = (event as CustomEvent).detail as [AccordionItem, number];
+        // Only the Accordion's own re-emit carries two arguments.
+        if (detail.length === 2) {
+          seen.push([type, detail[1]]);
+        }
+      });
+    }
+
+    items(root)[2].$refs.btn.click();
+    await settle();
+    items(root)[2].$refs.btn.click();
+    await settle();
+
+    expect(seen).toEqual([
+      ['open', 2],
+      ['close', 2],
+    ]);
+  });
+
+  it('forwards the parent `item` option to items that mount before it', async () => {
+    // The item is inserted first and on its own, so nothing about the
+    // Accordion is mounted when it reads its settings.
+    const root = document.createElement('div');
+    root.setAttribute('data-component', 'Accordion');
+    root.setAttribute('data-option-item', JSON.stringify({ isOpen: true }));
+    root.innerHTML = `
+      <div data-component="AccordionItem">
+        <button type="button" data-ref="btn">a</button>
+        <div data-ref="container"><div data-ref="content">content</div></div>
+      </div>`;
+    document.body.append(root);
+    await settle();
+
+    const [item] = items(root);
+    expect(item.isOpen).toBe(true);
+    expect(item.$refs.btn.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('keeps the collection live when an item is added or removed', async () => {
+    const root = render();
+    await settle();
+
+    const accordion = getInstance<Accordion>(root, 'Accordion');
+    root.querySelector('[data-component="AccordionItem"]')?.remove();
+    await settle();
+    expect(accordion.items.size).toBe(2);
+
+    const added = document.createElement('div');
+    added.setAttribute('data-component', 'AccordionItem');
+    added.innerHTML = `
+      <button type="button" data-ref="btn">d</button>
+      <div data-ref="container"><div data-ref="content">content d</div></div>`;
+    root.append(added);
+    await settle();
+    expect(accordion.items.size).toBe(3);
+    expect(accordion.items.items.at(-1)?.$el).toBe(added);
+  });
+
+  it('restores the container styles when the item leaves the DOM', async () => {
+    const root = render();
+    await settle();
+
+    const [, second] = items(root);
+    const { container } = second.$refs;
+    expect(container.style.height).toBe('0px');
+
+    second.$el.remove();
+    await settle();
+    expect(container.style.height).toBe('');
+    expect(container.style.visibility).toBe('');
+  });
+});

--- a/packages/v4/migration/Accordion/Accordion.ts
+++ b/packages/v4/migration/Accordion/Accordion.ts
@@ -1,0 +1,18 @@
+import type { BaseConfig } from '../../src/index.js';
+import { AccordionCore } from './AccordionCore.js';
+import { AccordionItem } from './AccordionItem.js';
+
+/**
+ * Accordion — the ready-to-use component.
+ *
+ * Unchanged from v3 apart from the config spread: v4 merges configs along the
+ * prototype chain, so `components` is all this class has to declare. In v3 it
+ * had to spread `AccordionCore.config` by hand or lose the parent's options
+ * (issue #627).
+ */
+export class Accordion extends AccordionCore {
+  static config: BaseConfig = {
+    name: 'Accordion',
+    components: { AccordionItem },
+  };
+}

--- a/packages/v4/migration/Accordion/AccordionCore.ts
+++ b/packages/v4/migration/Accordion/AccordionCore.ts
@@ -1,0 +1,57 @@
+import {
+  Base,
+  type BaseConfig,
+  type ChildrenCollection,
+  type DelegatedEvent,
+} from '../../src/index.js';
+import type { AccordionItem } from './AccordionItem.js';
+
+export interface AccordionProps {
+  $options: { autoclose: boolean; item: Record<string, unknown> };
+  $emits: {
+    open: [item: AccordionItem, index: number];
+    close: [item: AccordionItem, index: number];
+  };
+}
+
+/**
+ * AccordionCore — the orchestrator for a group of `AccordionItem` children.
+ *
+ * Port of @studiometa/ui 1.10's `AccordionCore`. Everything it does is
+ * cross-item coordination, which is exactly the `$children` coordinator shape
+ * v4 replaces:
+ *
+ * - `$children.AccordionItem` → `$watchChildren('AccordionItem')`, a live
+ *   DOM-ordered collection that is correct whatever the mount order.
+ * - `onAccordionItemOpen({ index })` → a delegated handler carrying the
+ *   emitting instance itself, so the index is only needed to keep the v3
+ *   event payload.
+ * - `config.emits: ['open', 'close']` → the type-only `$emits` declaration.
+ */
+export class AccordionCore extends Base<AccordionProps> {
+  static config: BaseConfig = {
+    name: 'Accordion',
+    options: {
+      autoclose: Boolean,
+      item: { type: Object, default: {} },
+    },
+  };
+
+  items: ChildrenCollection<AccordionItem> = this.$watchChildren<AccordionItem>('AccordionItem');
+
+  onAccordionItemOpen({ target }: DelegatedEvent<AccordionItem>): void {
+    this.$emit('open', target, this.items.items.indexOf(target));
+
+    if (this.$options.autoclose) {
+      for (const item of this.items) {
+        if (item !== target) {
+          item.close();
+        }
+      }
+    }
+  }
+
+  onAccordionItemClose({ target }: DelegatedEvent<AccordionItem>): void {
+    this.$emit('close', target, this.items.items.indexOf(target));
+  }
+}

--- a/packages/v4/migration/Accordion/AccordionItem.ts
+++ b/packages/v4/migration/Accordion/AccordionItem.ts
@@ -1,0 +1,216 @@
+import { Base } from '../../src/index.js';
+import { transition, type ClassesOrStyles } from '../utils/transition.js';
+import { uid } from '../utils/uid.js';
+
+export type AccordionItemStates = Partial<Record<'open' | 'active' | 'closed', ClassesOrStyles>>;
+
+export interface AccordionItemSettings {
+  isOpen: boolean;
+  styles: Record<string, AccordionItemStates>;
+}
+
+export interface AccordionItemProps {
+  $refs: { btn: HTMLElement; content: HTMLElement; container: HTMLElement };
+  $options: { isOpen: boolean; styles: Record<string, AccordionItemStates> };
+  $emits: { open: []; close: [] };
+}
+
+const ACCORDION_SELECTOR = '[data-component~="Accordion"]';
+
+/**
+ * The `item` option an ancestor `Accordion` declares, read straight from the
+ * DOM rather than from the instance.
+ *
+ * v3 forwarded these by *mutating* the child's `$options` in `mounted()`
+ * (`this.$options[key] = value`). Two v4 decisions make that impossible:
+ *
+ * - `$options` is a live view over the element's attributes, defined with
+ *   getters only. Assigning to it throws.
+ * - `$closest('Accordion')` only answers once the parent is mounted, and v4
+ *   has no mount ordering: an item can mount first.
+ *
+ * Reading the ancestor's attribute is the answer that fits the v4 model —
+ * DOM ancestry is a fact, available before anything is mounted — and it is
+ * live for free, exactly like `$options` itself.
+ */
+function inheritedSettings(el: HTMLElement): Partial<AccordionItemSettings> {
+  const accordion = el.parentElement?.closest(ACCORDION_SELECTOR);
+  const raw = accordion?.getAttribute('data-option-item');
+  if (!raw) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw) as Partial<AccordionItemSettings>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * AccordionItem — a single collapsible panel.
+ *
+ * Faithful port of @studiometa/ui 1.10's `AccordionItem`: the same `btn` /
+ * `content` / `container` refs, the same animated container height, the same
+ * ARIA wiring, the same `open` / `close` events.
+ */
+export class AccordionItem extends Base<AccordionItemProps> {
+  static config = {
+    name: 'AccordionItem',
+    refs: ['btn', 'content', 'container'],
+    options: {
+      isOpen: Boolean,
+      styles: { type: Object, default: {} as Record<string, AccordionItemStates> },
+    },
+  };
+
+  readonly id = uid('accordion-item');
+
+  /**
+   * Open state.
+   *
+   * v3 stored this in `$options.isOpen` and wrote to it on every toggle,
+   * conflating configuration with state. v4's read-only `$options` forces the
+   * split, which is the better shape: the attribute is the initial value, the
+   * field is the current one.
+   */
+  #isOpen = false;
+
+  get contentId(): string {
+    return `content-${this.id}`;
+  }
+
+  get isOpen(): boolean {
+    return this.#isOpen;
+  }
+
+  /**
+   * Own options merged under the ancestor Accordion's `item` defaults.
+   */
+  get settings(): AccordionItemSettings {
+    const inherited = inheritedSettings(this.$el);
+    return {
+      isOpen: this.$el.hasAttribute('data-option-is-open')
+        ? this.$options.isOpen
+        : (inherited.isOpen ?? false),
+      styles: { ...inherited.styles, ...this.$options.styles },
+    };
+  }
+
+  /**
+   * The refs that carry declared styles, `container` excluded — that one is
+   * driven by the measured height instead.
+   */
+  get styledRefs(): Array<[HTMLElement, AccordionItemStates]> {
+    const entries: Array<[HTMLElement, AccordionItemStates]> = [];
+    for (const [name, states] of Object.entries(this.settings.styles)) {
+      if (name === 'container') {
+        continue;
+      }
+      const ref = (this.$refs as Record<string, HTMLElement | HTMLElement[]>)[name];
+      if (ref instanceof HTMLElement) {
+        entries.push([ref, states]);
+      }
+    }
+    return entries;
+  }
+
+  mounted() {
+    const { btn, content, container } = this.$refs;
+
+    btn.setAttribute('id', this.id);
+    btn.setAttribute('aria-controls', this.contentId);
+    content.setAttribute('aria-labelledby', this.id);
+    content.setAttribute('id', this.contentId);
+
+    this.#isOpen = this.settings.isOpen;
+    this.updateAttributes(this.#isOpen);
+
+    for (const [ref, { open = '', closed = '' }] of this.styledRefs) {
+      transition(ref, { to: this.#isOpen ? open : closed }, 'keep');
+    }
+
+    // v3 undid this in a `destroyed()` hook; in v4 the cleanup lives in the
+    // closure that set it up, so setup and teardown cannot drift apart.
+    return () => {
+      container.style.visibility = '';
+      container.style.height = '';
+    };
+  }
+
+  onBtnClick(): void {
+    if (this.#isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  updateAttributes(isOpen: boolean): void {
+    const { btn, content, container } = this.$refs;
+    container.style.visibility = isOpen ? '' : 'hidden';
+    container.style.height = isOpen ? '' : '0';
+    content.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+    btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  async open(): Promise<void> {
+    if (this.#isOpen) {
+      return;
+    }
+
+    this.$emit('open');
+    this.#isOpen = true;
+    this.updateAttributes(true);
+
+    const { container, content } = this.$refs;
+    container.style.visibility = '';
+    const { active } = this.settings.styles.container ?? {};
+
+    await Promise.all([
+      transition(container, {
+        from: { height: '0' },
+        active,
+        to: { height: `${content.offsetHeight}px` },
+      }).then(() => {
+        // Only clear the style if the item was not closed again meanwhile.
+        if (this.#isOpen) {
+          content.style.position = '';
+        }
+      }),
+      ...this.styledRefs.map(([ref, { open = '', active: refActive = '', closed = '' }]) =>
+        transition(ref, { from: closed, active: refActive, to: open }, 'keep'),
+      ),
+    ]);
+  }
+
+  async close(): Promise<void> {
+    if (!this.#isOpen) {
+      return;
+    }
+
+    this.$emit('close');
+    this.#isOpen = false;
+
+    const { container, content } = this.$refs;
+    const height = container.offsetHeight;
+    content.style.position = 'absolute';
+    const { active } = this.settings.styles.container ?? {};
+
+    await Promise.all([
+      transition(container, {
+        from: { height: `${height}px` },
+        active,
+        to: { height: '0' },
+      }).then(() => {
+        if (!this.#isOpen) {
+          container.style.height = '0';
+          container.style.visibility = 'hidden';
+          this.updateAttributes(false);
+        }
+      }),
+      ...this.styledRefs.map(([ref, { open = '', active: refActive = '', closed = '' }]) =>
+        transition(ref, { from: open, active: refActive, to: closed }, 'keep'),
+      ),
+    ]);
+  }
+}

--- a/packages/v4/migration/Accordion/index.ts
+++ b/packages/v4/migration/Accordion/index.ts
@@ -1,0 +1,8 @@
+export { Accordion } from './Accordion.js';
+export { AccordionCore, type AccordionProps } from './AccordionCore.js';
+export {
+  AccordionItem,
+  type AccordionItemProps,
+  type AccordionItemSettings,
+  type AccordionItemStates,
+} from './AccordionItem.js';

--- a/packages/v4/migration/Dialog/Dialog.spec.ts
+++ b/packages/v4/migration/Dialog/Dialog.spec.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerComponent } from '../../src/index.js';
+import { getInstance, resetDom, settle } from '../../src/test-utils.js';
+import { Transition } from '../Transition/Transition.js';
+import { Dialog } from './Dialog.js';
+
+registerComponent(Dialog);
+
+afterEach(async () => {
+  document.documentElement.style.overflow = '';
+  await resetDom();
+});
+
+function render({ modal = true, withTransition = true } = {}): HTMLDialogElement {
+  const el = document.createElement('dialog');
+  el.setAttribute('data-component', 'Dialog');
+  el.setAttribute('data-option-modal', String(modal));
+  el.innerHTML = `
+    ${
+      withTransition
+        ? `<div data-component="Transition" data-option-enter-to="is-open" data-option-enter-keep="" data-option-leave-to="is-closed" data-option-leave-keep="">panel</div>`
+        : ''
+    }
+    <button type="button" id="first">first</button>
+    <button type="button" id="last">last</button>
+  `;
+  document.body.append(el);
+  return el;
+}
+
+describe('Dialog', () => {
+  it('opens and closes the native dialog', async () => {
+    const el = render();
+    await settle();
+    const dialog = getInstance<Dialog>(el, 'Dialog');
+
+    await dialog.open();
+    expect(el.open).toBe(true);
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    await dialog.close();
+    expect(el.open).toBe(false);
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('is a no-op when already in the requested state', async () => {
+    const el = render();
+    await settle();
+    const dialog = getInstance<Dialog>(el, 'Dialog');
+
+    await dialog.close();
+    expect(el.open).toBe(false);
+    await dialog.open();
+    await dialog.open();
+    expect(el.open).toBe(true);
+  });
+
+  it('runs the transition children on open and close', async () => {
+    const el = render();
+    await settle();
+    const dialog = getInstance<Dialog>(el, 'Dialog');
+    const panel = el.querySelector('[data-component="Transition"]') as HTMLElement;
+
+    expect(dialog.transitions).toHaveLength(1);
+    expect(getInstance(panel, 'Transition')).toBeInstanceOf(Transition);
+
+    await dialog.open();
+    expect(panel.classList.contains('is-open')).toBe(true);
+
+    await dialog.close();
+    expect(panel.classList.contains('is-open')).toBe(false);
+    expect(panel.classList.contains('is-closed')).toBe(true);
+  });
+
+  it('picks up a transition child inserted after mount', async () => {
+    const el = render({ withTransition: false });
+    await settle();
+    const dialog = getInstance<Dialog>(el, 'Dialog');
+    expect(dialog.transitions).toHaveLength(0);
+
+    const added = document.createElement('div');
+    added.setAttribute('data-component', 'Transition');
+    added.setAttribute('data-option-enter-to', 'is-open');
+    added.setAttribute('data-option-enter-keep', '');
+    el.prepend(added);
+    await settle();
+
+    expect(dialog.transitions).toHaveLength(1);
+    await dialog.open();
+    expect(added.classList.contains('is-open')).toBe(true);
+  });
+
+  it('closes through the component when Escape cancels the native dialog', async () => {
+    const el = render();
+    await settle();
+    const dialog = getInstance<Dialog>(el, 'Dialog');
+    const panel = el.querySelector('[data-component="Transition"]') as HTMLElement;
+
+    await dialog.open();
+    expect(el.open).toBe(true);
+
+    // What the browser dispatches on Escape.
+    el.dispatchEvent(new Event('cancel', { cancelable: true }));
+    await settle();
+
+    expect(el.open).toBe(false);
+    // The leave transition ran, which is what v3 lost on Escape.
+    expect(panel.classList.contains('is-closed')).toBe(true);
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('traps the tab key on the non-modal path only', async () => {
+    const el = render({ modal: false, withTransition: false });
+    await settle();
+    const dialog = getInstance<Dialog>(el, 'Dialog');
+    await dialog.open();
+
+    const last = el.querySelector('#last') as HTMLButtonElement;
+    const first = el.querySelector('#first') as HTMLButtonElement;
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', cancelable: true }));
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('releases the keydown listener on destroy', async () => {
+    const el = render({ modal: false, withTransition: false });
+    await settle();
+    const dialog = getInstance<Dialog>(el, 'Dialog');
+    await dialog.open();
+
+    const last = el.querySelector('#last') as HTMLButtonElement;
+    last.focus();
+    dialog.$destroy();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', cancelable: true }));
+    expect(document.activeElement).toBe(last);
+  });
+});

--- a/packages/v4/migration/Dialog/Dialog.ts
+++ b/packages/v4/migration/Dialog/Dialog.ts
@@ -1,0 +1,136 @@
+import { Base, type ChildrenCollection } from '../../src/index.js';
+import { Transition, type Transitionable } from '../Transition/Transition.js';
+import { ViewTransition } from '../Transition/ViewTransition.js';
+import { saveActiveElement, trapFocus, untrapFocus } from '../utils/focus.js';
+
+export interface DialogProps {
+  $el: HTMLDialogElement;
+  $options: {
+    /**
+     * Open as a modal (`showModal()`) or not (`show()`). A modal dialog gets
+     * a native focus trap, background `inert` and focus restore for free.
+     */
+    modal: boolean;
+    /** Trap the focus by hand — only meaningful on the non-modal path. */
+    trapFocus: boolean;
+    /** Lock the document scroll while open. */
+    scrollLock: boolean;
+  };
+  $emits: { open: []; close: [] };
+}
+
+/**
+ * Dialog — a headless wrapper around the native `<dialog>` element.
+ *
+ * Port of @studiometa/ui 1.10's `Dialog`. It owns only what the platform does
+ * not give for free (modality, scroll lock, an optional focus trap for the
+ * non-modal path) and fans `enter()`/`leave()` out to every transition child.
+ *
+ * Three v4 decisions show up here:
+ *
+ * - `$children.Transition` / `$children.ViewTransition` → two
+ *   `$watchChildren` collections, live and mount-order independent. v3's
+ *   `$children` only listed the classes declared in `config.components` of
+ *   this exact class; a transition inserted later was invisible until the
+ *   next `$update()`.
+ * - `keyed()` (KeyService) → a plain `keydown` listener registered in
+ *   `mounted()` and released by its returned cleanup. v4 dropped `KeyService`
+ *   on the grounds that "a keydown listener needs no service around it", and
+ *   this is the component that proves it: the hook cost more than the
+ *   listener.
+ * - `$el` is typed `HTMLDialogElement`, so `showModal()`, `close()` and
+ *   `open` are reachable without the `get dialog()` cast v3 needed.
+ */
+export class Dialog extends Base<DialogProps> {
+  static config = {
+    name: 'Dialog',
+    components: { Transition, ViewTransition },
+    options: {
+      modal: { type: Boolean, default: true },
+      trapFocus: { type: Boolean, default: true },
+      scrollLock: { type: Boolean, default: true },
+    },
+  };
+
+  transitionChildren: ChildrenCollection<Transition> =
+    this.$watchChildren<Transition>('Transition');
+
+  viewTransitionChildren: ChildrenCollection<ViewTransition> =
+    this.$watchChildren<ViewTransition>('ViewTransition');
+
+  get transitions(): Transitionable[] {
+    return [...this.transitionChildren.items, ...this.viewTransitionChildren.items];
+  }
+
+  get isOpen(): boolean {
+    return this.$el.open;
+  }
+
+  mounted() {
+    const onKeydown = (event: KeyboardEvent) => {
+      if (this.$options.modal || !this.$options.trapFocus || !this.$el.open) {
+        return;
+      }
+      trapFocus(this.$el, event);
+    };
+    document.addEventListener('keydown', onKeydown);
+    return () => document.removeEventListener('keydown', onKeydown);
+  }
+
+  /**
+   * Escape closes a native `<dialog>` behind the component's back: v3 let it
+   * happen, so the leave transitions never ran and the scroll stayed locked.
+   * Cancelling the native close and going through `close()` fixes both — the
+   * bubbling `cancel` event makes this a two-line handler in v4.
+   */
+  onCancel(event: Event): void {
+    event.preventDefault();
+    this.close();
+  }
+
+  async open(): Promise<void> {
+    if (this.$el.open) {
+      return;
+    }
+
+    if (this.$options.modal) {
+      this.$el.showModal();
+    } else {
+      if (this.$options.trapFocus) {
+        saveActiveElement();
+      }
+      this.$el.show();
+    }
+
+    if (this.$options.scrollLock) {
+      document.documentElement.style.overflow = 'hidden';
+    }
+
+    this.$emit('open');
+    await Promise.all(this.transitions.map((transition) => transition.enter()));
+  }
+
+  async close(): Promise<void> {
+    if (!this.$el.open) {
+      return;
+    }
+
+    this.$emit('close');
+    // Leave transitions are awaited *before* the native hide, so the dialog
+    // is still painted while its children animate out.
+    await Promise.all(this.transitions.map((transition) => transition.leave()));
+    this.$el.close();
+
+    if (!this.$options.modal && this.$options.trapFocus) {
+      untrapFocus();
+    }
+
+    if (this.$options.scrollLock) {
+      document.documentElement.style.overflow = '';
+    }
+  }
+
+  toggle(): Promise<void> {
+    return this.$el.open ? this.close() : this.open();
+  }
+}

--- a/packages/v4/migration/Dialog/index.ts
+++ b/packages/v4/migration/Dialog/index.ts
@@ -1,0 +1,1 @@
+export { Dialog, type DialogProps } from './Dialog.js';

--- a/packages/v4/migration/REPORT.md
+++ b/packages/v4/migration/REPORT.md
@@ -6,12 +6,12 @@ Four component families were ported onto v4 to find out what a real migration co
 
 ## What was ported
 
-| Family | Files | Ported | Not ported |
-| --- | --- | --- | --- |
-| `Accordion` | `AccordionCore`, `Accordion`, `AccordionItem` | full | — |
-| `Dialog` | `Dialog`, plus `Transition` / `ViewTransition` (its children) | full | `Action` triggers, `Transition`'s `group` option |
-| `ScrollAnimation` | `withScrolledInView`, `AbstractScrollAnimation`, `ScrollAnimationTimeline`, `…Target` | full (the non-deprecated pair) | the five `@deprecated` classes, `withScrollAnimationDebug` |
-| `Slider` | `Slider`, `SliderItem`, `SliderBtn`, `SliderCount` | full | `SliderDrag`, `SliderDots`, `SliderProgress` (mechanical follow-ups) |
+| Family            | Files                                                                                 | Ported                         | Not ported                                                           |
+| ----------------- | ------------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------- |
+| `Accordion`       | `AccordionCore`, `Accordion`, `AccordionItem`                                         | full                           | —                                                                    |
+| `Dialog`          | `Dialog`, plus `Transition` / `ViewTransition` (its children)                         | full                           | `Action` triggers, `Transition`'s `group` option                     |
+| `ScrollAnimation` | `withScrolledInView`, `AbstractScrollAnimation`, `ScrollAnimationTimeline`, `…Target` | full (the non-deprecated pair) | the five `@deprecated` classes, `withScrollAnimationDebug`           |
+| `Slider`          | `Slider`, `SliderItem`, `SliderBtn`, `SliderCount`                                    | full                           | `SliderDrag`, `SliderDots`, `SliderProgress` (mechanical follow-ups) |
 
 Utilities copied into `migration/utils/`, minimum viable only: `math.ts` (`clamp`, `clamp01`, `map`, `lerp`, `damp`), `easings.ts` (`cubicBezier`, replacing the `@motionone/easing` dependency), `keyframes.ts` (the interpolator carved out of `animate`), `transition.ts`, `focus.ts` (`trapFocus`/`untrapFocus`/`saveActiveElement`), `uid.ts` (a `$id` replacement).
 
@@ -19,15 +19,15 @@ Utilities copied into `migration/utils/`, minimum viable only: `math.ts` (`clamp
 
 **Ported unchanged.** The whole `AccordionItem` interaction: `btn`/`content`/`container` refs, `onBtnClick`, the animated container height, the `open`/`close` events, every ARIA attribute. `AccordionCore`'s autoclose logic, verbatim apart from how it reaches the items.
 
-| Change | Forced by |
-| --- | --- |
+| Change                                                                  | Forced by                                                                                                                         |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `this.$children.AccordionItem[index]` → `this.items` (`$watchChildren`) | `$children` removed. The collection is live and DOM-ordered, so the index is derived (`items.indexOf(target)`) rather than given. |
-| `onAccordionItemOpen({ index })` → `onAccordionItemOpen({ target })` | delegated `on<Child><Event>` hands over the emitting instance. |
-| `config.emits: ['open','close']` → `$emits` in the props type | runtime `emits` removed. Zero bytes, and `$emit('open', item, index)` is argument-checked. |
-| `destroyed()` style reset → the `mounted()` returned cleanup | v4 idiom; setup and teardown in one closure. |
-| `Accordion extends AccordionCore` no longer spreads the parent config | config merges along the prototype chain (#627). |
-| **`$options.isOpen` as mutable state → a private `#isOpen` field** | **`$options` is a read-only view over attributes in v4.** |
-| **Parent → child option forwarding rewritten** | see below. |
+| `onAccordionItemOpen({ index })` → `onAccordionItemOpen({ target })`    | delegated `on<Child><Event>` hands over the emitting instance.                                                                    |
+| `config.emits: ['open','close']` → `$emits` in the props type           | runtime `emits` removed. Zero bytes, and `$emit('open', item, index)` is argument-checked.                                        |
+| `destroyed()` style reset → the `mounted()` returned cleanup            | v4 idiom; setup and teardown in one closure.                                                                                      |
+| `Accordion extends AccordionCore` no longer spreads the parent config   | config merges along the prototype chain (#627).                                                                                   |
+| **`$options.isOpen` as mutable state → a private `#isOpen` field**      | **`$options` is a read-only view over attributes in v4.**                                                                         |
+| **Parent → child option forwarding rewritten**                          | see below.                                                                                                                        |
 
 **The option-forwarding problem.** v3's `AccordionItem.mounted()` reaches its parent and writes into its own options:
 
@@ -48,11 +48,11 @@ Two v4 decisions break it independently: `$options` is built from getters with n
 
 **Ported unchanged.** `open()`, `close()`, `toggle()`, the modal/non-modal split, scroll locking, and the ordering guarantee that leave transitions finish _before_ the native hide — line-for-line v3.
 
-| Change | Forced by |
-| --- | --- |
-| `$children.Transition` / `.ViewTransition` → two `$watchChildren` collections | `$children` removed. A transition inserted after mount is now picked up (tested). |
-| `keyed({ event, isDown })` → a `keydown` listener in `mounted()` | **`KeyService` was deliberately dropped.** The replacement is smaller than the hook it replaces. |
-| `get dialog() { return this.$el }` → deleted | `$el: HTMLDialogElement` in the props type. |
+| Change                                                                        | Forced by                                                                                        |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `$children.Transition` / `.ViewTransition` → two `$watchChildren` collections | `$children` removed. A transition inserted after mount is now picked up (tested).                |
+| `keyed({ event, isDown })` → a `keydown` listener in `mounted()`              | **`KeyService` was deliberately dropped.** The replacement is smaller than the hook it replaces. |
+| `get dialog() { return this.$el }` → deleted                                  | `$el: HTMLDialogElement` in the props type.                                                      |
 
 **Missing in v4:** nothing blocking. `Transition` lost v3's `group` option, which collects sibling instances via `getInstances(Transition)` — **v4 has no per-class instance registry**. Recorded, not worked around.
 
@@ -81,25 +81,25 @@ _Recommendation:_ ship the interpolator, keep the player separate. They are two 
 
 **Does the scroll service cover its needs? Partly.** `useWindowScroll()`, `useRaf()` and `useResize()` supply the damping loop. What they do not supply is what `withScrolledInView` exists for: **an element's progress through the viewport**, with the `"start end / end start"` offset syntax. `ScrollProps.progressY` is the _page's_ progress, not an element's. _Recommendation:_ `useScrollProgress(el, { offset })` in core — it is the most reused decorator in ui (`ScrollAnimation`, `ScrollReveal`, `Track`, `LargeText`, `CircularMarquee`…).
 
-| Change | Forced by |
-| --- | --- |
-| `withMountWhenInView(BaseClass, options)` → `config.mountStrategy = 'in-view'` | mount strategies moved into the registry (#751). **Clean win.** |
-| four `$on(…)` channels with a hand-built `handleEvent` → two service subscriptions returned as cleanups | services are subscribe/unsubscribe closures. ~40 lines deleted. |
-| grouped `ScrollInViewProps` → flat (`startX`, `dampedProgressY`…) | v4's service prop convention. |
-| **`$services.enable('ticked')`/`disable` → a hand-held `useRaf().add()`** | **no v4 equivalent — gap 1.** |
-| final boundary render moved off `$read`/`$write` onto the global `scheduler` | **`$destroy()` cancels pending tasks right after the cleanups — gap 5.** |
+| Change                                                                                                  | Forced by                                                                |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `withMountWhenInView(BaseClass, options)` → `config.mountStrategy = 'in-view'`                          | mount strategies moved into the registry (#751). **Clean win.**          |
+| four `$on(…)` channels with a hand-built `handleEvent` → two service subscriptions returned as cleanups | services are subscribe/unsubscribe closures. ~40 lines deleted.          |
+| grouped `ScrollInViewProps` → flat (`startX`, `dampedProgressY`…)                                       | v4's service prop convention.                                            |
+| **`$services.enable('ticked')`/`disable` → a hand-held `useRaf().add()`**                               | **no v4 equivalent — gap 1.**                                            |
+| final boundary render moved off `$read`/`$write` onto the global `scheduler`                            | **`$destroy()` cancels pending tasks right after the cleanups — gap 5.** |
 
 **Size:** components 193 → 136 (−30 %); infrastructure 879 → 441 (−50 %). **Verdict: components mechanical, infrastructure a rewrite that halves it.**
 
 ## 4. Slider — the handshake that motivated the design
 
-| Change | Forced by |
-| --- | --- |
-| **`AbstractSliderChild` deleted entirely (143 lines)** | its whole job was finding the parent Slider and subscribing to its store, retrying in `mounted()`, `resized()` **and** `updated()` because none was reliable alone. `$inject(SliderContext)` plus the returned unsubscribe replaces all of it. |
-| `createStorage(...)` → `$provide(SliderContext, …)` | provide/inject in core. |
-| `connectChildren()` + `__connect()` → nothing | the context protocol replays to pending consumers when a late provider mounts. The test `connects a control that mounts before its slider` is the two-sided handshake, gone. |
-| `keyed(...)` + `hasFocus` + focus/blur handlers → `onWrapperKeydown` | `KeyService` dropped. A delegated ref handler only fires when focus is inside the wrapper. |
-| `goTo()` throwing `Index out of bound.` → clamping | with a live children collection the slide count changes by design. |
+| Change                                                               | Forced by                                                                                                                                                                                                                                      |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`AbstractSliderChild` deleted entirely (143 lines)**               | its whole job was finding the parent Slider and subscribing to its store, retrying in `mounted()`, `resized()` **and** `updated()` because none was reliable alone. `$inject(SliderContext)` plus the returned unsubscribe replaces all of it. |
+| `createStorage(...)` → `$provide(SliderContext, …)`                  | provide/inject in core.                                                                                                                                                                                                                        |
+| `connectChildren()` + `__connect()` → nothing                        | the context protocol replays to pending consumers when a late provider mounts. The test `connects a control that mounts before its slider` is the two-sided handshake, gone.                                                                   |
+| `keyed(...)` + `hasFocus` + focus/blur handlers → `onWrapperKeydown` | `KeyService` dropped. A delegated ref handler only fires when focus is inside the wrapper.                                                                                                                                                     |
+| `goTo()` throwing `Index out of bound.` → clamping                   | with a live children collection the slide count changes by design.                                                                                                                                                                             |
 
 **What v4 is missing here: provide/inject carries a value, not an owner surface.** DESIGN.md §5 promises "optionally exposes a curated owner surface (`expose` pattern)"; `context.ts` ships `Signal<T>` only. So `SliderBtn` gets its _state_ from the injected signal but its _commands_ from `$closest('Slider')` — two ways to reach one parent, and the `$closest` one reintroduces the coupling context was meant to remove. **This is the most concrete missing piece for the ui 2.0 rewrite of the thirteen coordinators**, because most need commands as well as state.
 
@@ -120,33 +120,33 @@ _Recommendation:_ ship the interpolator, keep the player separate. They are two 
 
 ## What came out better
 
-|  | v3 | v4 |
-| --- | --- | --- |
-| a control finds its coordinator | 143-line `AbstractSliderChild` + two-sided handshake + retries in three hooks | `await this.$inject(SliderContext)` |
-| a coordinator finds its children | `$children.X`, resolved once, needs `$update()` | `$watchChildren('X')`, live, order-independent |
-| a child added after mount | invisible until `$update()` | just works (tested in all four families) |
-| mount when in view | `withMountWhenInView` wrapping the constructor (109 lines) | `config.mountStrategy = 'in-view'`, overridable per element |
-| keyboard nav on a focused region | `KeyService` + `hasFocus` + focus/blur handlers | `onWrapperKeydown` |
-| declaring emitted events | `config.emits` — bytes, no checking | `$emits` — no bytes, arguments checked |
-| Escape on a `<dialog>` | closes behind the component's back; transitions skipped, scroll lock stuck | `onCancel()`, two lines |
-| a view transition | ui ships a 108-line batching scheduler | `this.$viewTransition(update)` from core |
-| extending a component | spread the parent's config by hand or lose it (#627) | configs merge along the prototype chain |
-| N scroll targets on one timeline | 2N+ scheduler round trips, plus a nested pair inside `animate` | one `read`, one `write`, for the whole timeline |
+|                                  | v3                                                                            | v4                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| a control finds its coordinator  | 143-line `AbstractSliderChild` + two-sided handshake + retries in three hooks | `await this.$inject(SliderContext)`                         |
+| a coordinator finds its children | `$children.X`, resolved once, needs `$update()`                               | `$watchChildren('X')`, live, order-independent              |
+| a child added after mount        | invisible until `$update()`                                                   | just works (tested in all four families)                    |
+| mount when in view               | `withMountWhenInView` wrapping the constructor (109 lines)                    | `config.mountStrategy = 'in-view'`, overridable per element |
+| keyboard nav on a focused region | `KeyService` + `hasFocus` + focus/blur handlers                               | `onWrapperKeydown`                                          |
+| declaring emitted events         | `config.emits` — bytes, no checking                                           | `$emits` — no bytes, arguments checked                      |
+| Escape on a `<dialog>`           | closes behind the component's back; transitions skipped, scroll lock stuck    | `onCancel()`, two lines                                     |
+| a view transition                | ui ships a 108-line batching scheduler                                        | `this.$viewTransition(update)` from core                    |
+| extending a component            | spread the parent's config by hand or lose it (#627)                          | configs merge along the prototype chain                     |
+| N scroll targets on one timeline | 2N+ scheduler round trips, plus a nested pair inside `animate`                | one `read`, one `write`, for the whole timeline             |
 
 ## Size of change
 
 Code lines, comments and blanks excluded. The v4 numbers _include_ the heavy explanatory comments this exercise required, so they understate the reduction.
 
-|  | v3 | v4 | delta |
-| --- | ---: | ---: | ---: |
-| Accordion (3 classes) | 216 | 194 | −10 % |
-| Dialog | 82 | 83 | ±0 |
-| Transition + ViewTransition (+ ui's VT scheduler) | 278 | 147 | −47 % |
-| ScrollAnimation (3 classes) | 193 | 136 | −30 % |
-| ScrollAnimation infrastructure | 879 | 441 | −50 % |
-| Slider (5 classes → 4) | 472 | 295 | −38 % |
-| utilities actually used | 206 | 174 | −16 % |
-| **total** | **2326** | **1470** | **−37 %** |
+|                                                   |       v3 |       v4 |     delta |
+| ------------------------------------------------- | -------: | -------: | --------: |
+| Accordion (3 classes)                             |      216 |      194 |     −10 % |
+| Dialog                                            |       82 |       83 |        ±0 |
+| Transition + ViewTransition (+ ui's VT scheduler) |      278 |      147 |     −47 % |
+| ScrollAnimation (3 classes)                       |      193 |      136 |     −30 % |
+| ScrollAnimation infrastructure                    |      879 |      441 |     −50 % |
+| Slider (5 classes → 4)                            |      472 |      295 |     −38 % |
+| utilities actually used                           |      206 |      174 |     −16 % |
+| **total**                                         | **2326** | **1470** | **−37 %** |
 
 ## Verdict
 

--- a/packages/v4/migration/REPORT.md
+++ b/packages/v4/migration/REPORT.md
@@ -1,0 +1,170 @@
+# Migrating @studiometa/ui to v4 — a feasibility test
+
+Date: 2026-08-11. Against `@studiometa/ui` 1.10.0 and the v4 prototype in `packages/v4/src`.
+
+Four component families were ported onto v4 to find out what a real migration costs. They were picked because each leans on a part of v3 that v4 changed: the `$children` coordinator pattern, service hooks, `config.emits`, mount decorators, and the per-instance store handshake. Everything here runs; `migration/**/*.spec.ts` adds 41 tests to the real-browser suite (Vitest browser mode, Chromium) and the pre-existing 104 still pass.
+
+## What was ported
+
+| Family | Files | Ported | Not ported |
+| --- | --- | --- | --- |
+| `Accordion` | `AccordionCore`, `Accordion`, `AccordionItem` | full | — |
+| `Dialog` | `Dialog`, plus `Transition` / `ViewTransition` (its children) | full | `Action` triggers, `Transition`'s `group` option |
+| `ScrollAnimation` | `withScrolledInView`, `AbstractScrollAnimation`, `ScrollAnimationTimeline`, `…Target` | full (the non-deprecated pair) | the five `@deprecated` classes, `withScrollAnimationDebug` |
+| `Slider` | `Slider`, `SliderItem`, `SliderBtn`, `SliderCount` | full | `SliderDrag`, `SliderDots`, `SliderProgress` (mechanical follow-ups) |
+
+Utilities copied into `migration/utils/`, minimum viable only: `math.ts` (`clamp`, `clamp01`, `map`, `lerp`, `damp`), `easings.ts` (`cubicBezier`, replacing the `@motionone/easing` dependency), `keyframes.ts` (the interpolator carved out of `animate`), `transition.ts`, `focus.ts` (`trapFocus`/`untrapFocus`/`saveActiveElement`), `uid.ts` (a `$id` replacement).
+
+## 1. Accordion — `$children` coordinator, option forwarding, ARIA
+
+**Ported unchanged.** The whole `AccordionItem` interaction: `btn`/`content`/`container` refs, `onBtnClick`, the animated container height, the `open`/`close` events, every ARIA attribute. `AccordionCore`'s autoclose logic, verbatim apart from how it reaches the items.
+
+| Change | Forced by |
+| --- | --- |
+| `this.$children.AccordionItem[index]` → `this.items` (`$watchChildren`) | `$children` removed. The collection is live and DOM-ordered, so the index is derived (`items.indexOf(target)`) rather than given. |
+| `onAccordionItemOpen({ index })` → `onAccordionItemOpen({ target })` | delegated `on<Child><Event>` hands over the emitting instance. |
+| `config.emits: ['open','close']` → `$emits` in the props type | runtime `emits` removed. Zero bytes, and `$emit('open', item, index)` is argument-checked. |
+| `destroyed()` style reset → the `mounted()` returned cleanup | v4 idiom; setup and teardown in one closure. |
+| `Accordion extends AccordionCore` no longer spreads the parent config | config merges along the prototype chain (#627). |
+| **`$options.isOpen` as mutable state → a private `#isOpen` field** | **`$options` is a read-only view over attributes in v4.** |
+| **Parent → child option forwarding rewritten** | see below. |
+
+**The option-forwarding problem.** v3's `AccordionItem.mounted()` reaches its parent and writes into its own options:
+
+```js
+const accordion = this.$closest('Accordion');
+Object.entries(accordion.$options.item).forEach(([key, value]) => {
+  this.$options[key] = deepmerge(this.$options[key], value); // both halves illegal in v4
+});
+```
+
+Two v4 decisions break it independently: `$options` is built from getters with no setters, and `$closest('Accordion')` only answers for a _mounted_ ancestor while v4 guarantees no mount ordering — an item can and does mount before its accordion. The port reads the ancestor's `data-option-item` attribute off the DOM instead. That fits v4's model better than v3's version, since DOM ancestry is a fact that exists before anything mounts and is live for free — the test `forwards the parent 'item' option to items that mount before it` covers exactly the ordering v3 could not survive. But **every component that forwards options will reinvent this**, and there is no framework support for it.
+
+**Better in v4.** The item is no longer constructed by the accordion, so an `AccordionItem` outside any `Accordion` is a fully working disclosure. Adding or removing an item updates the collection with no `$update()`.
+
+**Size:** 216 → 194 code lines (−10 %). **Verdict: mostly mechanical, one rewritten path** — about 30 of ~200 lines are genuinely new.
+
+## 2. Dialog — refs, lifecycle, focus trap, `$children`
+
+**Ported unchanged.** `open()`, `close()`, `toggle()`, the modal/non-modal split, scroll locking, and the ordering guarantee that leave transitions finish _before_ the native hide — line-for-line v3.
+
+| Change | Forced by |
+| --- | --- |
+| `$children.Transition` / `.ViewTransition` → two `$watchChildren` collections | `$children` removed. A transition inserted after mount is now picked up (tested). |
+| `keyed({ event, isDown })` → a `keydown` listener in `mounted()` | **`KeyService` was deliberately dropped.** The replacement is smaller than the hook it replaces. |
+| `get dialog() { return this.$el }` → deleted | `$el: HTMLDialogElement` in the props type. |
+
+**Missing in v4:** nothing blocking. `Transition` lost v3's `group` option, which collects sibling instances via `getInstances(Transition)` — **v4 has no per-class instance registry**. Recorded, not worked around.
+
+**Better in v4.** A v3 bug disappears: pressing Escape closes a native `<dialog>` behind the component's back, so v3's leave transitions never ran and the scroll lock stayed on. In v4 the bubbling `cancel` event makes this a two-line `onCancel()` handler, with a test. The transition children shrank because v4 core absorbed the `viewTransition()` batching scheduler ui ships as `ViewTransition/scheduler.ts` (108 lines, deleted).
+
+**Size:** `Dialog` 82 → 83 lines; transition children 278 → 147 (−47 %). **Verdict: mechanical.**
+
+## 3. ScrollAnimation — the `animate` data point
+
+`ScrollAnimation` is the only real consumer of `animate()` in ui, and it uses exactly one method:
+
+```js
+get animation() {
+  return animate(this.target, keyframes, { easing });
+}
+render(progress) {
+  this.animation.progress(progress);
+}
+```
+
+It never calls `start()`, `play()`, `pause()` or `finish()`. It has no duration. It is not an animation player — it is a keyframes → styles interpolator sampled by scroll position. What it drags in to get that: `utils/css/animate.ts` (473 lines: keyframe compilation, a `running` WeakMap of concurrent animations per element, staggering, per-target durations, and `domScheduler.read`/`write` calls **inside** the render path), `utils/tween.ts` (246 lines), and `@motionone/easing` for `cubicBezier` alone.
+
+**What a v4 port needs from `animate`:** a pure `compile(keyframes, { easing }) => (progress, size) => styles`, and nothing else. That is `migration/utils/keyframes.ts` — ~120 lines of logic — plus 30 lines of `cubicBezier` replacing the dependency. No tween, no loop, no per-element registry, no stagger, and critically **no DOM writes and no scheduling of its own**: it returns a style patch and the component hands the write to the scheduler. That is what makes the timeline cheap — in v3, N targets cost N × (`read` + `write`) with another nested pair inside `animate`; in v4 every target computes in the `read` phase and returns its write, and the timeline runs them all in one `write`.
+
+_Recommendation:_ ship the interpolator, keep the player separate. They are two utilities v3 fused.
+
+**Does the scroll service cover its needs? Partly.** `useWindowScroll()`, `useRaf()` and `useResize()` supply the damping loop. What they do not supply is what `withScrolledInView` exists for: **an element's progress through the viewport**, with the `"start end / end start"` offset syntax. `ScrollProps.progressY` is the _page's_ progress, not an element's. _Recommendation:_ `useScrollProgress(el, { offset })` in core — it is the most reused decorator in ui (`ScrollAnimation`, `ScrollReveal`, `Track`, `LargeText`, `CircularMarquee`…).
+
+| Change | Forced by |
+| --- | --- |
+| `withMountWhenInView(BaseClass, options)` → `config.mountStrategy = 'in-view'` | mount strategies moved into the registry (#751). **Clean win.** |
+| four `$on(…)` channels with a hand-built `handleEvent` → two service subscriptions returned as cleanups | services are subscribe/unsubscribe closures. ~40 lines deleted. |
+| grouped `ScrollInViewProps` → flat (`startX`, `dampedProgressY`…) | v4's service prop convention. |
+| **`$services.enable('ticked')`/`disable` → a hand-held `useRaf().add()`** | **no v4 equivalent — gap 1.** |
+| final boundary render moved off `$read`/`$write` onto the global `scheduler` | **`$destroy()` cancels pending tasks right after the cleanups — gap 5.** |
+
+**Size:** components 193 → 136 (−30 %); infrastructure 879 → 441 (−50 %). **Verdict: components mechanical, infrastructure a rewrite that halves it.**
+
+## 4. Slider — the handshake that motivated the design
+
+| Change | Forced by |
+| --- | --- |
+| **`AbstractSliderChild` deleted entirely (143 lines)** | its whole job was finding the parent Slider and subscribing to its store, retrying in `mounted()`, `resized()` **and** `updated()` because none was reliable alone. `$inject(SliderContext)` plus the returned unsubscribe replaces all of it. |
+| `createStorage(...)` → `$provide(SliderContext, …)` | provide/inject in core. |
+| `connectChildren()` + `__connect()` → nothing | the context protocol replays to pending consumers when a late provider mounts. The test `connects a control that mounts before its slider` is the two-sided handshake, gone. |
+| `keyed(...)` + `hasFocus` + focus/blur handlers → `onWrapperKeydown` | `KeyService` dropped. A delegated ref handler only fires when focus is inside the wrapper. |
+| `goTo()` throwing `Index out of bound.` → clamping | with a live children collection the slide count changes by design. |
+
+**What v4 is missing here: provide/inject carries a value, not an owner surface.** DESIGN.md §5 promises "optionally exposes a curated owner surface (`expose` pattern)"; `context.ts` ships `Signal<T>` only. So `SliderBtn` gets its _state_ from the injected signal but its _commands_ from `$closest('Slider')` — two ways to reach one parent, and the `$closest` one reintroduces the coupling context was meant to remove. **This is the most concrete missing piece for the ui 2.0 rewrite of the thirteen coordinators**, because most need commands as well as state.
+
+**Size:** 472 → 295 (−38 %), one whole class deleted. **Verdict: coordination is a rewrite, geometry is a copy.**
+
+## Gaps in v4, ordered by cost
+
+1. **No way to suspend a service subscription within a mount cycle.** v3: `$services.enable('ticked')`/`disable`. v4: subscribe in `mounted()`, unsubscribe in `$destroy()`, nothing between. Two of four components needed it and both dropped `withRaf` for a hand-rolled start/stop. Not cosmetic: with `withRaf`, one slider or scroll animation keeps the rAF loop alive forever, contradicting DESIGN.md §7. **Ask:** pause/resume on the subscription handle, or `withRaf(Base, { manual: true })`.
+2. **`$options` is read-only, and several ui components write to it.** Any v3 component treating an option as mutable state breaks. **Ask:** setters that write the attribute back, or a migration note plus a lint rule. `grep -rn '\$options\.[a-zA-Z]* *=' packages/ui/src` is the checklist.
+3. **`$inject()` has no synchronous, optional or cancellable form.** It always returns a Promise even when a provider exists; it _never settles_ without one, so a standalone `SliderBtn` hangs forever; and `$destroy()` does not cancel a pending request. **Ask:** `$inject(key, { optional: true })`, `$injectSync(key)`, cancellation on destroy.
+4. **provide/inject has no `expose`.** Promised in DESIGN.md, absent from `context.ts`. Without it every control keeps a `$closest()` back-channel.
+5. **`$destroy()` cancels pending scheduler tasks _after_ the cleanups.** A cleanup that schedules `this.$write(…)` — the natural "reset my styles on the way out" — has its task cancelled immediately. **Ask:** cancel before running cleanups, or give `$destroy()` a surviving lane.
+6. **No `$id`.** Any ARIA wiring needs one; two of four families copied a `uid()`.
+7. **No per-class instance registry.** `Transition`'s `group` option is unportable.
+8. **`Object`/`Array` option defaults are shared between instances.** `buildOptions()` returns the `default` directly, so `default: {}` hands _the same object_ to every instance. v3 required a factory for exactly this reason. A latent, hard-to-debug bug.
+9. **Option definitions lost `merge: true`.** Merging is now the component's job.
+10. **No `utils`, no `$log`/`$warn`.** Known — but the shape of the need is the finding: ~530 lines of copies for four components, and the biggest v3 utility (`animate`, 719 lines) was **not** what was needed.
+
+## What came out better
+
+|  | v3 | v4 |
+| --- | --- | --- |
+| a control finds its coordinator | 143-line `AbstractSliderChild` + two-sided handshake + retries in three hooks | `await this.$inject(SliderContext)` |
+| a coordinator finds its children | `$children.X`, resolved once, needs `$update()` | `$watchChildren('X')`, live, order-independent |
+| a child added after mount | invisible until `$update()` | just works (tested in all four families) |
+| mount when in view | `withMountWhenInView` wrapping the constructor (109 lines) | `config.mountStrategy = 'in-view'`, overridable per element |
+| keyboard nav on a focused region | `KeyService` + `hasFocus` + focus/blur handlers | `onWrapperKeydown` |
+| declaring emitted events | `config.emits` — bytes, no checking | `$emits` — no bytes, arguments checked |
+| Escape on a `<dialog>` | closes behind the component's back; transitions skipped, scroll lock stuck | `onCancel()`, two lines |
+| a view transition | ui ships a 108-line batching scheduler | `this.$viewTransition(update)` from core |
+| extending a component | spread the parent's config by hand or lose it (#627) | configs merge along the prototype chain |
+| N scroll targets on one timeline | 2N+ scheduler round trips, plus a nested pair inside `animate` | one `read`, one `write`, for the whole timeline |
+
+## Size of change
+
+Code lines, comments and blanks excluded. The v4 numbers _include_ the heavy explanatory comments this exercise required, so they understate the reduction.
+
+|  | v3 | v4 | delta |
+| --- | ---: | ---: | ---: |
+| Accordion (3 classes) | 216 | 194 | −10 % |
+| Dialog | 82 | 83 | ±0 |
+| Transition + ViewTransition (+ ui's VT scheduler) | 278 | 147 | −47 % |
+| ScrollAnimation (3 classes) | 193 | 136 | −30 % |
+| ScrollAnimation infrastructure | 879 | 441 | −50 % |
+| Slider (5 classes → 4) | 472 | 295 | −38 % |
+| utilities actually used | 206 | 174 | −16 % |
+| **total** | **2326** | **1470** | **−37 %** |
+
+## Verdict
+
+**Migrating @studiometa/ui to v4 is mostly mechanical for component _behaviour_, and a rewrite for component _wiring_.** The split is clean and identical across all four families.
+
+- **Mechanical (~70 % of the code):** everything a component does to its own DOM — `AccordionItem`'s height animation and ARIA, `Dialog`'s open/close ordering, `Slider`'s geometry, `AbstractScrollAnimation`'s play-range maths. A codemod plus a careful eye handles this.
+- **A rewrite (~30 %):** everything about how a component reaches another component. Not renaming: the topology changed from parent-owned to DOM-observed, and code that assumed ordering has to be re-thought rather than translated.
+
+The rewrite is worth doing. It deletes 37 % of the code, removes an entire base class, a scheduler and a constructor-wrapping decorator; fixes a real Escape-key bug in `Dialog` for free; and makes "a child appeared after mount" a non-event everywhere. **Nothing in this sample turned out to be unportable.**
+
+### Build these in v4 before starting the real migration
+
+1. **A way to suspend a service subscription within a mount cycle** (gap 1). Without it v4's "no permanent rAF loop" promise is false on any page with a slider or scroll animation.
+2. **`useScrollProgress(el, { offset })` in core.** Every ui family that animates on scroll needs element-through-viewport progress; each would otherwise copy ~360 lines of edge maths.
+3. **The keyframes interpolator, split from the player.** Not `animate()` — the 719 lines of player behind it are what ui's only consumer never uses.
+4. **`$inject` with an optional/synchronous form, and `expose` on provide/inject** (gaps 3–4). Together these make provide/inject _the_ coordinator primitive; today it covers state but not commands.
+5. **Writable `$options` or a documented replacement, plus factory defaults for `Object`/`Array`** (gaps 2, 8). The second is a latent cross-instance bug, not just a migration cost.
+6. **`$id`** (gap 6). Ten lines, and every accessible component wants it.
+7. **A `utils` port** informed by the above: `clamp`/`clamp01`/`map`/`lerp`/`damp`, `transition`, `trapFocus`, `cubicBezier`. About 200 lines covered four families.
+
+Items 1–4 change what a component _can_ be written to do. Items 5–7 are cost, not capability.

--- a/packages/v4/migration/ScrollAnimation/AbstractScrollAnimation.ts
+++ b/packages/v4/migration/ScrollAnimation/AbstractScrollAnimation.ts
@@ -1,0 +1,134 @@
+import { Base, scheduler, type BaseConfig } from '../../src/index.js';
+import { applyStyles, compile, type Keyframe, type KeyframeStyles } from '../utils/keyframes.js';
+import { clamp01, map } from '../utils/math.js';
+import type { ScrollInViewProps, ScrolledInViewRender } from './withScrolledInView.js';
+
+export interface AbstractScrollAnimationProps {
+  $options: {
+    playRange: [number, number] | [number, number, number];
+    from: Keyframe;
+    to: Keyframe;
+    keyframes: Keyframe[];
+    easing: [number, number, number, number];
+  };
+}
+
+/**
+ * AbstractScrollAnimation — shared base for the scroll-linked animations.
+ *
+ * Port of @studiometa/ui 1.10's `AbstractScrollAnimation`. Same options, same
+ * `playRange` arithmetic, same mapping of the damped progress onto the
+ * animation.
+ *
+ * The one structural change is what drives the styles. v3 builds a full
+ * `animate()` player — a tween, a rAF loop, a per-element registry of running
+ * animations, `start` / `pause` / `play` / `finish` — and then never plays it:
+ * it only ever calls `animation.progress(p)`. v4 compiles the same keyframes
+ * into a pure `(progress, size) => styles` function, and `scrolledInView()`
+ * hands the resulting write back to the scheduler.
+ *
+ * `withFreezedOptions` is not ported: it existed because v3 re-read and
+ * re-parsed `data-option-*` attributes on every access, which was expensive
+ * inside a per-frame handler. v4 keeps the same live-getter semantics, so the
+ * decorator would still buy something for `Object`/`Array` options — noted in
+ * the report rather than worked around.
+ */
+export class AbstractScrollAnimation extends Base<AbstractScrollAnimationProps> {
+  static config: BaseConfig = {
+    name: 'AbstractScrollAnimation',
+    options: {
+      playRange: { type: Array, default: [0, 1] },
+      from: { type: Object, default: {} },
+      to: { type: Object, default: {} },
+      keyframes: { type: Array, default: [] },
+      easing: { type: Array, default: [0, 0, 1, 1] },
+    },
+  };
+
+  /** Current animation progress, 0 to 1. */
+  progress = 0;
+
+  #interpolate:
+    | ((progress: number, size: { width: number; height: number }) => KeyframeStyles)
+    | null = null;
+
+  /** The element the styles are written to. */
+  get target(): HTMLElement {
+    return this.$el;
+  }
+
+  get interpolate(): (progress: number, size: { width: number; height: number }) => KeyframeStyles {
+    if (!this.#interpolate) {
+      const { from, to } = this.$options;
+      let { keyframes } = this.$options;
+      if (!keyframes || keyframes.length <= 0) {
+        keyframes = [from, to];
+      }
+      this.#interpolate = compile(keyframes, { easing: this.$options.easing });
+    }
+    return this.#interpolate;
+  }
+
+  /**
+   * Start and end of the play range.
+   *
+   * The three-value form `[index, length, step]` splits the range into
+   * `length` staggered slices — unchanged from v3.
+   */
+  get playRange(): [number, number] {
+    const { playRange } = this.$options;
+
+    if (playRange.length === 3) {
+      const [index, length, step] = playRange;
+      const clampedStep = clamp01(step);
+      const start = clampedStep * index;
+      const duration = Math.max(0, 1 - clampedStep * (length - 1));
+      return [start, Math.min(1, start + duration)];
+    }
+
+    const [start = 0, end = 1] = playRange;
+    return [start, end];
+  }
+
+  mounted(): void {
+    // Restore the animation state for the current progress.
+    this.renderNow(this.progress);
+  }
+
+  destroyed(): void {
+    // Complete the animation to its nearest boundary.
+    this.renderNow(Math.round(this.progress));
+  }
+
+  /**
+   * Render outside a `scrolledInView()` pass. Measuring stays in `read` and
+   * writing in `write`, and neither is instance-owned: `$destroy()` cancels
+   * the instance's pending tasks straight after the cleanups, which would
+   * drop the boundary render this schedules.
+   */
+  renderNow(progress: number): void {
+    scheduler.read(() => scheduler.write(this.render(progress)));
+  }
+
+  scrolledInView({ dampedProgressY }: ScrollInViewProps): ScrolledInViewRender {
+    const [start, end] = this.playRange;
+    return this.render(clamp01(map(dampedProgressY, start, end, 0, 1)));
+  }
+
+  /**
+   * Compute the styles for a progress value and hand back the write.
+   *
+   * Splitting compute from write is what lets a whole timeline measure once
+   * and mutate once: v3's `animate` nested a `domScheduler.read` inside a
+   * `domScheduler.write` per element instead.
+   */
+  render(progress: number): ScrolledInViewRender {
+    this.progress = progress;
+    const { target } = this;
+    const styles = this.interpolate(progress, {
+      width: target.offsetWidth,
+      height: target.offsetHeight,
+    });
+    return () => applyStyles(target, styles);
+  }
+}

--- a/packages/v4/migration/ScrollAnimation/ScrollAnimation.spec.ts
+++ b/packages/v4/migration/ScrollAnimation/ScrollAnimation.spec.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerComponent } from '../../src/index.js';
+import { frames, getInstance, resetDom, settle } from '../../src/test-utils.js';
+import { ScrollAnimationTarget } from './ScrollAnimationTarget.js';
+import { ScrollAnimationTimeline } from './ScrollAnimationTimeline.js';
+
+registerComponent(ScrollAnimationTimeline);
+
+const SPACER = 2000;
+const HEIGHT = 200;
+
+afterEach(async () => {
+  window.scrollTo(0, 0);
+  document.body.style.height = '';
+  document.body.style.margin = '';
+  await resetDom();
+});
+
+/**
+ * A timeline 2000 px down a 6000 px page. With the default
+ * `start end / end start` offset the animation runs from
+ * `2000 - innerHeight` to `2200`.
+ */
+function render({
+  mount = 'eager',
+  targets = 1,
+}: { mount?: string; targets?: number } = {}): HTMLElement {
+  document.body.style.margin = '0';
+  document.body.style.height = '6000px';
+
+  const el = document.createElement('div');
+  el.setAttribute('data-component', 'ScrollAnimationTimeline');
+  el.setAttribute('data-mount', mount);
+  // Undamped, so a scroll settles in one frame and the assertions are exact.
+  el.setAttribute('data-option-damp-factor', '1');
+  el.style.cssText = `position:absolute;top:${SPACER}px;left:0;width:100px;height:${HEIGHT}px`;
+  el.innerHTML = Array.from(
+    { length: targets },
+    () => `
+      <div
+        data-component="ScrollAnimationTarget"
+        data-option-damp-factor="1"
+        data-option-from='{"opacity":0,"x":0}'
+        data-option-to='{"opacity":1,"x":100}'
+      ></div>`,
+  ).join('');
+  document.body.append(el);
+  return el;
+}
+
+function bounds() {
+  return { start: SPACER - window.innerHeight, end: SPACER + HEIGHT };
+}
+
+async function scrollTo(y: number): Promise<void> {
+  window.scrollTo(0, y);
+  await frames(10);
+}
+
+function targetsOf(el: HTMLElement): HTMLElement[] {
+  return [...el.querySelectorAll<HTMLElement>('[data-component="ScrollAnimationTarget"]')];
+}
+
+describe('ScrollAnimationTimeline', () => {
+  it('defaults to the reversible in-view mount strategy', () => {
+    const el = document.createElement('div');
+    expect(new ScrollAnimationTimeline(el).$config.mountStrategy).toBe('in-view');
+  });
+
+  it('tracks its targets as a live collection', async () => {
+    const el = render({ targets: 2 });
+    await settle();
+
+    const timeline = getInstance<ScrollAnimationTimeline>(el, 'ScrollAnimationTimeline');
+    expect(timeline.targets.size).toBe(2);
+
+    const added = document.createElement('div');
+    added.setAttribute('data-component', 'ScrollAnimationTarget');
+    added.setAttribute('data-option-to', '{"opacity":1}');
+    el.append(added);
+    await settle();
+    expect(timeline.targets.size).toBe(3);
+
+    added.remove();
+    await settle();
+    expect(timeline.targets.size).toBe(2);
+  });
+
+  it('drives its targets from the scroll position', async () => {
+    const el = render();
+    await settle();
+    const [target] = targetsOf(el);
+    const { start, end } = bounds();
+
+    await scrollTo(start);
+    expect(Number(target.style.opacity)).toBeCloseTo(0, 2);
+
+    await scrollTo(start + (end - start) / 2);
+    expect(Number(target.style.opacity)).toBeCloseTo(0.5, 1);
+    expect(target.style.transform).toContain('translate3d(5');
+
+    await scrollTo(end);
+    expect(Number(target.style.opacity)).toBeCloseTo(1, 2);
+    expect(target.style.transform).toBe('translate3d(100px, 0px, 0px)');
+  });
+
+  it('renders every target of the timeline in one pass', async () => {
+    const el = render({ targets: 3 });
+    await settle();
+    const { end } = bounds();
+
+    await scrollTo(end);
+    for (const target of targetsOf(el)) {
+      expect(Number(target.style.opacity)).toBeCloseTo(1, 2);
+    }
+  });
+
+  it('honours the play range of each target', async () => {
+    const el = render({ targets: 2 });
+    const [first, second] = targetsOf(el);
+    // The first plays over the first half, the second over the second half.
+    first.setAttribute('data-option-play-range', '[0, 0.5]');
+    second.setAttribute('data-option-play-range', '[0.5, 1]');
+    await settle();
+
+    const { start, end } = bounds();
+    await scrollTo(start + (end - start) / 2);
+
+    expect(Number(first.style.opacity)).toBeCloseTo(1, 1);
+    expect(Number(second.style.opacity)).toBeCloseTo(0, 1);
+  });
+
+  it('picks up a target inserted after the timeline mounted', async () => {
+    const el = render({ targets: 0 });
+    await settle();
+
+    const added = document.createElement('div');
+    added.setAttribute('data-component', 'ScrollAnimationTarget');
+    added.setAttribute('data-option-damp-factor', '1');
+    added.setAttribute('data-option-from', '{"opacity":0}');
+    added.setAttribute('data-option-to', '{"opacity":1}');
+    el.append(added);
+    await settle();
+
+    await scrollTo(bounds().end);
+    expect(Number(added.style.opacity)).toBeCloseTo(1, 2);
+  });
+
+  it('snaps a target to its nearest boundary when it is destroyed', async () => {
+    const el = render();
+    await settle();
+    const [target] = targetsOf(el);
+    const { start, end } = bounds();
+
+    await scrollTo(start + (end - start) * 0.8);
+    expect(Number(target.style.opacity)).toBeGreaterThan(0.5);
+
+    getInstance<ScrollAnimationTarget>(target, 'ScrollAnimationTarget').$destroy();
+    await frames(4);
+    expect(target.style.opacity).toBe('1');
+  });
+
+  it('stops the frame subscription once the damped value settled', async () => {
+    const el = render();
+    await settle();
+    const timeline = getInstance<ScrollAnimationTimeline>(el, 'ScrollAnimationTimeline');
+
+    await scrollTo(bounds().end);
+    // No frame subscription is left running: the whole point of v3's
+    // `$services.disable('ticked')`.
+    expect((timeline as unknown as { __unsubscribeFrame: unknown }).__unsubscribeFrame).toBeNull();
+  });
+});

--- a/packages/v4/migration/ScrollAnimation/ScrollAnimationTarget.ts
+++ b/packages/v4/migration/ScrollAnimation/ScrollAnimationTarget.ts
@@ -1,0 +1,50 @@
+import type { BaseConfig } from '../../src/index.js';
+import { clamp01, damp } from '../utils/math.js';
+import { AbstractScrollAnimation } from './AbstractScrollAnimation.js';
+import type { ScrollInViewProps, ScrolledInViewRender } from './withScrolledInView.js';
+
+/**
+ * ScrollAnimationTarget — one animated element inside a
+ * `ScrollAnimationTimeline`.
+ *
+ * Port of @studiometa/ui 1.10's `ScrollAnimationTarget`: it damps the
+ * timeline's raw progress again with its own factor, so several targets on
+ * one range each get their own inertia.
+ *
+ * v3 wrapped the damping in `domScheduler.read()` and the parent call in
+ * `domScheduler.write()`, which is wrong twice over — the maths touches no
+ * DOM at all, and running `super.scrolledInView()` in a write phase is what
+ * made `animate` schedule a nested read. Here the whole thing is the read
+ * pass and the returned function is the write pass.
+ */
+export class ScrollAnimationTarget extends AbstractScrollAnimation {
+  static config: BaseConfig = {
+    name: 'ScrollAnimationTarget',
+    options: {
+      dampFactor: { type: Number, default: 0.1 },
+      dampPrecision: { type: Number, default: 0.001 },
+    },
+  };
+
+  dampedCurrentX = 0;
+
+  dampedCurrentY = 0;
+
+  scrolledInView(props: ScrollInViewProps): ScrolledInViewRender {
+    const { dampFactor, dampPrecision } = this.$options as unknown as {
+      dampFactor: number;
+      dampPrecision: number;
+    };
+
+    this.dampedCurrentX = damp(props.currentX, this.dampedCurrentX, dampFactor, dampPrecision);
+    this.dampedCurrentY = damp(props.currentY, this.dampedCurrentY, dampFactor, dampPrecision);
+
+    return super.scrolledInView({
+      ...props,
+      dampedCurrentX: this.dampedCurrentX,
+      dampedCurrentY: this.dampedCurrentY,
+      dampedProgressX: clamp01((this.dampedCurrentX - props.startX) / (props.endX - props.startX)),
+      dampedProgressY: clamp01((this.dampedCurrentY - props.startY) / (props.endY - props.startY)),
+    });
+  }
+}

--- a/packages/v4/migration/ScrollAnimation/ScrollAnimationTimeline.ts
+++ b/packages/v4/migration/ScrollAnimation/ScrollAnimationTimeline.ts
@@ -1,0 +1,47 @@
+import { Base, type BaseConfig, type ChildrenCollection } from '../../src/index.js';
+import { ScrollAnimationTarget } from './ScrollAnimationTarget.js';
+import {
+  withScrolledInView,
+  type ScrollInViewProps,
+  type ScrolledInViewRender,
+} from './withScrolledInView.js';
+
+/**
+ * ScrollAnimationTimeline — the scroll driver for a group of targets.
+ *
+ * Port of @studiometa/ui 1.10's `ScrollAnimationTimeline`. It is one of the
+ * thirteen `$children` coordinators, and the change is the usual one:
+ * `$children.ScrollAnimationTarget` becomes a `$watchChildren` collection, so
+ * a target inserted after the timeline mounted is driven with no `$update()`.
+ *
+ * Forwarding also got cheaper. In v3 each child re-entered the scheduler on
+ * its own (`domScheduler.read` + `domScheduler.write` per target, plus one
+ * more pair inside `animate`). Here the timeline is already in the read
+ * phase, every target computes its styles there, and the returned functions
+ * are run together in one write — a timeline of N targets costs one
+ * layout pass instead of N.
+ */
+export class ScrollAnimationTimeline extends withScrolledInView(Base) {
+  static config: BaseConfig = {
+    name: 'ScrollAnimationTimeline',
+    components: { ScrollAnimationTarget },
+  };
+
+  targets: ChildrenCollection<ScrollAnimationTarget> =
+    this.$watchChildren<ScrollAnimationTarget>('ScrollAnimationTarget');
+
+  scrolledInView(props: ScrollInViewProps): ScrolledInViewRender {
+    const renders: ScrolledInViewRender[] = [];
+    for (const target of this.targets) {
+      const render = target.scrolledInView(props);
+      if (typeof render === 'function') {
+        renders.push(render);
+      }
+    }
+    return () => {
+      for (const render of renders) {
+        render();
+      }
+    };
+  }
+}

--- a/packages/v4/migration/ScrollAnimation/index.ts
+++ b/packages/v4/migration/ScrollAnimation/index.ts
@@ -1,0 +1,14 @@
+export {
+  AbstractScrollAnimation,
+  type AbstractScrollAnimationProps,
+} from './AbstractScrollAnimation.js';
+export { getEdges, normalizeOffset, type NormalizedOffset } from './offset.js';
+export { ScrollAnimationTarget } from './ScrollAnimationTarget.js';
+export { ScrollAnimationTimeline } from './ScrollAnimationTimeline.js';
+export {
+  withScrolledInView,
+  type ScrolledInViewHook,
+  type ScrolledInViewRender,
+  type ScrollInViewProps,
+  type WithScrolledInViewOptions,
+} from './withScrolledInView.js';

--- a/packages/v4/migration/ScrollAnimation/offset.ts
+++ b/packages/v4/migration/ScrollAnimation/offset.ts
@@ -1,0 +1,83 @@
+/**
+ * Offset parsing for `withScrolledInView`, ported from
+ * `@studiometa/js-toolkit/decorators/withScrolledInView/utils`.
+ *
+ * The syntax is unchanged: `"<target> <container> / <target> <container>"`,
+ * where each edge is `start` / `center` / `end`, a ratio, a percentage, or a
+ * length in `px` / `vh` / `vw` / `vmin` / `vmax`.
+ */
+
+export type OffsetValue = string | number;
+export type NormalizedOffset = [[OffsetValue, OffsetValue], [OffsetValue, OffsetValue]];
+
+const NAMED: Record<string, number> = { start: 0, center: 0.5, end: 1 };
+
+const VIEWPORT_UNITS: Record<string, () => number> = {
+  vh: () => window.innerHeight,
+  vw: () => window.innerWidth,
+  vmin: () => Math.min(window.innerWidth, window.innerHeight),
+  vmax: () => Math.max(window.innerWidth, window.innerHeight),
+};
+
+export function normalizeOffset(offsets: string): NormalizedOffset {
+  return offsets
+    .split('/')
+    .map((offset) => offset.trim().split(' ').slice(0, 2)) as NormalizedOffset;
+}
+
+/**
+ * An edge position given a start, a size and one offset token.
+ */
+export function getEdgeWithOffset(start: number, size: number, offset: OffsetValue): number {
+  if (typeof offset === 'number') {
+    return start + size * offset;
+  }
+
+  if (offset in NAMED) {
+    return start + size * NAMED[offset];
+  }
+
+  if (offset.endsWith('%')) {
+    return start + (size * Number.parseFloat(offset)) / 100;
+  }
+
+  const value = Number.parseFloat(offset);
+  if (Number.isNaN(value)) {
+    return start;
+  }
+
+  if (offset.endsWith('px')) {
+    return start + value;
+  }
+
+  for (const [unit, size100] of Object.entries(VIEWPORT_UNITS)) {
+    if (offset.endsWith(unit)) {
+      return start + (value * size100()) / 100;
+    }
+  }
+
+  // A bare number, e.g. "0.5".
+  return start + size * value;
+}
+
+export interface AxisRect {
+  position: number;
+  size: number;
+}
+
+/**
+ * The scroll positions at which the animation starts and ends on one axis.
+ */
+export function getEdges(
+  target: AxisRect,
+  container: AxisRect,
+  offset: NormalizedOffset,
+): [number, number] {
+  const start =
+    getEdgeWithOffset(target.position, target.size, offset[0][0]) -
+    getEdgeWithOffset(0, container.size, offset[0][1]);
+  const end =
+    getEdgeWithOffset(target.position, target.size, offset[1][0]) -
+    getEdgeWithOffset(0, container.size, offset[1][1]);
+  return [start, end];
+}

--- a/packages/v4/migration/ScrollAnimation/withScrolledInView.ts
+++ b/packages/v4/migration/ScrollAnimation/withScrolledInView.ts
@@ -1,0 +1,279 @@
+import {
+  scheduler,
+  useRaf,
+  useResize,
+  useWindowScroll,
+  type Base,
+  type BaseConstructor,
+  type MixedClass,
+  type MountedReturn,
+} from '../../src/index.js';
+import { clamp, clamp01, damp } from '../utils/math.js';
+import { getEdges, normalizeOffset } from './offset.js';
+
+/**
+ * What a `scrolledInView()` hook receives.
+ *
+ * v3 groups these as `{ start: {x, y}, end: {x, y}, current: {x, y}, … }`.
+ * v4's service props are flat, one key per axis (`ScrollProps` is `x`, `y`,
+ * `deltaX`, `deltaY`, …), so this follows the same convention — a handler
+ * destructures `{ dampedProgressY }` instead of reaching through two levels.
+ */
+export interface ScrollInViewProps {
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  currentX: number;
+  currentY: number;
+  dampedCurrentX: number;
+  dampedCurrentY: number;
+  progressX: number;
+  progressY: number;
+  dampedProgressX: number;
+  dampedProgressY: number;
+}
+
+/**
+ * A hook may return a function, which runs in the same frame's `write`
+ * phase — the read/write split the toolkit has always had, made explicit by
+ * the return value instead of by nested `domScheduler` calls.
+ */
+export type ScrolledInViewRender = () => void;
+
+export interface ScrolledInViewHook {
+  scrolledInView?(props: ScrollInViewProps): void | ScrolledInViewRender;
+}
+
+export interface WithScrolledInViewOptions {
+  /** Resolve the element whose position drives the progress. */
+  target?: (instance: Base) => HTMLElement;
+}
+
+function progressBetween(current: number, start: number, end: number): number {
+  return start === end ? 0 : clamp01((current - start) / (end - start));
+}
+
+/**
+ * Add scroll-linked progress to a component.
+ *
+ * Port of `@studiometa/js-toolkit/decorators/withScrolledInView`. The v3
+ * decorator is a `withMountWhenInView` subclass that listens to four `$on`
+ * channels (`mounted`, `resized`, `scrolled`, `ticked`) through a hand-built
+ * `handleEvent` delegate, and toggles the `ticked` service on and off with
+ * `$services.enable` / `$services.disable` so the frame loop only runs while
+ * the damped value is catching up.
+ *
+ * In v4:
+ *
+ * - `withMountWhenInView` is gone; the component declares
+ *   `config.mountStrategy = 'in-view'` instead, and any element overrides it
+ *   with `data-mount`.
+ * - the four `$on` channels become two service subscriptions returned as
+ *   `mounted()` cleanups, so nothing has to be unbound by hand.
+ * - `$services.enable('ticked')` / `disable('ticked')` has **no v4
+ *   equivalent**: a mixin subscribes for the whole mount cycle. The frame
+ *   subscription is therefore taken and released by hand here, which is the
+ *   thing this port could not do with `withRaf`.
+ */
+export function withScrolledInView<T extends BaseConstructor>(
+  BaseClass: T,
+  options: WithScrolledInViewOptions = {},
+): MixedClass<T, ScrolledInViewHook> {
+  return apply(BaseClass, options) as unknown as MixedClass<T, ScrolledInViewHook>;
+}
+
+/**
+ * The class is built against the concrete `BaseConstructor` rather than
+ * against the type parameter: TypeScript only allows extending a type
+ * parameter when its constructor takes `...args: any[]`, which `Base` does
+ * not. This is the shape `createServiceMixin` uses in core for the same
+ * reason.
+ */
+function apply(
+  BaseClass: BaseConstructor,
+  { target = (instance: Base) => instance.$el }: WithScrolledInViewOptions,
+) {
+  return class WithScrolledInView extends BaseClass {
+    static config = {
+      name: 'WithScrolledInView',
+      // The reversible strategy: a scroll animation is exactly the case the
+      // v4 design names for `in-view` over `visible`.
+      mountStrategy: 'in-view' as const,
+      options: {
+        dampFactor: { type: Number, default: 0.1 },
+        dampPrecision: { type: Number, default: 0.001 },
+        offset: { type: String, default: 'start end / end start' },
+      },
+    };
+
+    __scrollInViewProps: ScrollInViewProps = {
+      startX: 0,
+      startY: 0,
+      endX: 0,
+      endY: 0,
+      currentX: 0,
+      currentY: 0,
+      dampedCurrentX: 0,
+      dampedCurrentY: 0,
+      progressX: 0,
+      progressY: 0,
+      dampedProgressX: 0,
+      dampedProgressY: 0,
+    };
+
+    /** Live while the damped value is still catching up, `null` otherwise. */
+    __unsubscribeFrame: (() => void) | null = null;
+
+    __shouldMeasure = true;
+
+    get scrollInViewTarget(): HTMLElement {
+      return target(this as unknown as Base);
+    }
+
+    /**
+     * Measure the element against the viewport and seed every prop. The
+     * damped values start settled, so a component mounting mid-page renders
+     * its real state instead of animating from zero.
+     */
+    measure(): void {
+      this.__shouldMeasure = false;
+      const el = this.scrollInViewTarget;
+      const rect = el.getBoundingClientRect();
+      const offset = normalizeOffset(
+        (this.$options as { offset?: string }).offset ?? 'start end / end start',
+      );
+      const props = this.__scrollInViewProps;
+
+      const [startY, endY] = getEdges(
+        { position: rect.y + window.scrollY, size: rect.height },
+        { position: 0, size: window.innerHeight },
+        offset,
+      );
+      const [startX, endX] = getEdges(
+        { position: rect.x + window.scrollX, size: rect.width },
+        { position: 0, size: window.innerWidth },
+        offset,
+      );
+
+      props.startX = startX;
+      props.endX = endX;
+      props.startY = startY;
+      props.endY = endY;
+      props.currentX = clamp(window.scrollX, startX, endX);
+      props.currentY = clamp(window.scrollY, startY, endY);
+      props.dampedCurrentX = props.currentX;
+      props.dampedCurrentY = props.currentY;
+      props.progressX = progressBetween(props.currentX, startX, endX);
+      props.progressY = progressBetween(props.currentY, startY, endY);
+      props.dampedProgressX = props.progressX;
+      props.dampedProgressY = props.progressY;
+    }
+
+    /**
+     * One read pass calling the hook, one write pass running whatever it
+     * returned. Scheduled on the instance, so a destroyed component never
+     * writes to a detached element.
+     */
+    renderScrollInView(): void {
+      this.$read(() => {
+        if (this.__shouldMeasure) {
+          this.measure();
+        }
+        const hook = (this as unknown as ScrolledInViewHook).scrolledInView;
+        const render = hook?.call(this, this.__scrollInViewProps);
+        if (typeof render === 'function') {
+          this.$write(render);
+        }
+      });
+    }
+
+    /**
+     * Take the frame subscription, if it is not already running. This is the
+     * `$services.enable('ticked')` of v3 — v4 has no such switch on a mixin,
+     * so the subscription itself is the switch.
+     */
+    startTicking(): void {
+      this.__unsubscribeFrame ??= useRaf().add(() => {
+        const props = this.__scrollInViewProps;
+        const { dampFactor, dampPrecision } = this.$options as {
+          dampFactor: number;
+          dampPrecision: number;
+        };
+        const { x, y } = useWindowScroll().props();
+
+        props.currentX = clamp(x, props.startX, props.endX);
+        props.currentY = clamp(y, props.startY, props.endY);
+        props.dampedCurrentX = damp(
+          props.currentX,
+          props.dampedCurrentX,
+          dampFactor,
+          dampPrecision,
+        );
+        props.dampedCurrentY = damp(
+          props.currentY,
+          props.dampedCurrentY,
+          dampFactor,
+          dampPrecision,
+        );
+        props.progressX = progressBetween(props.currentX, props.startX, props.endX);
+        props.progressY = progressBetween(props.currentY, props.startY, props.endY);
+        props.dampedProgressX = progressBetween(props.dampedCurrentX, props.startX, props.endX);
+        props.dampedProgressY = progressBetween(props.dampedCurrentY, props.startY, props.endY);
+
+        if (props.dampedCurrentX === props.currentX && props.dampedCurrentY === props.currentY) {
+          this.stopTicking();
+        }
+
+        const hook = (this as unknown as ScrolledInViewHook).scrolledInView;
+        return hook?.call(this, props) ?? undefined;
+      });
+    }
+
+    stopTicking(): void {
+      this.__unsubscribeFrame?.();
+      this.__unsubscribeFrame = null;
+    }
+
+    mounted(): MountedReturn {
+      const inherited = super.mounted();
+      this.__shouldMeasure = true;
+      this.renderScrollInView();
+
+      return [
+        inherited,
+        useWindowScroll().add(({ changedX, changedY }) => {
+          if (changedX || changedY) {
+            this.startTicking();
+          }
+        }),
+        useResize().add(() => {
+          this.__shouldMeasure = true;
+          this.renderScrollInView();
+        }),
+        () => this.stopTicking(),
+      ];
+    }
+
+    destroyed(): void {
+      super.destroyed();
+      // Snap the damped values to their target and render once more, so a
+      // component leaving the viewport is not frozen mid-animation.
+      const props = this.__scrollInViewProps;
+      props.dampedCurrentX = props.currentX;
+      props.dampedCurrentY = props.currentY;
+      props.dampedProgressX = props.progressX;
+      props.dampedProgressY = props.progressY;
+      // Not `$read`/`$write`: `$destroy()` cancels the instance's pending
+      // tasks right after running the `mounted()` cleanups, so a final render
+      // has to be scheduled outside the instance's own lane.
+      scheduler.read(() => {
+        const hook = (this as unknown as ScrolledInViewHook).scrolledInView;
+        const render = hook?.call(this, props);
+        if (typeof render === 'function') {
+          scheduler.write(render);
+        }
+      });
+    }
+  };
+}

--- a/packages/v4/migration/Slider/Slider.spec.ts
+++ b/packages/v4/migration/Slider/Slider.spec.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerComponents } from '../../src/index.js';
+import { frames, getInstance, resetDom, settle } from '../../src/test-utils.js';
+import { Slider } from './Slider.js';
+import { SliderBtn } from './SliderBtn.js';
+import { SliderCount } from './SliderCount.js';
+import { SliderItem } from './SliderItem.js';
+
+registerComponents(Slider, SliderBtn, SliderCount);
+
+const ITEM_WIDTH = 100;
+
+afterEach(resetDom);
+
+function render({ items = 3, options = '' } = {}): HTMLElement {
+  const root = document.createElement('div');
+  root.setAttribute('data-component', 'Slider');
+  root.innerHTML = `
+    <div data-ref="wrapper" tabindex="0" style="width:${ITEM_WIDTH}px;overflow:hidden;display:flex">
+      ${Array.from(
+        { length: items },
+        (_, index) =>
+          `<div data-component="SliderItem" style="flex:0 0 ${ITEM_WIDTH}px;height:20px">${index}</div>`,
+      ).join('')}
+    </div>
+    <button type="button" data-component="SliderBtn" data-option-prev="">prev</button>
+    <button type="button" data-component="SliderBtn" data-option-next="">next</button>
+    <p data-component="SliderCount"><span data-ref="current"></span>/<span data-ref="total"></span></p>
+  `;
+  for (const attribute of options.split(' ').filter(Boolean)) {
+    root.setAttribute(attribute, '');
+  }
+  document.body.append(root);
+  return root;
+}
+
+function get(root: HTMLElement) {
+  const buttons = [...root.querySelectorAll<HTMLButtonElement>('[data-component="SliderBtn"]')];
+  return {
+    slider: getInstance<Slider>(root, 'Slider'),
+    prev: buttons[0],
+    next: buttons[1],
+    current: root.querySelector('[data-ref="current"]') as HTMLElement,
+    total: root.querySelector('[data-ref="total"]') as HTMLElement,
+  };
+}
+
+async function ready(root: HTMLElement) {
+  await settle();
+  await frames(4);
+  return get(root);
+}
+
+describe('Slider', () => {
+  it('collects its items and publishes the initial state', async () => {
+    const root = render();
+    const { slider, current, total } = await ready(root);
+
+    expect(slider.items.size).toBe(3);
+    expect(slider.items.items.every((item) => item instanceof SliderItem)).toBe(true);
+    expect(slider.state.value).toEqual({ index: 0, total: 3 });
+    expect(current.textContent).toBe('1');
+    expect(total.textContent).toBe('3');
+  });
+
+  it('sets the carousel accessibility attributes', async () => {
+    const root = render();
+    const { slider } = await ready(root);
+
+    expect(root.getAttribute('role')).toBe('group');
+    expect(root.getAttribute('aria-roledescription')).toBe('carousel');
+    const [item] = slider.items.items;
+    expect(item.$el.getAttribute('aria-roledescription')).toBe('slide');
+    expect(item.$el.getAttribute('aria-label')).toBe(item.id);
+  });
+
+  it('navigates on a real click and moves every slide', async () => {
+    const root = render();
+    const { slider, next } = await ready(root);
+
+    next.click();
+    await frames(30);
+
+    expect(slider.currentIndex).toBe(1);
+    for (const item of slider.items) {
+      expect(item.x).toBe(-ITEM_WIDTH);
+      expect(item.$el.style.transform).toContain('translate3d(-');
+    }
+  });
+
+  it('flags the active slide', async () => {
+    const root = render();
+    const { slider, next } = await ready(root);
+    const [first, second] = slider.items.items;
+
+    expect(first.$el.classList.contains('is-active')).toBe(true);
+
+    next.click();
+    await frames(4);
+    expect(first.$el.classList.contains('is-active')).toBe(false);
+    expect(second.$el.classList.contains('is-active')).toBe(true);
+  });
+
+  it('updates every control through the provided signal', async () => {
+    const root = render();
+    const { slider, next, current } = await ready(root);
+
+    next.click();
+    await frames(4);
+
+    expect(current.textContent).toBe('2');
+    expect(slider.state.value).toEqual({ index: 1, total: 3 });
+  });
+
+  it('disables the buttons at the bounds', async () => {
+    const root = render({ items: 2 });
+    const { next, prev } = await ready(root);
+
+    expect(prev.disabled).toBe(true);
+    expect(next.disabled).toBe(false);
+
+    next.click();
+    await frames(4);
+    expect(prev.disabled).toBe(false);
+    expect(next.disabled).toBe(true);
+  });
+
+  it('navigates with the arrow keys when the wrapper has the focus', async () => {
+    const root = render();
+    const { slider } = await ready(root);
+    const wrapper = root.querySelector('[data-ref="wrapper"]') as HTMLElement;
+
+    wrapper.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await frames(2);
+    expect(slider.currentIndex).toBe(1);
+
+    wrapper.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    await frames(2);
+    expect(slider.currentIndex).toBe(0);
+
+    // A key pressed outside the wrapper is not the slider's business.
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await frames(2);
+    expect(slider.currentIndex).toBe(0);
+  });
+
+  it('reacts to a slide added after mount', async () => {
+    const root = render({ items: 2 });
+    const { slider, total, next } = await ready(root);
+    expect(slider.items.size).toBe(2);
+
+    const added = document.createElement('div');
+    added.setAttribute('data-component', 'SliderItem');
+    added.style.cssText = `flex:0 0 ${ITEM_WIDTH}px;height:20px`;
+    (root.querySelector('[data-ref="wrapper"]') as HTMLElement).append(added);
+    await ready(root);
+
+    expect(slider.items.size).toBe(3);
+    expect(total.textContent).toBe('3');
+    // The next button is no longer at the bound.
+    expect(next.disabled).toBe(false);
+  });
+
+  it('clamps instead of throwing when the active slide is removed', async () => {
+    const root = render({ items: 3 });
+    const { slider, next } = await ready(root);
+
+    next.click();
+    next.click();
+    await frames(4);
+    expect(slider.currentIndex).toBe(2);
+
+    slider.items.items[2].$el.remove();
+    await ready(root);
+
+    // v3 threw `Index out of bound.` here.
+    expect(slider.items.size).toBe(2);
+    expect(slider.currentIndex).toBe(1);
+    expect(slider.state.value).toEqual({ index: 1, total: 2 });
+  });
+
+  it('connects a control that mounts before its slider', async () => {
+    // The counter is inserted on its own, so nothing about the Slider exists
+    // when it asks for the context.
+    const count = document.createElement('p');
+    count.setAttribute('data-component', 'SliderCount');
+    count.innerHTML = '<span data-ref="current"></span>';
+    document.body.append(count);
+    await settle();
+    expect(count.textContent).toBe('');
+
+    const root = render();
+    root.append(count);
+    await ready(root);
+
+    // No handshake, no `connectChildren()`: the late provider replays.
+    expect(count.querySelector('[data-ref="current"]')?.textContent).toBe('1');
+  });
+
+  it('resets a slide position when it leaves the DOM', async () => {
+    const root = render();
+    const { slider, next } = await ready(root);
+
+    next.click();
+    await frames(30);
+    const [first] = slider.items.items;
+    expect(first.x).toBe(-ITEM_WIDTH);
+
+    first.$el.remove();
+    await ready(root);
+    expect(first.x).toBe(0);
+  });
+});

--- a/packages/v4/migration/Slider/Slider.ts
+++ b/packages/v4/migration/Slider/Slider.ts
@@ -1,0 +1,248 @@
+import {
+  Base,
+  createContext,
+  withResize,
+  type ChildrenCollection,
+  type MountedReturn,
+  type RefEvent,
+  type Signal,
+} from '../../src/index.js';
+import { SliderItem } from './SliderItem.js';
+
+export type SliderModes = 'left' | 'center' | 'right';
+
+export interface SliderState {
+  index: number;
+  total: number;
+}
+
+/**
+ * The state a Slider publishes to its controls.
+ *
+ * This replaces the per-instance `createStorage()` store of v3 and, with it,
+ * the whole `AbstractSliderChild` handshake: no `connectChildren()` on the
+ * parent, no `__connect()` on the child, no `updated()`/`resized()`
+ * reconnection safety nets. The signal is resolved through the DOM event
+ * path, so mount order does not matter in either direction.
+ */
+export const SliderContext = /* @__PURE__ */ createContext<SliderState>('slider-state');
+
+export interface SliderProps {
+  $refs: { wrapper: HTMLElement };
+  $options: { mode: SliderModes; fitBounds: boolean; contain: boolean };
+  $emits: { goto: [index: number]; index: [index: number] };
+}
+
+interface SliderItemState {
+  left: number;
+  center: number;
+  right: number;
+}
+
+/**
+ * Slider — the root of the carousel system.
+ *
+ * Port of @studiometa/ui 1.10's `Slider`, minus `SliderDrag` (which needs the
+ * drag service and the inertia helper; v4 ships `useDrag`, so it is a
+ * mechanical follow-up rather than a blocker).
+ *
+ * What changed, and why:
+ *
+ * - `$children.SliderItem` → `$watchChildren('SliderItem')`, so slides added
+ *   or removed after mount are picked up.
+ * - the index store → a provided `Signal`, injected by the controls.
+ * - `keyed()` (KeyService) → `onWrapperKeydown`, a delegated handler on the
+ *   `wrapper` ref. The event only reaches the component when the focus is
+ *   inside the wrapper, which is what v3 tracked by hand with
+ *   `onWrapperFocus` / `onWrapperBlur` and a `hasFocus` flag.
+ */
+export class Slider extends withResize(Base)<SliderProps> {
+  static config = {
+    name: 'Slider',
+    refs: ['wrapper'],
+    components: { SliderItem },
+    options: {
+      mode: { type: String, default: 'left' },
+      fitBounds: Boolean,
+      contain: Boolean,
+    },
+  };
+
+  state: Signal<SliderState> = this.$provide(SliderContext, { index: 0, total: 0 });
+
+  items: ChildrenCollection<SliderItem> = this.$watchChildren<SliderItem>('SliderItem', {
+    added: () => this.refresh(),
+    removed: () => this.refresh(),
+  });
+
+  states: SliderItemState[] = [];
+
+  origins: Record<SliderModes, number> = { left: 0, center: 0, right: 0 };
+
+  #currentIndex = 0;
+
+  get currentIndex(): number {
+    return this.#currentIndex;
+  }
+
+  set currentIndex(value: number) {
+    this.currentSliderItem?.disactivate();
+    this.#currentIndex = value;
+    this.$emit('index', value);
+    this.state.value = { index: value, total: this.items.size };
+    this.currentSliderItem?.activate();
+  }
+
+  get indexMax(): number {
+    return this.items.size - 1;
+  }
+
+  get currentSliderItem(): SliderItem | undefined {
+    return this.items.items[this.#currentIndex];
+  }
+
+  get containMinState(): number {
+    return this.states[0]?.left ?? 0;
+  }
+
+  get containMaxState(): number {
+    return this.states.at(-1)?.right ?? 0;
+  }
+
+  mounted(): MountedReturn {
+    const inherited = super.mounted();
+    this.$el.setAttribute('role', 'group');
+    this.$el.setAttribute('aria-roledescription', 'carousel');
+    this.refresh();
+    return inherited;
+  }
+
+  /**
+   * Re-measure and re-publish. v3 split this between `mounted()`,
+   * `resized()` and `connectChildren()`; here one method answers every event
+   * that can change the geometry or the slide count.
+   */
+  refresh(): void {
+    this.$read(() => {
+      this.states = this.getStates();
+      this.$write(() => this.goTo(Math.min(this.#currentIndex, Math.max(0, this.indexMax))));
+    });
+  }
+
+  resized(): void {
+    this.refresh();
+  }
+
+  getStates(): SliderItemState[] {
+    const items = this.items.items;
+    if (items.length === 0) {
+      return [];
+    }
+
+    const originRect = this.$refs.wrapper.getBoundingClientRect();
+    this.origins = {
+      left: originRect.left,
+      center: originRect.left + originRect.width / 2,
+      right: originRect.left + originRect.width,
+    };
+
+    const states: SliderItemState[] = items.map((item) => ({
+      left: (item.rect.x - this.origins.left) * -1,
+      center: (item.rect.x + item.rect.width / 2 - this.origins.center) * -1,
+      right: (item.rect.x + item.rect.width - this.origins.right) * -1,
+    }));
+
+    if (!this.$options.contain) {
+      return states;
+    }
+
+    const { mode } = this.$options;
+
+    if (mode === 'left') {
+      const lastItem = items.at(-1) as SliderItem;
+      const maxState = states.find((state) => {
+        const lastPosition = lastItem.rect.x - this.origins.left + lastItem.rect.width + state.left;
+        const difference = originRect.width - lastPosition;
+        if (difference > 0) {
+          state.left = Math.min(state.left + difference, 0);
+          return true;
+        }
+        return false;
+      });
+
+      if (maxState) {
+        for (const state of states) {
+          state.left = Math.max(state.left, maxState.left);
+        }
+      }
+      return states;
+    }
+
+    if (mode === 'right') {
+      const maxStateIndex = states.findIndex((state) => state.right <= 0);
+      const maxState = maxStateIndex < 0 ? states.at(-1) : states[maxStateIndex - 1];
+      for (const state of states) {
+        state.right = maxStateIndex < 0 ? (maxState?.right ?? 0) : Math.min(state.right, 0);
+      }
+      return states;
+    }
+
+    // `center` + `contain` was never implemented in v3 either.
+    console.warn('[Slider] The `center` mode is not compatible with the `contain` mode.');
+    return states;
+  }
+
+  getStateValueByMode(state: SliderItemState, mode?: SliderModes): number {
+    return state[mode ?? this.$options.mode];
+  }
+
+  goNext(): void {
+    if (this.currentIndex + 1 <= this.indexMax) {
+      this.goTo(this.currentIndex + 1);
+    }
+  }
+
+  goPrev(): void {
+    if (this.currentIndex - 1 >= 0) {
+      this.goTo(this.currentIndex - 1);
+    }
+  }
+
+  /**
+   * v3 threw `Index out of bound.` here, which meant a slide removed from the
+   * DOM could crash the slider. With a live children collection the index is
+   * clamped instead — the collection is the source of truth and it changes
+   * under the component by design.
+   */
+  goTo(index: number): void {
+    if (this.items.size === 0) {
+      this.currentIndex = 0;
+      return;
+    }
+
+    const clamped = Math.max(0, Math.min(index, this.indexMax));
+    const state = this.states[clamped];
+    if (state) {
+      const value = this.getStateValueByMode(state);
+      for (const item of this.items) {
+        item.move(value);
+      }
+    }
+
+    this.currentIndex = clamped;
+    this.$emit('goto', clamped);
+  }
+
+  /**
+   * Arrow-key navigation. The handler is delegated from the `wrapper` ref, so
+   * it only fires when the focus is inside the wrapper.
+   */
+  onWrapperKeydown({ event }: RefEvent): void {
+    const { key } = event as KeyboardEvent;
+    if (key === 'ArrowLeft') {
+      this.goPrev();
+    } else if (key === 'ArrowRight') {
+      this.goNext();
+    }
+  }
+}

--- a/packages/v4/migration/Slider/SliderBtn.ts
+++ b/packages/v4/migration/Slider/SliderBtn.ts
@@ -1,0 +1,59 @@
+import { Base } from '../../src/index.js';
+import { SliderContext, type Slider } from './Slider.js';
+
+export interface SliderBtnProps {
+  $el: HTMLButtonElement;
+  $options: { prev: boolean; next: boolean };
+}
+
+/**
+ * SliderBtn — a previous/next control.
+ *
+ * Port of @studiometa/ui 1.10's `SliderBtn`, and the clearest illustration of
+ * what `AbstractSliderChild` was for. v3 needed 143 lines of base class to
+ * find its Slider and subscribe to its store, with a reconnection in
+ * `mounted()`, `resized()` and `updated()` because none of them was reliable
+ * on its own. Here it is one `$inject` in `mounted()` and the returned
+ * unsubscribe.
+ *
+ * State comes through the context; *commands* do not. v4's provide/inject
+ * carries a value signal only — DESIGN.md's "curated owner surface (`expose`
+ * pattern)" is not implemented — so the click handler still resolves the
+ * Slider with `$closest()`. That is fine at click time (the Slider is
+ * mounted), but it means a control has two different ways of reaching its
+ * parent.
+ */
+export class SliderBtn extends Base<SliderBtnProps> {
+  static config = {
+    name: 'SliderBtn',
+    options: { prev: Boolean, next: Boolean },
+  };
+
+  get slider(): Slider | null {
+    return this.$closest<Slider>('Slider');
+  }
+
+  async mounted() {
+    const state = await this.$inject(SliderContext);
+    return state.subscribe(
+      ({ index, total }) => {
+        this.$write(() => this.update(index, total));
+      },
+      { immediate: true },
+    );
+  }
+
+  update(index: number, total: number): void {
+    const isFirst = index === 0 && this.$options.prev;
+    const isLast = index >= total - 1 && this.$options.next;
+    this.$el.toggleAttribute('disabled', isFirst || isLast);
+  }
+
+  onClick(): void {
+    if (this.$options.prev) {
+      this.slider?.goPrev();
+    } else if (this.$options.next) {
+      this.slider?.goNext();
+    }
+  }
+}

--- a/packages/v4/migration/Slider/SliderCount.ts
+++ b/packages/v4/migration/Slider/SliderCount.ts
@@ -1,0 +1,32 @@
+import { Base } from '../../src/index.js';
+import { SliderContext } from './Slider.js';
+
+export interface SliderCountProps {
+  $refs: { current: HTMLElement; total: HTMLElement };
+}
+
+/**
+ * SliderCount — the slide counter.
+ *
+ * Port of @studiometa/ui 1.10's `SliderCount`. v3 only wrote the current
+ * index, because the store carried nothing else; the provided signal carries
+ * the total too, so an optional `total` ref costs nothing.
+ */
+export class SliderCount extends Base<SliderCountProps> {
+  static config = { name: 'SliderCount', refs: ['current', 'total'] };
+
+  async mounted() {
+    const state = await this.$inject(SliderContext);
+    return state.subscribe(
+      ({ index, total }) => {
+        this.$write(() => {
+          this.$refs.current.textContent = String(index + 1);
+          if (this.$refs.total) {
+            this.$refs.total.textContent = String(total);
+          }
+        });
+      },
+      { immediate: true },
+    );
+  }
+}

--- a/packages/v4/migration/Slider/SliderItem.ts
+++ b/packages/v4/migration/Slider/SliderItem.ts
@@ -1,0 +1,109 @@
+import { Base, useRaf, useResize, type MountedReturn } from '../../src/index.js';
+import { damp } from '../utils/math.js';
+import { uid } from '../utils/uid.js';
+
+export interface SliderItemRect {
+  x: number;
+  width: number;
+}
+
+/**
+ * SliderItem — one slide.
+ *
+ * Port of @studiometa/ui 1.10's `SliderItem`. It caches its position for the
+ * Slider's arithmetic and translates itself along the x axis, instantly or
+ * with a damped animation.
+ *
+ * v3 drove the animation with `this.$services.enable('ticked')` /
+ * `disable('ticked')`, toggling the shared RAF service per item. v4 has no
+ * such switch: `withRaf` subscribes for the whole mount cycle. The
+ * subscription is therefore taken and released by hand — which is the same
+ * behaviour, and arguably clearer, but it is a hook the mixin cannot give.
+ */
+export class SliderItem extends Base {
+  static config = { name: 'SliderItem' };
+
+  readonly id = uid('slider-item');
+
+  /** Target position. */
+  x = 0;
+
+  /** Smoothed position. */
+  dampedX = 0;
+
+  #rect: SliderItemRect | null = null;
+
+  #unsubscribeFrame: (() => void) | null = null;
+
+  /**
+   * Position and width of the slide as if it were untranslated.
+   *
+   * Invalidated by the resize service instead of by v3's `resized()` hook
+   * plus a `shouldEvaluateRect` flag: a `ResizeObserver` reports the current
+   * size on subscribe, so there is no first-resize gap to work around.
+   */
+  get rect(): SliderItemRect {
+    if (!this.#rect) {
+      const rect = this.$el.getBoundingClientRect();
+      this.#rect = { x: rect.left - this.dampedX, width: rect.width };
+    }
+    return this.#rect;
+  }
+
+  mounted(): MountedReturn {
+    this.$el.setAttribute('role', 'group');
+    this.$el.setAttribute('aria-roledescription', 'slide');
+    this.$el.setAttribute('aria-label', this.id);
+
+    return [
+      useResize().add(() => {
+        this.#rect = null;
+      }),
+      () => this.#stopTicking(),
+    ];
+  }
+
+  destroyed(): void {
+    this.moveInstantly(0);
+  }
+
+  activate(): void {
+    this.$el.classList.add('is-active');
+  }
+
+  disactivate(): void {
+    this.$el.classList.remove('is-active');
+  }
+
+  /** Move with inertia. */
+  move(targetPosition: number): void {
+    this.x = targetPosition;
+    this.#startTicking();
+  }
+
+  /** Move now, no animation. */
+  moveInstantly(targetPosition: number): void {
+    this.x = targetPosition;
+    this.dampedX = targetPosition;
+    this.$write(() => this.render());
+  }
+
+  render(): void {
+    this.$el.style.transform = `translate3d(${this.dampedX}px, 0px, 0px)`;
+  }
+
+  #startTicking(): void {
+    this.#unsubscribeFrame ??= useRaf().add(() => {
+      this.dampedX = damp(this.x, this.dampedX, 0.1, 0.00001);
+      if (this.dampedX === this.x) {
+        this.#stopTicking();
+      }
+      return () => this.render();
+    });
+  }
+
+  #stopTicking(): void {
+    this.#unsubscribeFrame?.();
+    this.#unsubscribeFrame = null;
+  }
+}

--- a/packages/v4/migration/Slider/index.ts
+++ b/packages/v4/migration/Slider/index.ts
@@ -1,0 +1,10 @@
+export {
+  Slider,
+  SliderContext,
+  type SliderModes,
+  type SliderProps,
+  type SliderState,
+} from './Slider.js';
+export { SliderBtn, type SliderBtnProps } from './SliderBtn.js';
+export { SliderCount, type SliderCountProps } from './SliderCount.js';
+export { SliderItem, type SliderItemRect } from './SliderItem.js';

--- a/packages/v4/migration/Transition/Transition.ts
+++ b/packages/v4/migration/Transition/Transition.ts
@@ -1,0 +1,107 @@
+import { Base, nextFrame } from '../../src/index.js';
+import { transition } from '../utils/transition.js';
+
+export interface TransitionProps {
+  $options: {
+    enterFrom: string;
+    enterActive: string;
+    enterTo: string;
+    enterKeep: boolean;
+    leaveFrom: string;
+    leaveActive: string;
+    leaveTo: string;
+    leaveKeep: boolean;
+  };
+  $emits: {
+    'transition-enter': [];
+    'transition-enter-start': [];
+    'transition-enter-end': [];
+    'transition-leave': [];
+    'transition-leave-start': [];
+    'transition-leave-end': [];
+  };
+}
+
+/**
+ * A component that can be entered and left — what `Dialog` fans its
+ * open/close out to.
+ */
+export interface Transitionable {
+  enter(): Promise<void>;
+  leave(): Promise<void>;
+  toggle(): Promise<void>;
+}
+
+/**
+ * Transition — enter/leave CSS transitions on an element.
+ *
+ * Port of @studiometa/ui 1.10's `Transition` component and the
+ * `withTransition` decorator behind it, collapsed into one class: v3 split
+ * them so that `SliderDots` could reuse the behaviour through a mixin, which
+ * `$watchChildren` makes unnecessary.
+ *
+ * One v3 feature is **not** ported: the `group` option, which collects the
+ * other `Transition` instances sharing a group name through
+ * `getInstances(Transition)`. v4 has no per-class instance registry — the
+ * registry maps a name to a constructor, not to its live instances — so a
+ * group would have to be resolved by DOM query instead.
+ */
+export class Transition extends Base<TransitionProps> implements Transitionable {
+  static config = {
+    name: 'Transition',
+    options: {
+      enterFrom: String,
+      enterActive: String,
+      enterTo: String,
+      enterKeep: Boolean,
+      leaveFrom: String,
+      leaveActive: String,
+      leaveTo: String,
+      leaveKeep: Boolean,
+    },
+  };
+
+  state: 'entering' | 'leaving' | null = null;
+
+  get target(): HTMLElement {
+    return this.$el;
+  }
+
+  async enter(): Promise<void> {
+    const { enterFrom, enterActive, enterTo, enterKeep, leaveTo } = this.$options;
+    this.state = 'entering';
+    this.$emit('transition-enter');
+    this.$emit('transition-enter-start');
+    if (leaveTo) {
+      this.target.classList.remove(...leaveTo.split(' ').filter(Boolean));
+    }
+    await nextFrame();
+    await transition(
+      this.target,
+      { from: enterFrom, active: enterActive, to: enterTo },
+      enterKeep ? 'keep' : 'remove',
+    );
+    this.$emit('transition-enter-end');
+  }
+
+  async leave(): Promise<void> {
+    const { leaveFrom, leaveActive, leaveTo, leaveKeep, enterTo } = this.$options;
+    this.state = 'leaving';
+    this.$emit('transition-leave');
+    this.$emit('transition-leave-start');
+    if (enterTo) {
+      this.target.classList.remove(...enterTo.split(' ').filter(Boolean));
+    }
+    await nextFrame();
+    await transition(
+      this.target,
+      { from: leaveFrom, active: leaveActive, to: leaveTo },
+      leaveKeep ? 'keep' : 'remove',
+    );
+    this.$emit('transition-leave-end');
+  }
+
+  toggle(): Promise<void> {
+    return this.state === 'entering' ? this.leave() : this.enter();
+  }
+}

--- a/packages/v4/migration/Transition/ViewTransition.ts
+++ b/packages/v4/migration/Transition/ViewTransition.ts
@@ -1,0 +1,86 @@
+import { Base } from '../../src/index.js';
+import type { Transitionable } from './Transition.js';
+
+export interface ViewTransitionProps {
+  $options: { viewTransitionName: string; enterTo: string; leaveTo: string };
+  $emits: {
+    enter: [];
+    'enter-start': [];
+    'enter-end': [];
+    leave: [];
+    'leave-start': [];
+    'leave-end': [];
+  };
+}
+
+/**
+ * ViewTransition — the same interface as `Transition`, animated by the
+ * native View Transitions API.
+ *
+ * This is the port that shrank the most, and it did so without a single
+ * decision to make: @studiometa/ui ships its own batching scheduler for this
+ * (`ViewTransition/scheduler.ts` — microtask-batched updates flushed into one
+ * `document.startViewTransition()`, batches serialised, synchronous
+ * fallback). v4 moved that into core, so the component is just
+ * `this.$viewTransition(update)` and the whole scheduler file disappears.
+ */
+export class ViewTransition extends Base<ViewTransitionProps> implements Transitionable {
+  static config = {
+    name: 'ViewTransition',
+    options: {
+      viewTransitionName: String,
+      enterTo: String,
+      leaveTo: String,
+    },
+  };
+
+  state: 'entering' | 'leaving' | null = null;
+
+  get target(): HTMLElement {
+    return this.$el;
+  }
+
+  mounted(): void {
+    const { viewTransitionName } = this.$options;
+    if (viewTransitionName) {
+      this.target.style.setProperty('view-transition-name', viewTransitionName);
+    }
+  }
+
+  async enter(): Promise<void> {
+    const { enterTo, leaveTo } = this.$options;
+    this.state = 'entering';
+    this.$emit('enter');
+    this.$emit('enter-start');
+    await this.$viewTransition(() => {
+      this.#toggleClasses(leaveTo, enterTo);
+    });
+    this.$emit('enter-end');
+  }
+
+  async leave(): Promise<void> {
+    const { enterTo, leaveTo } = this.$options;
+    this.state = 'leaving';
+    this.$emit('leave');
+    this.$emit('leave-start');
+    await this.$viewTransition(() => {
+      this.#toggleClasses(enterTo, leaveTo);
+    });
+    this.$emit('leave-end');
+  }
+
+  toggle(): Promise<void> {
+    return this.state === 'entering' ? this.leave() : this.enter();
+  }
+
+  #toggleClasses(remove: string, add: string): void {
+    const removed = remove.split(' ').filter(Boolean);
+    const added = add.split(' ').filter(Boolean);
+    if (removed.length > 0) {
+      this.target.classList.remove(...removed);
+    }
+    if (added.length > 0) {
+      this.target.classList.add(...added);
+    }
+  }
+}

--- a/packages/v4/migration/Transition/index.ts
+++ b/packages/v4/migration/Transition/index.ts
@@ -1,0 +1,2 @@
+export { Transition, type Transitionable, type TransitionProps } from './Transition.js';
+export { ViewTransition, type ViewTransitionProps } from './ViewTransition.js';

--- a/packages/v4/migration/index.ts
+++ b/packages/v4/migration/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @studiometa/ui components ported onto the v4 prototype.
+ *
+ * This is a migration feasibility test, not a component library: four
+ * families were chosen because they hit the parts of v3 that v4 changed most.
+ * Each file documents what its port cost against the v3 original.
+ *
+ * Registering is left to the consumer — `registerComponent(Accordion)` and so
+ * on — so importing the barrel mounts nothing on its own.
+ */
+
+export * from './Accordion/index.js';
+export * from './Dialog/index.js';
+export * from './ScrollAnimation/index.js';
+export * from './Slider/index.js';
+export * from './Transition/index.js';
+export * from './utils/easings.js';
+export * from './utils/focus.js';
+export * from './utils/keyframes.js';
+export * from './utils/math.js';
+export * from './utils/transition.js';
+export * from './utils/uid.js';

--- a/packages/v4/migration/utils/easings.ts
+++ b/packages/v4/migration/utils/easings.ts
@@ -1,0 +1,66 @@
+/**
+ * Easing helpers.
+ *
+ * v3 imports `cubicBezier` from `@motionone/easing`, which is the only third
+ * party dependency the `animate` chain pulls in. v4 has none, so the curve is
+ * solved here with the usual Newton–Raphson pass and a bisection fallback —
+ * about thirty lines against a package.
+ */
+
+export type EasingFunction = (progress: number) => number;
+export type BezierCurve = [number, number, number, number];
+
+const SUBDIVISION_PRECISION = 1e-7;
+const SUBDIVISION_MAX_ITERATIONS = 12;
+
+function calcBezier(t: number, a1: number, a2: number): number {
+  return (((1 - 3 * a2 + 3 * a1) * t + (3 * a2 - 6 * a1)) * t + 3 * a1) * t;
+}
+
+export function linear(progress: number): number {
+  return progress;
+}
+
+/**
+ * Build the easing function for a CSS-style cubic bezier curve.
+ */
+export function cubicBezier(mX1: number, mY1: number, mX2: number, mY2: number): EasingFunction {
+  if (mX1 === mY1 && mX2 === mY2) {
+    return linear;
+  }
+
+  return (progress: number) => {
+    if (progress <= 0 || progress >= 1) {
+      return progress;
+    }
+
+    let lower = 0;
+    let upper = 1;
+    let t = progress;
+    for (let i = 0; i < SUBDIVISION_MAX_ITERATIONS; i += 1) {
+      const x = calcBezier(t, mX1, mX2) - progress;
+      if (Math.abs(x) < SUBDIVISION_PRECISION) {
+        break;
+      }
+      if (x > 0) {
+        upper = t;
+      } else {
+        lower = t;
+      }
+      t = (upper + lower) / 2;
+    }
+
+    return calcBezier(t, mY1, mY2);
+  };
+}
+
+/**
+ * Accept either a function or a `[x1, y1, x2, y2]` curve, as v3's
+ * `normalizeEase` does.
+ */
+export function normalizeEasing(easing?: EasingFunction | BezierCurve): EasingFunction {
+  if (!easing) {
+    return linear;
+  }
+  return Array.isArray(easing) ? cubicBezier(...easing) : easing;
+}

--- a/packages/v4/migration/utils/focus.ts
+++ b/packages/v4/migration/utils/focus.ts
@@ -1,0 +1,74 @@
+/**
+ * `trapFocus` / `untrapFocus` / `saveActiveElement`, ported from
+ * `@studiometa/js-toolkit/utils/trapFocus`.
+ *
+ * The one change is the key test: v3 reads `event.keyCode`, deprecated since
+ * 2016 and the reason the toolkit ships a `keyCodes` table. `event.key` needs
+ * no table.
+ */
+
+const FOCUSABLE = [
+  'a[href]:not([tabindex^="-"]):not([inert])',
+  'area[href]:not([tabindex^="-"]):not([inert])',
+  'input:not([disabled]):not([inert])',
+  'select:not([disabled]):not([inert])',
+  'textarea:not([disabled]):not([inert])',
+  'button:not([disabled]):not([inert])',
+  'iframe:not([tabindex^="-"]):not([inert])',
+  'audio:not([tabindex^="-"]):not([inert])',
+  'video:not([tabindex^="-"]):not([inert])',
+  '[contenteditable]:not([tabindex^="-"]):not([inert])',
+  '[tabindex]:not([tabindex^="-"]):not([inert])',
+].join(', ');
+
+let focusedBefore: Element | null = null;
+
+/**
+ * Remember what had the focus, to restore it later.
+ */
+export function saveActiveElement(): void {
+  focusedBefore = document.activeElement;
+}
+
+/**
+ * Keep tab navigation inside an element.
+ */
+export function trapFocus(el: HTMLElement, event: KeyboardEvent): void {
+  if (event.key !== 'Tab') {
+    return;
+  }
+
+  focusedBefore ??= document.activeElement;
+
+  const focusable = [...el.querySelectorAll<HTMLElement>(FOCUSABLE)];
+  if (focusable.length === 0) {
+    return;
+  }
+
+  const index =
+    document.activeElement instanceof HTMLElement ? focusable.indexOf(document.activeElement) : -1;
+
+  if (index < 0) {
+    focusable[0].focus();
+    event.preventDefault();
+    return;
+  }
+
+  if (event.shiftKey && index === 0) {
+    focusable.at(-1)?.focus();
+    event.preventDefault();
+  } else if (!event.shiftKey && index === focusable.length - 1) {
+    focusable[0].focus();
+    event.preventDefault();
+  }
+}
+
+/**
+ * Give the focus back to whatever had it before the trap.
+ */
+export function untrapFocus(): void {
+  if (focusedBefore instanceof HTMLElement) {
+    focusedBefore.focus();
+  }
+  focusedBefore = null;
+}

--- a/packages/v4/migration/utils/keyframes.spec.ts
+++ b/packages/v4/migration/utils/keyframes.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { applyStyles, compile } from './keyframes.js';
+
+const size = { width: 200, height: 100 };
+
+describe('compile', () => {
+  it('interpolates opacity and transforms between two keyframes', () => {
+    const interpolate = compile([
+      { opacity: 0, x: 0 },
+      { opacity: 1, x: 100 },
+    ]);
+
+    expect(interpolate(0, size).opacity).toBe('0');
+    expect(interpolate(0, size).transform).toBe('translate3d(0px, 0px, 0px)');
+    expect(interpolate(0.5, size).opacity).toBe('0.5');
+    expect(interpolate(0.5, size).transform).toBe('translate3d(50px, 0px, 0px)');
+    expect(interpolate(1, size).opacity).toBe('1');
+    expect(interpolate(1, size).transform).toBe('translate3d(100px, 0px, 0px)');
+  });
+
+  it('resolves percentage units against the element size', () => {
+    const interpolate = compile([{ x: 0 }, { x: [50, '%'], y: [100, '%'] }]);
+
+    // 50% of the width, 100% of the height.
+    expect(interpolate(1, size).transform).toBe('translate3d(100px, 100px, 0px)');
+  });
+
+  it('walks several keyframes through their offsets', () => {
+    const interpolate = compile([{ opacity: 0 }, { opacity: 1 }, { opacity: 0 }]);
+
+    expect(interpolate(0, size).opacity).toBe('0');
+    expect(interpolate(0.25, size).opacity).toBe('0.5');
+    expect(interpolate(0.5, size).opacity).toBe('1');
+    expect(interpolate(0.75, size).opacity).toBe('0.5');
+    expect(interpolate(1, size).opacity).toBe('0');
+  });
+
+  it('honours explicit offsets', () => {
+    const interpolate = compile([
+      { opacity: 0, offset: 0 },
+      { opacity: 1, offset: 0.2 },
+      { opacity: 1, offset: 1 },
+    ]);
+
+    expect(interpolate(0.1, size).opacity).toBe('0.5');
+    expect(interpolate(0.6, size).opacity).toBe('1');
+  });
+
+  it('applies a cubic bezier easing', () => {
+    const eased = compile([{ opacity: 0 }, { opacity: 1 }], { easing: [0.5, 0, 0.5, 1] });
+    const linear = compile([{ opacity: 0 }, { opacity: 1 }]);
+
+    expect(Number(eased(0.5, size).opacity)).toBeCloseTo(0.5, 3);
+    // An ease-in-out curve is behind the linear one at a quarter.
+    expect(Number(eased(0.25, size).opacity)).toBeLessThan(Number(linear(0.25, size).opacity));
+  });
+
+  it('interpolates custom properties and rotation', () => {
+    const interpolate = compile([
+      { rotate: 0, '--shift': 0 },
+      { rotate: 90, '--shift': 10 },
+    ]);
+
+    const styles = interpolate(0.5, size);
+    expect(styles.transform).toBe('rotate(45deg)');
+    expect(styles.customProperties).toEqual([['--shift', '5']]);
+  });
+
+  it('writes the style patch to an element', () => {
+    const el = document.createElement('div');
+    applyStyles(el, compile([{ opacity: 0 }, { opacity: 1, '--shift': 4 }])(1, size));
+
+    expect(el.style.opacity).toBe('1');
+    expect(el.style.getPropertyValue('--shift')).toBe('');
+
+    const withVars = compile([{ '--shift': 0 }, { '--shift': 4 }]);
+    applyStyles(el, withVars(0.5, size));
+    expect(el.style.getPropertyValue('--shift')).toBe('2');
+  });
+});

--- a/packages/v4/migration/utils/keyframes.ts
+++ b/packages/v4/migration/utils/keyframes.ts
@@ -1,0 +1,208 @@
+import { clamp01, map } from './math.js';
+import { normalizeEasing, type BezierCurve, type EasingFunction } from './easings.js';
+
+/**
+ * The keyframes → styles interpolator the `ScrollAnimation` family needs.
+ *
+ * v3's `animate()` is a player: it owns a `tween`, a rAF loop, a `running`
+ * WeakMap of concurrent animations per element, `start`/`pause`/`play`/
+ * `finish`, staggering across several targets, and it writes to the DOM
+ * itself through `domScheduler`. `ScrollAnimation` — its only real consumer
+ * in @studiometa/ui — never calls any of that. It builds the animation once
+ * and only ever calls `animation.progress(p)` from a scroll handler.
+ *
+ * So the port keeps the interpolation and drops the player: `compile()`
+ * returns a pure `(progress, size) => Styles` function. Nothing is scheduled
+ * here and nothing is written; the caller measures in `read` and writes in
+ * `write`, which is what makes the whole family batch into one frame.
+ */
+
+export type CSSCustomPropertyName = `--${string}`;
+
+/** A length that may carry a CSS unit, e.g. `[50, '%']`. */
+export type UnitValue = number | [number, string];
+
+export interface Keyframe {
+  x?: UnitValue;
+  y?: UnitValue;
+  z?: UnitValue;
+  rotate?: number;
+  rotateX?: number;
+  rotateY?: number;
+  rotateZ?: number;
+  scale?: number;
+  scaleX?: number;
+  scaleY?: number;
+  scaleZ?: number;
+  skew?: number;
+  skewX?: number;
+  skewY?: number;
+  opacity?: number;
+  transformOrigin?: string;
+  easing?: EasingFunction | BezierCurve;
+  offset?: number;
+  [key: CSSCustomPropertyName]: unknown;
+}
+
+/** What the interpolator produces: a style patch, not a DOM write. */
+export interface KeyframeStyles {
+  transform: string;
+  opacity: string;
+  transformOrigin: string;
+  customProperties: Array<[string, string]>;
+}
+
+/** The element size the `%` unit resolves against. */
+export interface ElementSize {
+  width: number;
+  height: number;
+}
+
+interface NormalizedKeyframe extends Keyframe {
+  offset: number;
+  ease: EasingFunction;
+  vars: string[];
+}
+
+/** `[keyframe property, css function, unit, default value]`. */
+const SIMPLE_TRANSFORMS: ReadonlyArray<readonly [keyof Keyframe, string, string, number]> = [
+  ['rotate', 'rotate', 'deg', 0],
+  ['rotateX', 'rotateX', 'deg', 0],
+  ['rotateY', 'rotateY', 'deg', 0],
+  ['rotateZ', 'rotateZ', 'deg', 0],
+  ['scale', 'scale', '', 1],
+  ['scaleX', 'scaleX', '', 1],
+  ['scaleY', 'scaleY', '', 1],
+  ['scaleZ', 'scaleZ', '', 1],
+  ['skew', 'skew', 'deg', 0],
+  ['skewX', 'skewX', 'deg', 0],
+  ['skewY', 'skewY', 'deg', 0],
+];
+
+/** `[keyframe property, size axis]` — grouped into one `translate3d()`. */
+const TRANSLATES: ReadonlyArray<readonly ['x' | 'y' | 'z', keyof ElementSize]> = [
+  ['x', 'width'],
+  ['y', 'height'],
+  ['z', 'width'],
+];
+
+const UNIT_CONVERTERS: Record<string, (value: number, size: number) => number> = {
+  '%': (value, size) => (value * size) / 100,
+  vh: (value) => (value * window.innerHeight) / 100,
+  vw: (value) => (value * window.innerWidth) / 100,
+  vmin: (value) => (value * Math.min(window.innerWidth, window.innerHeight)) / 100,
+  vmax: (value) => (value * Math.max(window.innerWidth, window.innerHeight)) / 100,
+};
+
+function resolveUnit(value: UnitValue | undefined, fallback: number, size: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  const converter = UNIT_CONVERTERS[value[1]];
+  return converter ? converter(value[0], size) : value[0];
+}
+
+function normalize(keyframes: Keyframe[], easing?: EasingFunction | BezierCurve) {
+  const last = Math.max(1, keyframes.length - 1);
+  return keyframes.map(
+    (keyframe, index): NormalizedKeyframe => ({
+      ...keyframe,
+      offset: keyframe.offset ?? index / last,
+      ease: normalizeEasing(keyframe.easing ?? easing),
+      vars: Object.keys(keyframe).filter((key) => key.startsWith('--')),
+    }),
+  );
+}
+
+/**
+ * Compile a keyframe list into the pure function that reads it.
+ *
+ * @returns `(progress, size) => KeyframeStyles`, where `size` resolves the
+ *   `%` unit of the translate axes.
+ */
+export function compile(
+  keyframes: Keyframe[],
+  { easing }: { easing?: EasingFunction | BezierCurve } = {},
+): (progress: number, size: ElementSize) => KeyframeStyles {
+  const normalized = normalize(keyframes, easing);
+
+  return (progress: number, size: ElementSize): KeyframeStyles => {
+    const styles: KeyframeStyles = {
+      transform: '',
+      opacity: '',
+      transformOrigin: '',
+      customProperties: [],
+    };
+
+    if (normalized.length < 2) {
+      return styles;
+    }
+
+    // The segment the progress falls in, the last one included.
+    let index = 1;
+    while (index < normalized.length - 1 && normalized[index].offset <= progress) {
+      index += 1;
+    }
+    const from = normalized[index - 1];
+    const to = normalized[index];
+    const local = to.ease(clamp01(map(progress, from.offset, to.offset, 0, 1)));
+
+    let transform = '';
+    let hasTranslate = false;
+    const translated = TRANSLATES.map(([axis, sizeKey]) => {
+      if (from[axis] !== undefined || to[axis] !== undefined) {
+        hasTranslate = true;
+      }
+      const start = resolveUnit(from[axis], 0, size[sizeKey]);
+      const end = resolveUnit(to[axis], 0, size[sizeKey]);
+      return start + (end - start) * local;
+    });
+    if (hasTranslate) {
+      transform += `translate3d(${translated[0]}px, ${translated[1]}px, ${translated[2]}px) `;
+    }
+
+    for (const [property, cssFunction, unit, defaultValue] of SIMPLE_TRANSFORMS) {
+      if (from[property] === undefined && to[property] === undefined) {
+        continue;
+      }
+      const start = (from[property] as number | undefined) ?? defaultValue;
+      const end = (to[property] as number | undefined) ?? defaultValue;
+      transform += `${cssFunction}(${start + (end - start) * local}${unit}) `;
+    }
+    styles.transform = transform.trimEnd();
+
+    if (from.opacity !== undefined || to.opacity !== undefined) {
+      const start = from.opacity ?? 1;
+      const end = to.opacity ?? 1;
+      styles.opacity = String(start + (end - start) * local);
+    }
+
+    if (to.transformOrigin !== undefined) {
+      styles.transformOrigin = to.transformOrigin;
+    }
+
+    for (const name of from.vars) {
+      const start = from[name as CSSCustomPropertyName] as number;
+      const end = (to[name as CSSCustomPropertyName] as number | undefined) ?? start;
+      styles.customProperties.push([name, String(start + (end - start) * local)]);
+    }
+
+    return styles;
+  };
+}
+
+/**
+ * Apply a style patch. Meant to be called from the scheduler's `write`
+ * phase — it does no scheduling of its own.
+ */
+export function applyStyles(el: HTMLElement, styles: KeyframeStyles): void {
+  el.style.transform = styles.transform;
+  el.style.opacity = styles.opacity;
+  el.style.transformOrigin = styles.transformOrigin;
+  for (const [name, value] of styles.customProperties) {
+    el.style.setProperty(name, value);
+  }
+}

--- a/packages/v4/migration/utils/math.ts
+++ b/packages/v4/migration/utils/math.ts
@@ -1,0 +1,57 @@
+/**
+ * The five math helpers the ported components actually reach for, copied
+ * verbatim from `@studiometa/js-toolkit/utils/math`. v4 ships no `utils`
+ * yet; this file is the minimum, not a port of the library.
+ */
+
+/**
+ * Clamp a value in a given range.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  if (min < max) {
+    return value < min ? min : value > max ? max : value;
+  }
+  return value < max ? max : value > min ? min : value;
+}
+
+/**
+ * Clamp a value in the 0–1 range.
+ */
+export function clamp01(value: number): number {
+  return clamp(value, 0, 1);
+}
+
+/**
+ * Map a value from one range onto another.
+ */
+export function map(
+  value: number,
+  inputMin: number,
+  inputMax: number,
+  outputMin: number,
+  outputMax: number,
+): number {
+  return ((value - inputMin) * (outputMax - outputMin)) / (inputMax - inputMin) + outputMin;
+}
+
+/**
+ * Interpolate a ratio between two bounds.
+ */
+export function lerp(min: number, max: number, ratio: number): number {
+  return (1 - ratio) * min + ratio * max;
+}
+
+/**
+ * Next damped value for a given factor, snapping to the target once it is
+ * within `precision`.
+ */
+export function damp(
+  targetValue: number,
+  currentValue: number,
+  factor = 0.5,
+  precision = 0.01,
+): number {
+  return Math.abs(targetValue - currentValue) < precision
+    ? targetValue
+    : currentValue + (targetValue - currentValue) * factor;
+}

--- a/packages/v4/migration/utils/transition.ts
+++ b/packages/v4/migration/utils/transition.ts
@@ -1,0 +1,122 @@
+import { nextFrame } from '../../src/index.js';
+
+/**
+ * The `transition` helper, ported from
+ * `@studiometa/js-toolkit/utils/css/transition`.
+ *
+ * It is the Vue `<transition>` recipe: apply the `from` state, wait a frame,
+ * swap to `to` with the `active` state applied, resolve on `transitionend`.
+ * Both the class form and the inline-style form are kept because
+ * `AccordionItem` needs the style one (it animates a measured pixel height)
+ * and the `Transition` component needs the class one.
+ */
+
+export type ClassesOrStyles = string | string[] | Partial<CSSStyleDeclaration>;
+
+export interface TransitionStyles {
+  from?: ClassesOrStyles;
+  active?: ClassesOrStyles;
+  to?: ClassesOrStyles;
+}
+
+interface TransitionState {
+  isTransitioning: boolean;
+  onEnd: (() => void) | null;
+}
+
+const states = new WeakMap<HTMLElement, TransitionState>();
+
+function stateFor(el: HTMLElement): TransitionState {
+  let state = states.get(el);
+  if (!state) {
+    state = { isTransitioning: false, onEnd: null };
+    states.set(el, state);
+  }
+  return state;
+}
+
+function toClassList(value: string | string[]): string[] {
+  return (Array.isArray(value) ? value : value.split(' ')).filter(Boolean);
+}
+
+export function setClassesOrStyles(
+  el: HTMLElement,
+  value: ClassesOrStyles | undefined,
+  method: 'add' | 'remove' = 'add',
+): void {
+  if (!value) {
+    return;
+  }
+  if (typeof value === 'string' || Array.isArray(value)) {
+    el.classList[method](...toClassList(value));
+    return;
+  }
+  for (const [property, propertyValue] of Object.entries(value)) {
+    // Removing an inline style means resetting it, not deleting the key.
+    el.style[property as never] = (method === 'add' ? propertyValue : '') as never;
+  }
+}
+
+function hasTransition(el: HTMLElement): boolean {
+  const { transitionDuration } = window.getComputedStyle(el);
+  return Boolean(transitionDuration) && transitionDuration !== '0s';
+}
+
+function end(el: HTMLElement, classesOrStyles: TransitionStyles, mode: 'keep' | 'remove'): void {
+  const state = stateFor(el);
+  if (state.onEnd) {
+    el.removeEventListener('transitionend', state.onEnd);
+  }
+  if (mode === 'remove') {
+    setClassesOrStyles(el, classesOrStyles.to, 'remove');
+  }
+  setClassesOrStyles(el, classesOrStyles.active, 'remove');
+  state.isTransitioning = false;
+  state.onEnd = null;
+}
+
+/**
+ * Run a CSS transition on an element.
+ *
+ * @param mode Whether the `to` state is kept or removed at the end.
+ */
+export async function transition(
+  el: HTMLElement,
+  nameOrStyles: string | TransitionStyles,
+  mode: 'keep' | 'remove' = 'remove',
+): Promise<void> {
+  const classesOrStyles: TransitionStyles =
+    typeof nameOrStyles === 'string'
+      ? {
+          from: `${nameOrStyles}-from`,
+          active: `${nameOrStyles}-active`,
+          to: `${nameOrStyles}-to`,
+        }
+      : { from: '', active: '', to: '', ...nameOrStyles };
+
+  const state = stateFor(el);
+  if (state.isTransitioning) {
+    end(el, classesOrStyles, 'remove');
+  }
+
+  state.isTransitioning = true;
+  setClassesOrStyles(el, classesOrStyles.from);
+  await nextFrame();
+  setClassesOrStyles(el, classesOrStyles.active);
+
+  await new Promise<void>((resolve) => {
+    if (hasTransition(el)) {
+      state.onEnd = () => resolve();
+      el.addEventListener('transitionend', state.onEnd);
+    }
+    setClassesOrStyles(el, classesOrStyles.from, 'remove');
+    setClassesOrStyles(el, classesOrStyles.to);
+    nextFrame().then(() => {
+      if (!state.onEnd) {
+        resolve();
+      }
+    });
+  });
+
+  end(el, classesOrStyles, mode);
+}

--- a/packages/v4/migration/utils/uid.ts
+++ b/packages/v4/migration/utils/uid.ts
@@ -1,0 +1,14 @@
+let count = 0;
+
+/**
+ * A unique, stable id for an instance.
+ *
+ * v3's `Base` gives every instance a `$id` (`<Name>-<random>`), which the
+ * ARIA wiring of `AccordionItem` and the `aria-label` of `SliderItem` both
+ * rely on. v4's `Base` has no such property, so components that need one
+ * mint it themselves.
+ */
+export function uid(prefix: string): string {
+  count += 1;
+  return `${prefix}-${count}`;
+}

--- a/packages/v4/tsconfig.json
+++ b/packages/v4/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "types": []
   },
-  "include": ["src/**/*.ts", "demo/**/*.ts"]
+  "include": ["src/**/*.ts", "demo/**/*.ts", "migration/**/*.ts"]
 }

--- a/packages/v4/vitest.config.js
+++ b/packages/v4/vitest.config.js
@@ -5,7 +5,7 @@ import { decorators } from './vite-plugin-decorators.js';
 export default defineConfig({
   plugins: [decorators()],
   test: {
-    include: ['src/**/*.spec.ts'],
+    include: ['src/**/*.spec.ts', 'migration/**/*.spec.ts'],
     browser: {
       enabled: true,
       provider: playwright(),


### PR DESCRIPTION
A **migration feasibility test**, not a component library. Four families ported onto the v4 prototype to find out what migrating @studiometa/ui actually costs. The deliverable is [`packages/v4/migration/REPORT.md`](https://github.com/studiometa/js-toolkit/blob/feature/v4-ui-migration/packages/v4/migration/REPORT.md); the code exists to make the report honest.

Chosen because each leans on a part of v3 that v4 changed: **Accordion** (the `$children` coordinator, option forwarding, ARIA), **Dialog** (focus trap, `inert`, escape, scroll lock), **ScrollAnimation** (the single real consumer of `animate`), **Slider** (the `connectChildren` handshake that motivated the whole data-sharing design).

## The verdict

**Behaviour ports mechanically; wiring is a rewrite.** The split is identical across all four families.

- **~70 % mechanical** — everything a component does to its own DOM. `AccordionItem`'s height animation and ARIA, `Dialog`'s open/close ordering, `Slider`'s geometry, `AbstractScrollAnimation`'s play-range maths came over unchanged.
- **~30 % rewrite** — everything about how a component reaches another component. Not renaming: the topology moved from parent-owned to DOM-observed, so code that assumed mount ordering has to be re-thought.

It pays for itself: **−37 % lines** (2326 → 1470), one whole base class deleted (`AbstractSliderChild`, 143 lines), plus ui's `ViewTransition/scheduler.ts` (108 lines, now in core) and `withMountWhenInView` (109 lines, now `config.mountStrategy`). **Nothing in the sample was unportable.**

A real bug disappears on the way: pressing Escape closes a native `<dialog>` behind v3's back, so its leave transitions never ran and the scroll lock stayed on. In v4 the bubbling `cancel` event makes it a two-line handler, with a test.

## The ten gaps — the actual value of this exercise

Ordered by cost; full detail in the report.

1. **A service subscription cannot be suspended within a mount cycle.** v3 has `$services.enable('ticked')`/`disable`; v4 subscribes in `mounted()` and unsubscribes in `$destroy()`, with nothing between. Two of four components needed it and both abandoned `withRaf` for hand-rolled start/stop — so **v4's "no permanent rAF loop" promise is false on any page with a slider or a scroll animation**.
2. **`$options` is read-only** and several ui components write to it.
3. **`$inject()` has no optional, synchronous or cancellable form** — a control with no provider waits forever, and a destroyed instance leaks its pending request.
4. **provide/inject carries a value but no owner surface.** `DESIGN.md` §5 promises `expose`; `context.ts` ships `Signal<T>` only, so a control still reaches its coordinator through `$closest()` for commands. **The most concrete blocker for the thirteen coordinators.**
5. **`$destroy()` cancels pending scheduler tasks *after* running the cleanups**, so a cleanup that schedules `$write()` to reset styles is cancelled immediately.
6. No `$id`. 7. No per-class instance registry. 8. **`Object`/`Array` option defaults are shared between instances** — a latent cross-instance bug, not just a migration cost. 9. No `merge` on options. 10. No `utils` port.

## What `animate` is actually for

ScrollAnimation is its only real consumer in ui, and it uses exactly one method — `progress()`. It never plays. It needs a **keyframes → styles interpolator**, not a player: ~120 lines rather than the 719 of `animate` + `tween` behind it, with no scheduling of its own. That also makes the timeline cheaper — all targets compute in one `read` and their writes run in one `write`, instead of 2N round trips with another nested pair inside `animate`.

## Verification

- `npx tsgo --noEmit -p .` clean, `npx oxlint .` 0/0, prettier clean
- **145 tests** in headless Chromium — 104 pre-existing, all still passing, plus 41 new

`tsconfig.json` and `vitest.config.js` were extended so `migration/**` is typechecked and linted as strictly as `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU