### PR TITLE
Close four v4 gaps the ui migration test exposed

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -56,7 +56,7 @@ class TodoCount extends Base {
 
 - The cleanup lives in the same closure as the resource it releases: no instance fields, no paired `destroyed()` boilerplate, symmetry guaranteed per mount cycle — which matters once `data-mount` strategies remount the same instance repeatedly.
 - If an async `mounted()` resolves after the instance was destroyed, the cleanup runs immediately instead of leaking.
-- Two cleanup scopes follow from the lifecycle model: `mounted()` returns are **destroy-scoped** (per cycle); constructor-time registrations (`$provide`, `$watchChildren`, `$inject`) are **terminate-scoped** (instance lifetime).
+- Two cleanup scopes follow from the lifecycle model: `mounted()` returns are **destroy-scoped** (per cycle), and so is a pending `$inject()` request — `mounted()` re-runs on remount, which re-issues it, and a destroyed instance must not sit in the context module's pending set forever. Constructor-time registrations that outlive a cycle (`$provide`, `$watchChildren`) are **terminate-scoped** (instance lifetime).
 - The hook keeps its `mounted` name — "setup" in Vue means "runs before mount", which is not what this is, and `mounted()` stays familiar to v3 authors. `destroyed()`/`terminated()` hooks remain for cases that do not fit the returned-cleanup shape.
 - `config.components` loses its ownership meaning. Two jobs remain: register the listed classes when the parent registers, and provide the name set for `on<Child><Event>` resolution.
 - `$parent`, `$children`, `$root`, and `createApp` are removed. `$query()` / `$closest()` (shipped in 3.x) are the replacements.
@@ -92,6 +92,22 @@ The two remaining regressions are understood rather than outstanding. `$emit` pa
 ### The public surface is typed, and free
 
 `Base` takes an optional props type — `class Slider extends Base<{ $refs: …; $options: …; $emits: … }>`. It types `$refs` and `$options` (no more casting on access) and checks `$emit()`'s event names and payloads. `$emits` is the successor to v3's runtime `config.emits`: it keeps the documentation value of declaring what a component dispatches, with nothing left in the bundle.
+
+### Option defaults belong to the instance, and may be factories
+
+`$options` reads its `data-option-*` attribute on every access — an attribute is the source of truth, and stays live. A **default** is the opposite kind of value: it is not in the DOM, so it belongs to the instance that reads it.
+
+```js
+options: {
+  speed: { type: Number, default: 1 },
+  tween: { type: Object, default: () => ({ ease: 'linear' }) },
+}
+```
+
+- **`default` is a value or a factory.** `Function` is not an `OptionType`, so `typeof definition.default === 'function'` unambiguously means factory. The types require the factory form for `Array` and `Object`, because a literal there would live on the class — the shape Vue's `data()` and its object-prop defaults enforce for exactly the same reason.
+- **Built once per instance, then memoised.** Repeated reads hand back the same object, so `this.$options.list.push(x)` persists and two instances of one component never share — and corrupt — the same default. `Array` and `Object` with no declared default memoise an empty one per instance, for the same reason. Primitive defaults are unaffected.
+- **The factory is lazy**: nothing is built for an option that is never read, and a component whose attribute is present never runs its factory at all.
+- Written without types (the no-build path), a literal object or array default is copied per instance rather than shared. A mutation of a value **parsed from an attribute** is not kept, on the other hand: the attribute is re-read and re-parsed on the next access, which is what keeps options live.
 
 ## 2. One registry
 
@@ -195,9 +211,28 @@ The initial sweep is deferred to a microtask: `$watchChildren` is typically call
 Advertisement solves "who is there", not "what is the current value". For continuous shared state, v4 ships a provide/inject primitive modeled on Vue:
 
 - Typed injection key (no string collisions).
-- Reactive value signal (live reference, never serialized).
 - Subtree scope with nearest-provider-wins shadowing.
-- Optionally exposes a curated owner surface (`expose` pattern) instead of the raw instance.
+- **The value is provided verbatim** — nothing is wrapped, so the key's type is the contract end to end.
+- Which is what makes the curated owner surface (`expose` pattern) expressible: state to read, commands to call, and nothing else of the coordinator.
+
+```ts
+// The coordinator exposes what a control may ask for.
+api = this.$provide(SliderContext, {
+  state: new Signal({ index: 0, total: 0 }), // what changes
+  goNext: () => this.goNext(), // what a control may command
+});
+```
+
+A reactive value is a provided `Signal`; a command surface is a provided object; both together is an object holding Signals. Auto-wrapping every value in a `Signal` — the first shape this took — made the third case impossible, and a control that needs `goNext()` then has only one way left to reach it: `$closest('Slider')`, which is precisely the coupling the primitive exists to remove. An event and a command are both legitimate and not interchangeable: `$emit` says "this happened" upward, an exposed method says "do this" to a known owner.
+
+Injection has two forms, and the difference is what the caller does about absence:
+
+| form               | resolves                             | when nothing provides                                                                     |
+| ------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `$inject(key)`     | a promise, `await` it in `mounted()` | **never settles** — deliberate: order independence means a missing provider is "not yet". |
+| `$injectSync(key)` | the value, synchronously             | `undefined` — the caller falls back, does nothing, or degrades.                           |
+
+`$injectSync` costs nothing extra: the context request is answered synchronously when a provider is listening, so the sync form is that same round trip without the promise. It is the form a click handler or a keyboard shortcut wants — an answer now or not at all. The async form's pending request is **destroy-scoped**: a destroyed instance leaves nothing in the module's pending set, and `mounted()` running again on remount re-issues it with nothing to re-declare. (The `@inject` field decorator requests once, at construction, so a field left unresolved through a destroy is not re-requested; a consumer that may wait through several cycles calls `$inject()` from `mounted()`.)
 
 Mechanics follow the WICG community context protocol: the consumer dispatches a bubbling `context-request` event with a key and callback; the nearest mounted provider answers, and replays to late requesters / re-announces on late provider mount. This fixes both criticals from the earlier `withStore` design: resolution goes through the DOM event path instead of attribute walking, and replay happens only after the provider is mounted and initialized.
 
@@ -277,6 +312,7 @@ const unsubscribe = scheduler.tick(({ time, delta }) => { … });
 
 - Tick callbacks run **at the start of the flush, before `read`**, so anything they schedule belongs to the same frame. That is what preserves v3's `RafService` contract without a second loop: the callback measures in `read`, the render function it returns mutates in `write`, once, before paint.
 - The subscription is the only handle — no keys, no `remove(key)` — and it is what keeps the loop alive. `#schedule()` is called again at the end of a flush when an in-frame queue is non-empty **or** a tick subscriber remains, so the rAF loop stops on its own once the last one leaves. This answers the "idle-frame behavior" open point below: there is no permanent loop. Pending `background` work is deliberately not part of that condition — it drains on its own turns and never holds a frame open.
+- That property is only true if a component can actually let go **within** a mount cycle, which is what the services' `manual` subscriptions (§8) are for. A component holding `ticked()` for the lifetime of the page would make "no permanent rAF loop" false on any page with a slider or a scroll animation.
 - Tick subscribers are **not queued work**, so `whenIdle()` ignores them. A page with a live scroll animation would otherwise never be idle, and the test helper `settle()` would never return.
 - A throwing tick callback is reported and skipped, never unsubscribed: the subscription belongs to whoever created it, not to the frame that broke.
 
@@ -311,6 +347,18 @@ A service is a shared source of props components subscribe to: `ticked`, `scroll
 - **Scoped to a target.** `useScroll(target?)` takes an element or the window, `useResize(target?)` an element, `useDrag(el)` its element; `useWindowScroll()` and `useWindowSize()` name the default cases, the split VueUse, solid-primitives, react-use and runed all make. `useRaf()` and `usePointer()` have nothing to scope — the frame is the clock and the pointer is read from the window.
 - **One instance per target,** keyed in a `WeakMap` by `perTarget()`. This is lifecycle bookkeeping rather than throughput: reference counting only means something against a target, so the last subscriber of one element must release that element's observer and leave the others running. Sharing one observer across targets was measured indifferent — the widespread claim traces to a single 2017 measurement, and 500 idle observers now cost ~0.02 ms/frame in total — so nothing tries to group them.
 - **Bound per mount cycle, by a mixin.** `withRaf`/`withScroll`/`withResize`/`withPointer`/`withDrag` override `mounted()`, subscribe the component's `ticked`/`scrolled`/`resized`/`moved`/`dragged` method, and hand the unsubscribe back as a cleanup — so `$destroy()` releases it and a remount subscribes again, with `Base` knowing nothing about services. A hook is sugar for the default target; any other target is an option of the mixin (`target`, `hook`) or an explicit `useX(target).add(…)` in `mounted()`. The mixin is the primitive because it needs no build step; `@withScroll()` is the decorator sugar over it, and both are tree-shakeable: an unimported service cannot make a hook silently do nothing.
+- **Suspendable within a cycle — `{ manual: true }` and the v3 verbs.** A mount cycle is the right span for most subscriptions and the wrong one for a component that needs the frame loop only while something settles. `manual` declares the hook without subscribing it, and the component owns the span:
+
+  ```js
+  class SliderItem extends withRaf(Base, { manual: true }) {
+    ticked() { … }                   // declared, not subscribed yet
+    onIndexChange() { this.$enable('ticked'); }
+    onSettled() { this.$disable('ticked'); }
+  }
+  ```
+
+  `$enable`/`$disable` are v3's `$services.enable('ticked')`/`.disable('ticked')` renamed onto the instance, so migrating a component is a rename. The mixin keeps a per-instance `hook → unsubscribe` map filled at construction, which is what lets one call reach the right layer when mixins are stacked and what makes `$enable` idempotent — repeated calls cannot produce two subscriptions. Both verbs are safe before mount and after destroy; everything is released on `$destroy()` whichever side subscribed it, and `$enable` on a terminated instance is a no-op rather than a subscription nothing would release. Reference counting does the rest: a suspended service with no other subscriber genuinely stops, frame loop included (asserted in `mixin.spec.ts` by watching `requestAnimationFrame`).
+
 - **No loops of their own.** `RafService` and the drag inertia subscribe to `scheduler.tick()`; `ScrollService` coalesces its events into one `read` per frame instead of debouncing; `ResizeService` is a `ResizeObserver`, which also means a subscriber is told the current size on subscribe rather than on the next resize. `RafService` collects the render functions its callbacks return itself — the shared primitive fans props out and expects nothing back.
 - **Props are flat, one per axis.** `ScrollProps` is `x`/`y`, `changedX`/`changedY`, `lastX`/`lastY`, `deltaX`/`deltaY`, `maxX`/`maxY`, `progressX`/`progressY`, `isUp`/`isRight`/`isDown`/`isLeft` — v3's spelling exactly, so a ported handler reads identically. The grouped objects (`last`, `delta`, `max`, `progress`, `direction`, `changed`) are gone, and with them the `ScrollDirection*` unions: v3 shipped both shapes, v4 ships one. `PointerProps` and `DragProps` follow the same `<name>X`/`<name>Y` convention, which flattens `origin`, `distance` and `final` too. `ResizeProps` was already flat. A handler destructures what it uses — `scrolled({ deltaY, isDown })` — instead of reaching through a group.
 - **What the simplification dropped.** `PointerService` is pointer-events-only and viewport-relative (v3 branched on `TouchEvent` and took a target element); `ResizeService` keeps `width`/`height`/`ratio`/`orientation`/`breakpoint` and drops `breakpoints`/`activeBreakpoints`; `DragService` drops `props.MODES` (the `DragMode` union types it) and fixes the `dragTreshold` spelling.

--- a/packages/v4/demo/components/Slider.ts
+++ b/packages/v4/demo/components/Slider.ts
@@ -1,17 +1,28 @@
-import { Base, createContext, type DelegatedEvent, type ScheduledTask } from '../../src/index.js';
+import {
+  Base,
+  Signal,
+  createContext,
+  type DelegatedEvent,
+  type ScheduledTask,
+} from '../../src/index.js';
 
 /**
  * Slider-lite — a reimplementation of the @studiometa/ui Slider family on
  * the v4 model. This is the component whose `createStorage` store and
  * two-sided `connectChildren`/`__connect` handshake motivated the whole
- * data-sharing design: here the shared state is one provided reactive signal.
+ * data-sharing design: here the shared state and the commands travel through
+ * one provided owner surface.
  *
  * - Scrolling uses native CSS scroll-snap + `scrollIntoView` — no math.
- * - `Slider` provides `{ index, total }` through `SliderContext`.
- * - `SliderCount` injects the signal and subscribes: mount order does not
- *   matter, no handshake, no declaration.
+ * - `Slider` provides `{ state, goTo, goToItem }` through `SliderContext`:
+ *   a `Signal` for what changes, methods for what a control may ask for.
+ * - `SliderCount` injects the surface and subscribes to `state`: mount order
+ *   does not matter, no handshake, no declaration.
+ * - `SliderItem` calls `goToItem()` on click through `$injectSync` — a
+ *   command surface instead of a `$closest('Slider')` reach-back.
  * - `SliderBtn` emits a bubbling `slide` event; `Slider` catches it through
- *   delegation (`onSliderBtnSlide`).
+ *   delegation (`onSliderBtnSlide`). Both directions are legitimate: an
+ *   event says "this happened", a command says "do this".
  * - `SliderItem`s are tracked with `$watchChildren`: add or remove a slide
  *   in the DOM and the count updates.
  */
@@ -20,10 +31,26 @@ export interface SliderState {
   total: number;
 }
 
-export const SliderContext = createContext<SliderState>('slider-state');
+/**
+ * The curated surface the coordinator exposes — state to read, commands to
+ * call. Nothing else of the `Slider` is reachable through it.
+ */
+export interface SliderApi {
+  state: Signal<SliderState>;
+  goTo(index: number): void;
+  goToItem(item: SliderItem): void;
+}
+
+export const SliderContext = createContext<SliderApi>('slider');
 
 export class SliderItem extends Base {
   static config = { name: 'SliderItem' };
+
+  // A click must be answered now, so the surface is resolved synchronously:
+  // no provider above means no slider to drive, and nothing happens.
+  onClick(): void {
+    this.$injectSync(SliderContext)?.goToItem(this);
+  }
 }
 
 export class SliderBtn extends Base<{
@@ -45,7 +72,7 @@ export class SliderCount extends Base<{ $el: HTMLSpanElement }> {
   static config = { name: 'SliderCount' };
 
   async mounted() {
-    const state = await this.$inject(SliderContext);
+    const { state } = await this.$inject(SliderContext);
     return state.subscribe(
       ({ index, total }) => {
         this.$write(() => {
@@ -68,7 +95,19 @@ export class Slider extends Base<{
 
   index = 0;
 
-  state = this.$provide(SliderContext, { index: 0, total: 0 });
+  // The owner surface: one reactive Signal plus the commands a control is
+  // allowed to call. Provided verbatim, so a consumer gets this object and
+  // nothing more of the coordinator.
+  api = this.$provide<SliderApi>(SliderContext, {
+    state: new Signal<SliderState>({ index: 0, total: 0 }),
+    goTo: (index) => this.goTo(index),
+    goToItem: (item) => {
+      const index = this.items.items.indexOf(item);
+      if (index >= 0) {
+        this.goTo(index);
+      }
+    },
+  });
 
   items = this.$watchChildren<SliderItem>('SliderItem', {
     added: () => this.refresh(),
@@ -152,7 +191,7 @@ export class Slider extends Base<{
   update(): void {
     const total = this.items?.size ?? 0;
     this.index = Math.min(this.index, Math.max(0, total - 1));
-    this.state.value = { index: this.index, total };
+    this.api.state.value = { index: this.index, total };
   }
 
   // Naming the event types `args` from SliderBtn's own `$emits`.

--- a/packages/v4/demo/components/TodoList.ts
+++ b/packages/v4/demo/components/TodoList.ts
@@ -1,10 +1,11 @@
-import { Base, createContext, type DelegatedEvent } from '../../src/index.js';
+import { Base, Signal, createContext, type DelegatedEvent } from '../../src/index.js';
 
 /**
  * The TodoList demo from the playground: registry auto-mount, delegation,
  * `$watchChildren`, provide/inject, and native view transitions.
  */
-export const CountContext = createContext<number>('todo-count');
+// The value travels verbatim, so a reactive count is a provided `Signal`.
+export const CountContext = createContext<Signal<number>>('todo-count');
 
 export class TodoItem extends Base<{
   $refs: { remove: HTMLButtonElement };
@@ -44,7 +45,7 @@ export class TodoList extends Base<{
     components: { TodoItem, TodoCount },
   };
 
-  count = this.$provide(CountContext, 0);
+  count = this.$provide(CountContext, new Signal(0));
 
   items = this.$watchChildren<TodoItem>('TodoItem', {
     added: () => this.sync(),

--- a/packages/v4/demo/index.html
+++ b/packages/v4/demo/index.html
@@ -83,11 +83,19 @@
       <p>
         CSS scroll-snap does the scrolling.
         <code>Slider</code>
-        provides
-        <code>{ index, total }</code>
-        as a reactive signal;
+        provides an owner surface —
+        <code>{ state, goTo, goToItem }</code>
+        — through provide/inject;
         <code>SliderCount</code>
-        injects it — no handshake, no
+        subscribes to
+        <code>state</code>
+        and each slide calls
+        <code>goToItem()</code>
+        on click through
+        <code>$injectSync</code>
+        , so a control drives its coordinator with no
+        <code>$closest</code>
+        , no handshake and no
         <code>connectChildren</code>
         . Buttons emit a bubbling
         <code>slide</code>

--- a/packages/v4/src/Base.spec.ts
+++ b/packages/v4/src/Base.spec.ts
@@ -77,6 +77,127 @@ describe('$options', () => {
     el.setAttribute('data-option-count', '9');
     expect(instance.$options.count).toBe(9);
   });
+
+  it('gives each instance its own defaulted object, declared or not', () => {
+    class Defaulted extends Base<{
+      $options: { tween: Record<string, unknown>; list: unknown[]; bag: Record<string, unknown> };
+    }> {
+      static config = {
+        name: 'Defaulted',
+        options: {
+          // Declared through a factory: called once per instance.
+          tween: { type: Object, default: () => ({ ease: 'linear' }) },
+          // Undeclared: an empty array, still one per instance.
+          list: Array,
+          bag: Object,
+        },
+      };
+    }
+
+    const first = new Defaulted(document.createElement('div'));
+    const second = new Defaulted(document.createElement('div'));
+
+    expect(first.$options.tween).toEqual({ ease: 'linear' });
+    expect(second.$options.tween).toEqual({ ease: 'linear' });
+    // Same value, never the same object: this is the bug that let one
+    // component corrupt every other instance of its class.
+    expect(first.$options.tween).not.toBe(second.$options.tween);
+    expect(first.$options.list).not.toBe(second.$options.list);
+    expect(first.$options.bag).not.toBe(second.$options.bag);
+
+    first.$options.tween.ease = 'ease-out';
+    expect(second.$options.tween).toEqual({ ease: 'linear' });
+  });
+
+  it('memoises the default, so a mutation of it persists on that instance', () => {
+    class Listed extends Base<{ $options: { list: number[]; tween: Record<string, unknown> } }> {
+      static config = {
+        name: 'Listed',
+        options: {
+          list: Array,
+          tween: { type: Object, default: () => ({ ease: 'linear' }) },
+        },
+      };
+    }
+
+    const instance = new Listed(document.createElement('div'));
+
+    // Every read used to build a fresh array, so this push went nowhere.
+    instance.$options.list.push(1, 2);
+    expect(instance.$options.list).toEqual([1, 2]);
+    expect(instance.$options.list).toBe(instance.$options.list);
+
+    instance.$options.tween.ease = 'ease-out';
+    expect(instance.$options.tween).toEqual({ ease: 'ease-out' });
+  });
+
+  it('calls the factory once per instance, lazily', () => {
+    let calls = 0;
+
+    class Lazy extends Base<{ $options: { tween: Record<string, unknown> } }> {
+      static config = {
+        name: 'Lazy',
+        options: {
+          tween: {
+            type: Object,
+            default: () => {
+              calls += 1;
+              return { id: calls };
+            },
+          },
+        },
+      };
+    }
+
+    const first = new Lazy(document.createElement('div'));
+    const second = new Lazy(document.createElement('div'));
+    // Nothing is built before the option is read.
+    expect(calls).toBe(0);
+
+    const read = first.$options.tween;
+    expect(first.$options.tween).toBe(read);
+    expect(calls).toBe(1);
+
+    expect(second.$options.tween).not.toBe(read);
+    expect(calls).toBe(2);
+    expect(second.$options.tween).toEqual({ id: 2 });
+  });
+
+  it('keeps primitive defaults and attribute values as they were', () => {
+    class Mixed extends Base<{
+      $options: { speed: number; label: string; flag: boolean; list: unknown[] };
+    }> {
+      static config = {
+        name: 'Mixed',
+        options: {
+          speed: { type: Number, default: 3 },
+          label: { type: String, default: 'none' },
+          flag: { type: Boolean, default: true },
+          list: { type: Array, default: () => [1] },
+        },
+      };
+    }
+
+    const el = document.createElement('div');
+    const instance = new Mixed(el);
+
+    expect(instance.$options.speed).toBe(3);
+    expect(instance.$options.label).toBe('none');
+    expect(instance.$options.flag).toBe(true);
+    expect(instance.$options.list).toEqual([1]);
+
+    // An attribute is still the source of truth, read on every access.
+    el.setAttribute('data-option-speed', '9');
+    el.setAttribute('data-option-flag', 'false');
+    el.setAttribute('data-option-list', '[2, 3]');
+    expect(instance.$options.speed).toBe(9);
+    expect(instance.$options.flag).toBe(false);
+    expect(instance.$options.list).toEqual([2, 3]);
+
+    // Malformed JSON falls back to the instance's own default.
+    el.setAttribute('data-option-list', '{oops');
+    expect(instance.$options.list).toEqual([1]);
+  });
 });
 
 describe('$el', () => {

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -1,4 +1,4 @@
-import { Signal, injectContext, provideContext, type ContextKey } from './context.js';
+import { injectContext, injectContextSync, provideContext, type ContextKey } from './context.js';
 import { domVersion } from './dom-version.js';
 import { scheduler, type ScheduledTask } from './scheduler.js';
 import type { MountStrategy } from './mount-strategies.js';
@@ -18,7 +18,40 @@ export type OptionType =
   | typeof Array
   | typeof Object;
 
-export type OptionDefinition = OptionType | { type: OptionType; default?: unknown };
+/**
+ * The value an option of a given type holds.
+ */
+type OptionValue<T extends OptionType> = T extends typeof String
+  ? string
+  : T extends typeof Number
+    ? number
+    : T extends typeof Boolean
+      ? boolean
+      : T extends typeof Array
+        ? unknown[]
+        : Record<string, unknown>;
+
+/**
+ * `default` is a value, or a **factory** called once per instance.
+ *
+ * A factory is the only form `Array` and `Object` accept, and the reason is
+ * the bug it prevents: a default declared as `default: {}` lives on the class,
+ * so every instance of the component would read — and mutate — the same
+ * object. `Function` is not an `OptionType`, so a function default is
+ * unambiguously a factory.
+ *
+ *     options: {
+ *       speed: { type: Number, default: 1 },
+ *       tween: { type: Object, default: () => ({ ease: 'linear' }) },
+ *     }
+ */
+type TypedOptionDefinition<T extends OptionType = OptionType> = T extends OptionType
+  ? T extends typeof Array | typeof Object
+    ? { type: T; default?: () => OptionValue<T> }
+    : { type: T; default?: OptionValue<T> | (() => OptionValue<T>) }
+  : never;
+
+export type OptionDefinition = OptionType | TypedOptionDefinition;
 
 export interface BaseConfig {
   name: string;
@@ -258,29 +291,70 @@ function buildRefs(instance: Base): Record<string, HTMLElement | HTMLElement[]> 
   return refs;
 }
 
+/**
+ * Build the live `$options` view.
+ *
+ * Values are read from the `data-option-*` attributes on every access, so an
+ * attribute is always the source of truth. **Defaults belong to the
+ * instance**, not to the class: each one is built once per instance and kept,
+ * which is what makes `this.$options.list.push(x)` persist and what stops two
+ * components from sharing — and corrupting — the same defaulted object.
+ */
 function buildOptions(instance: Base): Record<string, unknown> {
   const options: Record<string, unknown> = {};
   const el = instance.$el;
   for (const [name, definition] of Object.entries(instance.$config.options ?? {})) {
     const type = typeof definition === 'function' ? definition : definition.type;
-    const defaultValue = typeof definition === 'function' ? undefined : definition.default;
+    const declared = typeof definition === 'function' ? undefined : definition.default;
     const attribute = `data-option-${kebabCase(name)}`;
+
+    // Built on first read and memoised, so repeated reads hand back the same
+    // object and a mutation of it sticks — for this instance only.
+    let memoized: unknown;
+    let isMemoized = false;
+    const defaultValue = (): unknown => {
+      if (!isMemoized) {
+        isMemoized = true;
+        memoized = buildDefault();
+      }
+      return memoized;
+    };
+    const buildDefault = (): unknown => {
+      // `Function` is not an option type, so a callable default is a factory.
+      if (typeof declared === 'function') {
+        return (declared as () => unknown)();
+      }
+      if (declared !== null && typeof declared === 'object') {
+        // The types ask for a factory here; the no-build path has no types,
+        // so a literal object or array is copied rather than shared.
+        return Array.isArray(declared)
+          ? [...declared]
+          : { ...(declared as Record<string, unknown>) };
+      }
+      if (declared !== undefined) {
+        return declared;
+      }
+      // An undeclared object or array default is still the instance's own.
+      if (type === Array) return [];
+      if (type === Object) return {};
+      return undefined;
+    };
+
     Object.defineProperty(options, name, {
       enumerable: true,
       get() {
         if (type === Boolean) {
           if (!el.hasAttribute(attribute)) {
-            return defaultValue ?? false;
+            return defaultValue() ?? false;
           }
           return el.getAttribute(attribute) !== 'false';
         }
         const raw = el.getAttribute(attribute);
         if (raw === null) {
-          if (defaultValue !== undefined) return defaultValue;
+          const value = defaultValue();
+          if (value !== undefined) return value;
           if (type === Number) return 0;
           if (type === String) return '';
-          if (type === Array) return [];
-          if (type === Object) return {};
           return undefined;
         }
         if (type === Number) {
@@ -290,7 +364,7 @@ function buildOptions(instance: Base): Record<string, unknown> {
           try {
             return JSON.parse(raw);
           } catch {
-            return defaultValue ?? (type === Array ? [] : {});
+            return defaultValue();
           }
         }
         return raw;
@@ -408,6 +482,11 @@ export class Base<T extends BaseProps = BaseProps> {
 
   get $isMounted(): boolean {
     return this.#isMounted;
+  }
+
+  /** Whether `$terminate()` has run — the instance never mounts again. */
+  get $isTerminated(): boolean {
+    return this.#isTerminated;
   }
 
   constructor(el: HTMLElement) {
@@ -638,21 +717,58 @@ export class Base<T extends BaseProps = BaseProps> {
   }
 
   /**
-   * Provide a reactive signal to the subtree (nearest provider wins).
+   * Provide a value to the subtree — nearest provider wins, and the value is
+   * provided **verbatim**: what is handed over is what a consumer resolves.
+   *
+   * Reactive state is a `Signal`; a curated owner surface is an object of
+   * commands (the `expose` pattern), which is how a control reaches its
+   * coordinator without `$closest()` and the coupling that comes with it:
+   *
+   *     api = this.$provide(SliderContext, {
+   *       state: new Signal({ index: 0, total: 0 }),
+   *       goNext: () => this.goNext(),
+   *     });
+   *
+   * The provider is instance-lifetime: it survives destroy/mount cycles and
+   * is disposed on `$terminate()`.
    */
-  $provide<T>(key: ContextKey<T>, value: T | Signal<T>): Signal<T> {
-    const { signal, dispose } = provideContext(this.$el, key, value);
+  $provide<V>(key: ContextKey<V>, value: V): V {
+    const { dispose } = provideContext(this.$el, key, value);
     this.#terminateCallbacks.push(dispose);
-    return signal;
+    return value;
   }
 
   /**
-   * Resolve the nearest provided signal, now or when a provider appears.
+   * Resolve the nearest provided value, now or when a provider appears.
+   *
+   * **The promise never settles while no provider exists** — deliberately:
+   * order independence is the whole point, and a consumer mounting before its
+   * provider must not be told "absent" by an ordering accident. Use
+   * `$injectSync()` when an answer is needed now.
+   *
+   * The pending request is destroy-scoped, so a destroyed instance leaves
+   * nothing behind — and `mounted()` runs again on remount, which re-issues
+   * the request naturally.
    */
-  $inject<T>(key: ContextKey<T>): Promise<Signal<T>> {
+  $inject<V>(key: ContextKey<V>): Promise<V> {
     const { promise, cancel } = injectContext(this.$el, key);
-    this.#terminateCallbacks.push(cancel);
+    this.#destroyCallbacks.push(cancel);
     return promise;
+  }
+
+  /**
+   * Resolve the nearest provided value — now, or not at all.
+   *
+   * Nothing is queued and nothing is replayed: `undefined` means no provider
+   * is listening above this element at this moment, which a control can act
+   * on instead of waiting:
+   *
+   *     onClick() {
+   *       this.$injectSync(SliderContext)?.goToItem(this);
+   *     }
+   */
+  $injectSync<V>(key: ContextKey<V>): V | undefined {
+    return injectContextSync(this.$el, key);
   }
 
   /** Schedule a DOM read; canceled automatically when the instance unmounts. */

--- a/packages/v4/src/context.spec.ts
+++ b/packages/v4/src/context.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Base } from './Base.js';
 import { Signal, createContext, provideContext } from './context.js';
 import { registerComponent } from './registry.js';
-import { renderTodoList, resetDom, settle } from './test-utils.js';
+import { getInstance, renderTodoList, resetDom, settle } from './test-utils.js';
 
 afterEach(resetDom);
 
@@ -31,7 +31,7 @@ describe('Signal', () => {
 
 describe('provide/inject', () => {
   it('resolves for a consumer that mounts before its provider', async () => {
-    const Key = createContext<string>('late-provider');
+    const Key = createContext<Signal<string>>('late-provider');
     const received: string[] = [];
 
     class LateConsumer extends Base {
@@ -70,7 +70,7 @@ describe('provide/inject', () => {
     const { promise } = await import('./context.js').then(({ injectContext }) =>
       injectContext(consumer, Key),
     );
-    await expect(promise).resolves.toHaveProperty('value', 'inner');
+    await expect(promise).resolves.toBe('inner');
   });
 
   it('ignores requests for another key', async () => {
@@ -85,8 +85,8 @@ describe('provide/inject', () => {
 
     const { injectContext } = await import('./context.js');
     let resolved: unknown;
-    injectContext(consumer, Wanted).promise.then((signal) => {
-      resolved = signal.value;
+    injectContext(consumer, Wanted).promise.then((value) => {
+      resolved = value;
     });
     await settle();
     expect(resolved).toBeUndefined();
@@ -94,6 +94,138 @@ describe('provide/inject', () => {
     provideContext(host, Wanted, 'yes');
     await settle();
     expect(resolved).toBe('yes');
+  });
+
+  it('provides the value verbatim, wrapping nothing', async () => {
+    const Key = createContext<{ label: string }>('verbatim');
+    const host = document.createElement('div');
+    const consumer = document.createElement('span');
+    host.append(consumer);
+    document.body.append(host);
+
+    const provided = { label: 'exposed' };
+    const { value } = provideContext(host, Key, provided);
+    expect(value).toBe(provided);
+
+    const { injectContext } = await import('./context.js');
+    await expect(injectContext(consumer, Key).promise).resolves.toBe(provided);
+  });
+
+  it('exposes an owner surface a consumer calls without $closest', async () => {
+    interface CounterApi {
+      state: Signal<number>;
+      increment(): void;
+    }
+    const Key = createContext<CounterApi>('counter-api');
+
+    class Counter extends Base {
+      static config = { name: 'Counter' };
+
+      value = 0;
+
+      api = this.$provide<CounterApi>(Key, {
+        state: new Signal(0),
+        increment: () => {
+          this.value += 1;
+          this.api.state.value = this.value;
+        },
+      });
+    }
+
+    class CounterBtn extends Base {
+      static config = { name: 'CounterBtn' };
+
+      seen: number[] = [];
+
+      async mounted() {
+        const { state } = await this.$inject(Key);
+        return state.subscribe((value) => this.seen.push(value));
+      }
+
+      // No `$closest('Counter')`, no reach-back into the coordinator: the
+      // command is part of the surface it exposed.
+      onClick(): void {
+        this.$injectSync(Key)?.increment();
+      }
+    }
+
+    registerComponent(Counter);
+    registerComponent(CounterBtn);
+
+    const root = document.createElement('div');
+    root.setAttribute('data-component', 'Counter');
+    root.innerHTML = '<button data-component="CounterBtn">+</button>';
+    document.body.append(root);
+    await settle();
+
+    const counter = getInstance<Counter>(root, 'Counter');
+    const button = root.querySelector('button');
+    const control = getInstance<CounterBtn>(button, 'CounterBtn');
+
+    button?.click();
+    button?.click();
+    await settle();
+
+    expect(counter.value).toBe(2);
+    expect(control.seen).toEqual([1, 2]);
+  });
+
+  it('answers $injectSync now, or not at all', async () => {
+    const Key = createContext<string>('sync');
+
+    class Consumer extends Base {
+      static config = { name: 'SyncConsumer' };
+    }
+
+    const host = document.createElement('div');
+    const el = document.createElement('span');
+    host.append(el);
+    document.body.append(host);
+    const consumer = new Consumer(el).$mount();
+
+    // No provider: the control is told so instead of waiting forever.
+    expect(consumer.$injectSync(Key)).toBeUndefined();
+
+    provideContext(host, Key, 'ready');
+    expect(consumer.$injectSync(Key)).toBe('ready');
+  });
+
+  it('leaves no pending request behind when the consumer is destroyed', async () => {
+    const Key = createContext<string>('destroyed-consumer');
+    const received: string[] = [];
+
+    class Waiting extends Base {
+      static config = { name: 'Waiting' };
+
+      async mounted() {
+        received.push(await this.$inject(Key));
+      }
+    }
+
+    const host = document.createElement('div');
+    const el = document.createElement('span');
+    host.append(el);
+    document.body.append(host);
+
+    const consumer = new Waiting(el).$mount();
+    await settle();
+    expect(received).toEqual([]);
+
+    consumer.$destroy();
+    // The provider appears after the destroy: a request left in the module's
+    // pending set would be replayed here and resolve.
+    const { dispose } = provideContext(host, Key, 'late');
+    await settle();
+    expect(received).toEqual([]);
+
+    // And the scope is right: `mounted()` runs again on remount, so the
+    // injection happens again with nothing to re-declare.
+    consumer.$mount();
+    await settle();
+    expect(received).toEqual(['late']);
+
+    consumer.$terminate();
+    dispose();
   });
 
   it('feeds a component through the provided signal', async () => {

--- a/packages/v4/src/context.ts
+++ b/packages/v4/src/context.ts
@@ -55,13 +55,13 @@ export class Signal<T = unknown> {
 
 interface ContextRequestDetail {
   key: symbol;
-  provide(signal: Signal<unknown>): void;
+  provide(value: unknown): void;
 }
 
 interface PendingRequest {
   el: Element;
   key: symbol;
-  resolve(signal: Signal<unknown>): void;
+  resolve(value: unknown): void;
 }
 
 const pendingRequests = new Set<PendingRequest>();
@@ -70,10 +70,10 @@ function requestContext(request: PendingRequest): boolean {
   let isAnswered = false;
   const detail: ContextRequestDetail = {
     key: request.key,
-    provide(signal) {
+    provide(value) {
       isAnswered = true;
       pendingRequests.delete(request);
-      request.resolve(signal);
+      request.resolve(value);
     },
   };
   request.el.dispatchEvent(new CustomEvent(CONTEXT_REQUEST, { bubbles: true, detail }));
@@ -81,23 +81,32 @@ function requestContext(request: PendingRequest): boolean {
 }
 
 /**
- * Provide a reactive value for the subtree rooted at `el`.
+ * Provide a value for the subtree rooted at `el`.
  * The nearest provider wins, because the consumer's request event stops at
  * the first ancestor that answers.
+ *
+ * **The value is provided verbatim** — nothing is wrapped. What the owner
+ * hands over is exactly what a consumer resolves, so the key's type decides
+ * the shape:
+ *
+ * - reactive state → provide a `Signal`;
+ * - a command surface → provide an object of methods (the `expose` pattern),
+ *   which is what lets a control call its coordinator without reaching back
+ *   through `$closest()`;
+ * - both → provide an object holding Signals.
  */
 export function provideContext<T>(
   el: Element,
   key: ContextKey<T>,
-  value: T | Signal<T>,
-): { signal: Signal<T>; dispose: () => void } {
-  const signal = value instanceof Signal ? value : new Signal(value);
+  value: T,
+): { value: T; dispose: () => void } {
   const onRequest = (event: Event) => {
     const { detail } = event as CustomEvent<ContextRequestDetail>;
     if (detail?.key !== key) {
       return;
     }
     event.stopPropagation();
-    detail.provide(signal as unknown as Signal<unknown>);
+    detail.provide(value);
   };
   el.addEventListener(CONTEXT_REQUEST, onRequest);
 
@@ -113,25 +122,52 @@ export function provideContext<T>(
   }
 
   return {
-    signal,
+    value,
     dispose: () => el.removeEventListener(CONTEXT_REQUEST, onRequest),
   };
 }
 
 /**
- * Resolve the nearest provided signal for `key`, now or when a provider
+ * Resolve the nearest provided value for `key`, now or when a provider
  * appears. Order-independent.
+ *
+ * **The promise never settles while no provider exists.** That is the price
+ * of order independence: a consumer mounting before its provider must not be
+ * told "absent" by an ordering accident. A consumer that needs an answer now
+ * — a click handler, a keyboard shortcut — asks with `injectContextSync()`
+ * and falls back on `undefined`.
  */
 export function injectContext<T>(
   el: Element,
   key: ContextKey<T>,
-): { promise: Promise<Signal<T>>; cancel: () => void } {
+): { promise: Promise<T>; cancel: () => void } {
   let request!: PendingRequest;
-  const promise = new Promise<Signal<T>>((resolve) => {
-    request = { el, key, resolve: resolve as unknown as (signal: Signal<unknown>) => void };
+  const promise = new Promise<T>((resolve) => {
+    request = { el, key, resolve: resolve as (value: unknown) => void };
     if (!requestContext(request)) {
       pendingRequests.add(request);
     }
   });
   return { promise, cancel: () => pendingRequests.delete(request) };
+}
+
+/**
+ * Resolve the nearest provided value for `key` — now, or not at all.
+ *
+ * The context request is answered synchronously when a provider is already
+ * listening, so this is the same round trip as `injectContext()` without the
+ * promise: nothing is queued, nothing is replayed later. `undefined` means
+ * "no provider above this element right now", which a control can act on
+ * (fall back, do nothing) instead of waiting forever.
+ */
+export function injectContextSync<T>(el: Element, key: ContextKey<T>): T | undefined {
+  let resolved: T | undefined;
+  requestContext({
+    el,
+    key,
+    resolve: (value) => {
+      resolved = value as T;
+    },
+  });
+  return resolved;
 }

--- a/packages/v4/src/decorators.spec.ts
+++ b/packages/v4/src/decorators.spec.ts
@@ -6,7 +6,7 @@ import { registerComponents } from './registry.js';
 import { scheduler } from './scheduler.js';
 import { getInstance, resetDom, settle } from './test-utils.js';
 
-const DecoContext = createContext<number>('deco-context');
+const DecoContext = createContext<Signal<number>>('deco-context');
 
 @component({ name: 'DecoChild' })
 class DecoChild extends Base {

--- a/packages/v4/src/decorators.ts
+++ b/packages/v4/src/decorators.ts
@@ -8,7 +8,7 @@ import {
   type HandlerRegistration,
   type WatchChildrenCallbacks,
 } from './Base.js';
-import { Signal, type ContextKey } from './context.js';
+import type { ContextKey } from './context.js';
 import { registerComponent } from './registry.js';
 
 /**
@@ -166,48 +166,53 @@ export function component(config: BaseConfig) {
 }
 
 /**
- * Provide the decorated signal to the subtree (nearest provider wins) — the
- * field-decorator form of `$provide()`:
+ * Provide the decorated field to the subtree (nearest provider wins) — the
+ * field-decorator form of `$provide()`. The value is provided verbatim, so
+ * the field is whatever the key declares: a `Signal` for reactive state, an
+ * object of commands for an owner surface, an object of Signals for both.
  *
  *     class Slider extends Base {
  *       @provide(SliderContext)
- *       state = new Signal({ index: 0, total: 0 });
+ *       api = { state: new Signal({ index: 0, total: 0 }), goNext: () => this.goNext() };
  *     }
- *
- * A plain value is wrapped in a `Signal` automatically.
  */
-export function provide<T>(key: ContextKey<T>): ValueDecorator<Signal<T>> {
+export function provide<T>(key: ContextKey<T>): ValueDecorator<T> {
   return function decorate<This extends Base>(
     _target: unknown,
-    context: ValueDecoratorContext<This, Signal<T>>,
+    context: ValueDecoratorContext<This, T>,
   ) {
-    return withInitializer(context, function initialize(this: This, initial: Signal<T>) {
+    return withInitializer(context, function initialize(this: This, initial: T) {
       return this.$provide(key, initial);
     });
-  } as ValueDecorator<Signal<T>>;
+  } as ValueDecorator<T>;
 }
 
 /**
- * Resolve the nearest provided signal into the decorated field, now or when a
+ * Resolve the nearest provided value into the decorated field, now or when a
  * provider appears — the field stays `undefined` until then (the
  * field-decorator form of `$inject()`, shaped like Lit's `@consume`):
  *
  *     class SliderCount extends Base {
  *       @inject(SliderContext)
- *       state?: Signal<SliderState>;
+ *       accessor api: SliderApi | undefined;
  *     }
+ *
+ * The request is issued once, at construction, and is destroy-scoped like
+ * `$inject()`: a field still unresolved when the instance is destroyed is not
+ * requested again on remount. A consumer that may outlive several cycles
+ * waiting for its provider calls `$inject()` from `mounted()` instead.
  */
-export function inject<T>(key: ContextKey<T>): ValueObserver<Signal<T> | undefined> {
+export function inject<T>(key: ContextKey<T>): ValueObserver<T | undefined> {
   return function decorate<This extends Base>(
     _target: unknown,
-    context: ValueDecoratorContext<This, Signal<T> | undefined>,
+    context: ValueDecoratorContext<This, T | undefined>,
   ): void {
     context.addInitializer(function initialize(this: This) {
-      this.$inject(key).then((signal) => {
-        context.access.set(this, signal);
+      this.$inject(key).then((value) => {
+        context.access.set(this, value);
       });
     });
-  } as ValueObserver<Signal<T> | undefined>;
+  } as ValueObserver<T | undefined>;
 }
 
 /**

--- a/packages/v4/src/index.ts
+++ b/packages/v4/src/index.ts
@@ -20,7 +20,8 @@
  * 7. Lazy, reference-counted services, one instance per observed target —
  *    subscribed by hand, or through the `withRaf`/`withScroll`/`withResize`/
  *    `withPointer`/`withDrag` mixins and their `ticked`, `scrolled`,
- *    `resized`, `moved` and `dragged` hooks, per mount cycle.
+ *    `resized`, `moved` and `dragged` hooks, per mount cycle — or on the
+ *    component's own terms with `{ manual: true }` + `$enable`/`$disable`.
  *
  * Lifecycle: destroy !== terminate !== disconnected.
  * - disconnected (DOM fact) → `$destroy()`: reversible, the instance stays
@@ -58,6 +59,7 @@ export {
   Signal,
   createContext,
   injectContext,
+  injectContextSync,
   provideContext,
   type ContextKey,
 } from './context.js';
@@ -85,6 +87,7 @@ export {
 export {
   createServiceMixin,
   type MixedClass,
+  type ServiceControls,
   type ServiceMixin,
   type ServiceMixinDefinition,
   type ServiceMixinOptions,

--- a/packages/v4/src/services/mixin.spec.ts
+++ b/packages/v4/src/services/mixin.spec.ts
@@ -265,6 +265,132 @@ describe('service mixins', () => {
   });
 });
 
+describe('manual subscriptions', () => {
+  class ManualTicker extends withRaf(Base, { manual: true }) {
+    static config = { name: 'ManualTicker' };
+
+    ticks = 0;
+
+    ticked(): void {
+      this.ticks += 1;
+    }
+  }
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  it('declares the hook without subscribing it, until $enable', async () => {
+    const instance = new ManualTicker(render()).$mount();
+
+    await frames(3);
+    // Declared, not subscribed: `mounted()` left it off.
+    expect(instance.ticks).toBe(0);
+
+    instance.$enable('ticked');
+    await frames(3);
+    expect(instance.ticks).toBeGreaterThan(0);
+
+    const frozen = instance.ticks;
+    instance.$disable('ticked');
+    await frames(3);
+    expect(instance.ticks).toBe(frozen);
+
+    // And it resumes within the same mount cycle.
+    instance.$enable('ticked');
+    await frames(3);
+    expect(instance.ticks).toBeGreaterThan(frozen);
+
+    instance.$terminate();
+  });
+
+  it('cannot subscribe twice, whatever the number of $enable calls', async () => {
+    const instance = new ManualTicker(render()).$mount();
+
+    instance.$enable('ticked');
+    instance.$enable('ticked');
+    instance.$enable('ticked');
+
+    await frames(4);
+    const counted = instance.ticks;
+    // One subscription means at most one tick per frame — three would treble
+    // the count.
+    expect(counted).toBeGreaterThan(0);
+    expect(counted).toBeLessThanOrEqual(6);
+
+    // One `$disable` is enough to release it.
+    instance.$disable('ticked');
+    await frames(3);
+    expect(instance.ticks).toBe(counted);
+
+    instance.$terminate();
+  });
+
+  it('is safe before mount and after destroy, and releases on destroy', async () => {
+    const instance = new ManualTicker(render());
+
+    expect(() => instance.$enable('ticked')).not.toThrow();
+    await frames(2);
+    expect(instance.ticks).toBeGreaterThan(0);
+
+    instance.$mount();
+    instance.$destroy();
+    const frozen = instance.ticks;
+    await frames(3);
+    // Everything is released on destroy, manual or not.
+    expect(instance.ticks).toBe(frozen);
+
+    expect(() => {
+      instance.$disable('ticked');
+      instance.$enable('ticked');
+      instance.$disable('ticked');
+    }).not.toThrow();
+
+    instance.$terminate();
+    const afterTerminate = instance.ticks;
+    // A terminated instance never mounts again, so nothing would release a
+    // new subscription: `$enable` is a no-op rather than a leak.
+    expect(() => instance.$enable('ticked')).not.toThrow();
+    await frames(3);
+    expect(instance.ticks).toBe(afterTerminate);
+  });
+
+  it('stops the frame loop when nothing else needs it', async () => {
+    await settle();
+    const original = globalThis.requestAnimationFrame;
+    let calls = 0;
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      calls += 1;
+      return original.call(globalThis, callback);
+    }) as typeof requestAnimationFrame;
+
+    try {
+      const instance = new ManualTicker(render()).$mount();
+      await sleep(100);
+      // Nothing subscribed, nothing queued: no frame was ever requested.
+      expect(calls).toBe(0);
+
+      instance.$enable('ticked');
+      await sleep(100);
+      expect(calls).toBeGreaterThan(2);
+      expect(instance.ticks).toBeGreaterThan(0);
+
+      instance.$disable('ticked');
+      // Let the frame already requested run out.
+      await sleep(50);
+      const stopped = calls;
+      const ticks = instance.ticks;
+
+      await sleep(150);
+      // The rAF loop is genuinely gone, not merely quiet.
+      expect(calls).toBe(stopped);
+      expect(instance.ticks).toBe(ticks);
+
+      instance.$terminate();
+    } finally {
+      globalThis.requestAnimationFrame = original;
+    }
+  });
+});
+
 describe('service decorators', () => {
   it('is the mixin with a build step', async () => {
     @withRaf()

--- a/packages/v4/src/services/mixin.ts
+++ b/packages/v4/src/services/mixin.ts
@@ -15,6 +15,76 @@ export interface ServiceMixinOptions<Target, Host = Base> {
    * applying the mixin twice with two names subscribes twice.
    */
   hook?: string;
+  /**
+   * Declare the hook without subscribing it: `mounted()` leaves it off, and
+   * the component turns it on and off itself with `$enable(hook)` /
+   * `$disable(hook)`.
+   *
+   * This is what keeps a service honest about doing no work while nobody
+   * needs it — a component that only wants the frame loop while a value
+   * settles releases it as soon as it has, instead of holding the loop open
+   * for the lifetime of the page.
+   */
+  manual?: boolean;
+}
+
+/**
+ * The v3 `$services.enable()` / `.disable()` verbs, on the instance: a
+ * subscription can be suspended and resumed **within** one mount cycle.
+ *
+ * Both are safe before mount and after destroy, and `$enable()` is
+ * idempotent — a hook cannot end up subscribed twice.
+ */
+export interface ServiceControls {
+  /** Subscribe the named hook now, if it is not subscribed already. */
+  $enable(hook: string): void;
+  /** Release the named hook's subscription, if it has one. */
+  $disable(hook: string): void;
+}
+
+interface ServiceSubscription {
+  /** Subscribe, returning the unsubscribe. */
+  subscribe(): () => void;
+  /** The live unsubscribe, or `null` while the hook is suspended. */
+  unsubscribe: (() => void) | null;
+}
+
+/**
+ * Per-instance `hook → subscription` map, filled by each mixin layer at
+ * construction. It is shared by every layer, so `$enable('scrolled')` called
+ * on a class built from stacked mixins finds the layer that owns the hook.
+ */
+const SERVICE_SUBSCRIPTIONS: unique symbol = /* @__PURE__ */ Symbol('service subscriptions');
+
+type WithSubscriptions = { [SERVICE_SUBSCRIPTIONS]?: Map<string, ServiceSubscription> };
+
+function subscriptionsOf(instance: unknown): Map<string, ServiceSubscription> {
+  const host = instance as WithSubscriptions;
+  return (host[SERVICE_SUBSCRIPTIONS] ??= new Map());
+}
+
+function enableHook(instance: unknown, hook: string): void {
+  const subscription = subscriptionsOf(instance).get(hook);
+  if (!subscription) {
+    console.warn(`[service] No service mixin declares a "${hook}" hook on this component.`);
+    return;
+  }
+  // A terminated instance never mounts again, so nothing would ever release
+  // the subscription this would start.
+  if ((instance as Base).$isTerminated) {
+    return;
+  }
+  // Idempotent: an already-running hook keeps its one subscription.
+  subscription.unsubscribe ??= subscription.subscribe();
+}
+
+function disableHook(instance: unknown, hook: string): void {
+  const subscription = subscriptionsOf(instance).get(hook);
+  if (!subscription) {
+    return;
+  }
+  subscription.unsubscribe?.();
+  subscription.unsubscribe = null;
 }
 
 /**
@@ -60,7 +130,9 @@ export interface ServiceMixin<Instance, Target, Options extends object = object>
  * returning different types cannot be extended (TS2510).
  */
 export type MixedClass<T extends BaseConstructor, Instance> = Pick<T, keyof T> & {
-  new <P extends BaseProps = BaseProps>(el: HTMLElement): InstanceType<T> & Base<P> & Instance;
+  new <P extends BaseProps = BaseProps>(
+    el: HTMLElement,
+  ): InstanceType<T> & Base<P> & Instance & ServiceControls;
 };
 
 /**
@@ -92,6 +164,20 @@ export type MixedClass<T extends BaseConstructor, Instance> = Pick<T, keyof T> &
  *     mounted() {
  *       return [super.mounted(), () => { … }];
  *     }
+ *
+ * **A mount cycle is not always the right span.** `{ manual: true }` declares
+ * the hook without subscribing it, and the component decides — the v3
+ * `$services.enable()`/`.disable()` pair, on the instance:
+ *
+ *     class SliderItem extends withRaf(Base, { manual: true }) {
+ *       ticked() { … }
+ *       onIndexChange() { this.$enable('ticked'); }
+ *       onSettled() { this.$disable('ticked'); }
+ *     }
+ *
+ * Either way the subscription is released on destroy, so a suspended service
+ * with no other subscriber genuinely stops: no listener, no observer, no
+ * frame.
  */
 export function createServiceMixin<Instance, Target, Options extends object = object>(
   definition: ServiceMixinDefinition<Target, Options & ServiceMixinOptions<Target>>,
@@ -101,22 +187,54 @@ export function createServiceMixin<Instance, Target, Options extends object = ob
   function apply(BaseClass: BaseConstructor, options: MixinOptions) {
     const hook = options.hook ?? definition.hook;
     const target = options.target ?? definition.target;
+    const isManual = options.manual ?? false;
 
     return class extends BaseClass {
+      constructor(el: HTMLElement) {
+        super(el);
+        // Declared at construction, so `$enable()` works before the first
+        // mount and finds the right layer when mixins are stacked.
+        subscriptionsOf(this).set(hook, {
+          unsubscribe: null,
+          subscribe: () => {
+            const method = (this as unknown as Record<string, unknown>)[hook];
+            // A component that does not implement the method subscribes to
+            // nothing, so the service it would have started never runs.
+            if (typeof method !== 'function') {
+              return () => {};
+            }
+            return definition
+              .use(target(this), options)
+              .add((props) => (method as (props: unknown) => unknown).call(this, props));
+          },
+        });
+      }
+
       mounted(): MountedReturn {
-        const method = (this as unknown as Record<string, unknown>)[hook];
         const inherited = super.mounted();
-        // A component that does not implement the method subscribes to
-        // nothing, so the service it would have started never runs.
-        if (typeof method !== 'function') {
-          return inherited;
+        if (!isManual) {
+          enableHook(this, hook);
         }
-        const unsubscribe = definition
-          .use(target(this), options)
-          .add((props) => (method as (props: unknown) => unknown).call(this, props));
-        // The subscription happened synchronously; an async `super.mounted()`
-        // only defers its own cleanup, never this one.
-        return [inherited, unsubscribe];
+        // Released with the mount cycle whichever side subscribed it — the
+        // mixin above, or the component through `$enable()`. The subscription
+        // is synchronous, so an async `super.mounted()` only defers its own
+        // cleanup, never this one.
+        return [inherited, () => disableHook(this, hook)];
+      }
+
+      $enable(name: string): void {
+        enableHook(this, name);
+      }
+
+      $disable(name: string): void {
+        disableHook(this, name);
+      }
+
+      $terminate(): this {
+        // `$destroy()` releases whatever was subscribed during a mount cycle;
+        // this covers the instance that was enabled and never mounted.
+        disableHook(this, hook);
+        return super.$terminate() as this;
       }
     };
   }

--- a/packages/v4/src/test-utils.ts
+++ b/packages/v4/src/test-utils.ts
@@ -3,7 +3,7 @@
  * Not part of the public API.
  */
 import { Base } from './Base.js';
-import { createContext } from './context.js';
+import { Signal, createContext } from './context.js';
 import { registerComponent } from './registry.js';
 import { nextFrame, scheduler } from './scheduler.js';
 import type { DelegatedEvent } from './Base.js';
@@ -32,7 +32,9 @@ export function getInstance<T extends Base = Base>(el: Element | null, name: str
   return el?.__base__?.get(name) as T;
 }
 
-export const CountContext = createContext<number>('todo-count');
+// Reactive state is provided as a `Signal`: the value travels verbatim, so
+// the key says so.
+export const CountContext = createContext<Signal<number>>('todo-count');
 
 export class TodoItem extends Base {
   static config = { name: 'TodoItem', refs: ['remove'] };
@@ -71,7 +73,7 @@ export class TodoList extends Base {
     components: { TodoItem, TodoCount },
   };
 
-  count = this.$provide(CountContext, 0);
+  count = this.$provide(CountContext, new Signal(0));
 
   items = this.$watchChildren<TodoItem>('TodoItem', {
     added: () => this.sync(),


### PR DESCRIPTION
Four gaps found by porting real @studiometa/ui components onto v4 (#765). Two are bugs shipping in `main`; two are missing capability that blocked the component library's coordinators.

## 1. Option defaults were shared, and mutations were lost

Two bugs from the same code. An explicit `default: {}` returned **the same object to every instance of every component**, so one component mutating it corrupted the others. With no declared default, every access built a **fresh** `{}`/`[]` — so `this.$options.list.push(x)` silently did nothing.

Defaults are now built **once per instance and memoised**, and may be factories. The types require the factory form for `Array`/`Object`, so `default: {}` is a type error that tells you to write `default: () => ({})`; the no-build path shallow-copies a literal instead. Primitive defaults and attribute reads are unchanged, and an attribute-provided object still re-parses per access — the attribute stays the source of truth, only *defaults* belong to the instance.

## 2. `$inject()` leaked, and had no synchronous form

Its cancellation was registered in the **terminate** scope, but the registry only ever calls `$destroy()` when an element leaves the DOM — so every removed consumer stayed in the module-level pending-request set for the life of the page. Cancellation is destroy-scoped now, which is also the correct scope: `mounted()` re-runs on remount and re-injects.

`$injectSync(key)` is added for consumers that would rather fall back than wait, since the async form deliberately never settles without a provider — that is the price of order-independence, now documented rather than implied.

## 3. provide/inject could not expose an owner surface

`$provide` wrapped anything that was not a `Signal`, so a coordinator could only hand over a value cell, and a control had to reach back through `$closest()` for commands — the coupling context exists to remove. `DESIGN.md` §5 promised the `expose` pattern; this delivers it.

Values are provided **verbatim** now — a `Signal` for state, an object for commands, an object of Signals for both:

```js
api = this.$provide(SliderContext, {
  state: new Signal({ index: 0, total: 0 }),
  goTo: (index) => this.goTo(index),
});
```

The demo Slider shows it end to end: `SliderCount` subscribes to `api.state`, and a slide drives its coordinator with `this.$injectSync(SliderContext)?.goToItem(this)`. **There is now no `$closest` anywhere in the demo.**

## 4. A service subscription could not be suspended within a mount cycle

A component needing the frame loop only while a value settles kept it running for the life of the page — which made the design's **"no permanent rAF loop" false on any page with a slider or a scroll animation**. Two of the four ported ui components hit this and both abandoned `withRaf` for hand-rolled start/stop.

Mixins take `{ manual: true }`, and instances get `$enable(hook)` / `$disable(hook)` — v3's `$services.enable('ticked')` verbs, so migrating is a rename. `$enable` is idempotent, both verbs are safe before mount and after destroy, and everything is released on `$destroy()` whichever side subscribed it.

## Verification

Every fix was verified to **fail against the old code** — temporary reverts, then restored — not merely to pass against the new:

- old `buildOptions` → 4 failures (own defaulted object per instance, mutation persists, factory called once lazily)
- `cancel` back in terminate scope → `leaves no pending request behind when the consumer is destroyed` fails
- `$disable` made a no-op → 9 failures, including `stops the frame loop when nothing else needs it`, which watches `requestAnimationFrame` and asserts the count is flat — the loop is gone, not merely quiet

`npx tsgo --noEmit -p .` clean · `npx oxlint .` 0/0 · prettier clean · **123 tests** in headless Chromium, stable across runs.

## Notes for a reviewer

- **`@inject` (the decorator) requests once at construction**, so with the now-correct destroy scope a field still unresolved at destroy is not re-requested on remount. Documented, with the guidance to use `$inject()` inside `mounted()` for consumers that may wait across cycles. Say the word if it should re-issue per mount instead.
- **`$isTerminated`** is new public surface on `Base`, added only so `$enable` after terminate is a no-op rather than a subscription nothing would release.
- `$enable` with an unknown hook warns rather than throwing.
- Rebased onto `main` after #764; the `DESIGN.md` conflict was resolved by hand, keeping the `tick` naming from #764 and folding in the `manual` documentation.

Once this and #765 are in, the workarounds documented in the migration report become unnecessary — simplifying those components is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU