### PR TITLE
Fix main: bring the ported components onto the new option and context contracts

### DIFF
--- a/packages/v4/migration/Accordion/AccordionCore.ts
+++ b/packages/v4/migration/Accordion/AccordionCore.ts
@@ -33,7 +33,7 @@ export class AccordionCore extends Base<AccordionProps> {
     name: 'Accordion',
     options: {
       autoclose: Boolean,
-      item: { type: Object, default: {} },
+      item: { type: Object, default: () => ({}) },
     },
   };
 

--- a/packages/v4/migration/Accordion/AccordionItem.ts
+++ b/packages/v4/migration/Accordion/AccordionItem.ts
@@ -59,7 +59,7 @@ export class AccordionItem extends Base<AccordionItemProps> {
     refs: ['btn', 'content', 'container'],
     options: {
       isOpen: Boolean,
-      styles: { type: Object, default: {} as Record<string, AccordionItemStates> },
+      styles: { type: Object, default: () => ({}) as Record<string, AccordionItemStates> },
     },
   };
 

--- a/packages/v4/migration/ScrollAnimation/AbstractScrollAnimation.ts
+++ b/packages/v4/migration/ScrollAnimation/AbstractScrollAnimation.ts
@@ -37,11 +37,11 @@ export class AbstractScrollAnimation extends Base<AbstractScrollAnimationProps> 
   static config: BaseConfig = {
     name: 'AbstractScrollAnimation',
     options: {
-      playRange: { type: Array, default: [0, 1] },
-      from: { type: Object, default: {} },
-      to: { type: Object, default: {} },
-      keyframes: { type: Array, default: [] },
-      easing: { type: Array, default: [0, 0, 1, 1] },
+      playRange: { type: Array, default: () => [0, 1] },
+      from: { type: Object, default: () => ({}) },
+      to: { type: Object, default: () => ({}) },
+      keyframes: { type: Array, default: () => [] },
+      easing: { type: Array, default: () => [0, 0, 1, 1] },
     },
   };
 

--- a/packages/v4/migration/Slider/Slider.ts
+++ b/packages/v4/migration/Slider/Slider.ts
@@ -1,11 +1,11 @@
 import {
   Base,
   createContext,
+  Signal,
   withResize,
   type ChildrenCollection,
   type MountedReturn,
   type RefEvent,
-  type Signal,
 } from '../../src/index.js';
 import { SliderItem } from './SliderItem.js';
 
@@ -25,7 +25,7 @@ export interface SliderState {
  * reconnection safety nets. The signal is resolved through the DOM event
  * path, so mount order does not matter in either direction.
  */
-export const SliderContext = /* @__PURE__ */ createContext<SliderState>('slider-state');
+export const SliderContext = /* @__PURE__ */ createContext<Signal<SliderState>>('slider-state');
 
 export interface SliderProps {
   $refs: { wrapper: HTMLElement };
@@ -68,7 +68,12 @@ export class Slider extends withResize(Base)<SliderProps> {
     },
   };
 
-  state: Signal<SliderState> = this.$provide(SliderContext, { index: 0, total: 0 });
+  state: Signal<SliderState> = this.$provide(
+    SliderContext,
+    // Provided verbatim since v4 stopped wrapping: the coordinator decides
+    // its own surface, and this one is a value cell.
+    new Signal<SliderState>({ index: 0, total: 0 }),
+  );
 
   items: ChildrenCollection<SliderItem> = this.$watchChildren<SliderItem>('SliderItem', {
     added: () => this.refresh(),


### PR DESCRIPTION
**`main` is currently broken** — five failing tests and a type error in `packages/v4/migration`.

#765 (the ui migration test) and #766 (the four gap fixes) were each green on their own branch and conflict semantically once combined. #766 changed two contracts the ported components use:

- `Object`/`Array` option defaults must now be factories, since a declared default is no longer shared between instances — `default: {}` is deliberately a type error.
- `$provide` hands values over verbatim instead of wrapping them in a `Signal`.

The ported components were written against the old contracts. Git merged both cleanly because nothing textually overlapped; **neither CI run tested the combination**, which is exactly what a semantic conflict hides.

## The fix

- `AccordionCore.item`, `AccordionItem.styles`, and `AbstractScrollAnimation`'s `playRange`/`from`/`to`/`keyframes`/`easing` become factory defaults.
- `Slider` provides `new Signal<SliderState>({ index: 0, total: 0 })` explicitly, and `SliderContext` is typed `createContext<Signal<SliderState>>`.

Nothing else changed — these are the migration components adopting the contracts the fixes introduced, which is the outcome #766 predicted.

## Verification

- `npx tsgo --noEmit -p .` clean
- **164 tests** pass in headless Chromium (they do not on `main` right now)
- `npx oxlint .` 0/0, prettier clean repo-wide

## Worth noting for next time

Two PRs that each pass CI can still break `main` together. Worth considering merge-queue-style verification, or simply rebasing the second PR onto the first and re-running before merging, whenever one changes an API the other consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU