### PR TITLE
Report scroll settling from the service, and use it in the Slider

### DIFF
--- a/packages/v4/demo/components/Slider.ts
+++ b/packages/v4/demo/components/Slider.ts
@@ -1,10 +1,4 @@
-import {
-  Base,
-  Signal,
-  createContext,
-  type DelegatedEvent,
-  type ScheduledTask,
-} from '../../src/index.js';
+import { Base, Signal, createContext, useScroll, type DelegatedEvent } from '../../src/index.js';
 
 /**
  * Slider-lite — a reimplementation of the @studiometa/ui Slider family on
@@ -114,30 +108,24 @@ export class Slider extends Base<{
     removed: () => this.refresh(),
   });
 
-  #scrollRead: ScheduledTask<void> | null = null;
-
   /**
    * Index a button navigation is scrolling toward. While set, scroll-driven
    * syncs are ignored so the smooth-scroll animation does not fight the
-   * already-updated count; the target measurement (or `scrollend`) clears it.
+   * already-updated count; reaching it, or the scroll settling, clears it.
    */
   #navigationTarget: number | null = null;
 
-  // `scroll` does not bubble, so the wrapper listener is bound per mount
-  // cycle — the returned cleanup removes it on destroy.
+  // The wrapper is its own scroll container, which is what `useScroll`
+  // takes a target for. The service coalesces the events into one read per
+  // frame and reports `isScrolling`, so there is nothing to bind, nothing
+  // to debounce, and no `scrollend` handling of our own.
   mounted() {
-    const { wrapper } = this.$refs;
-    const onScroll = () => this.syncFromScroll();
-    const onScrollEnd = () => {
-      this.#navigationTarget = null;
+    return useScroll(this.$refs.wrapper).add(({ isScrolling }) => {
+      if (!isScrolling) {
+        this.#navigationTarget = null;
+      }
       this.syncFromScroll();
-    };
-    wrapper.addEventListener('scroll', onScroll, { passive: true });
-    wrapper.addEventListener('scrollend', onScrollEnd);
-    return () => {
-      wrapper.removeEventListener('scroll', onScroll);
-      wrapper.removeEventListener('scrollend', onScrollEnd);
-    };
+    });
   }
 
   /**
@@ -147,8 +135,7 @@ export class Slider extends Base<{
    * in sync for native scroll-snap swipes, not only for the buttons.
    */
   syncFromScroll(): void {
-    this.#scrollRead?.cancel();
-    this.#scrollRead = this.$read(() => {
+    this.$read(() => {
       // Rects, not offsetLeft: offsets are relative to the positioned
       // ancestor (the page), not to the scroll wrapper.
       const wrapperRect = this.$refs.wrapper.getBoundingClientRect();

--- a/packages/v4/migration/Accordion/AccordionCore.ts
+++ b/packages/v4/migration/Accordion/AccordionCore.ts
@@ -33,7 +33,7 @@ export class AccordionCore extends Base<AccordionProps> {
     name: 'Accordion',
     options: {
       autoclose: Boolean,
-      item: { type: Object, default: {} },
+      item: { type: Object, default: () => ({}) },
     },
   };
 

--- a/packages/v4/migration/Accordion/AccordionItem.ts
+++ b/packages/v4/migration/Accordion/AccordionItem.ts
@@ -59,7 +59,7 @@ export class AccordionItem extends Base<AccordionItemProps> {
     refs: ['btn', 'content', 'container'],
     options: {
       isOpen: Boolean,
-      styles: { type: Object, default: {} as Record<string, AccordionItemStates> },
+      styles: { type: Object, default: () => ({}) as Record<string, AccordionItemStates> },
     },
   };
 

--- a/packages/v4/migration/ScrollAnimation/AbstractScrollAnimation.ts
+++ b/packages/v4/migration/ScrollAnimation/AbstractScrollAnimation.ts
@@ -37,11 +37,11 @@ export class AbstractScrollAnimation extends Base<AbstractScrollAnimationProps> 
   static config: BaseConfig = {
     name: 'AbstractScrollAnimation',
     options: {
-      playRange: { type: Array, default: [0, 1] },
-      from: { type: Object, default: {} },
-      to: { type: Object, default: {} },
-      keyframes: { type: Array, default: [] },
-      easing: { type: Array, default: [0, 0, 1, 1] },
+      playRange: { type: Array, default: () => [0, 1] },
+      from: { type: Object, default: () => ({}) },
+      to: { type: Object, default: () => ({}) },
+      keyframes: { type: Array, default: () => [] },
+      easing: { type: Array, default: () => [0, 0, 1, 1] },
     },
   };
 

--- a/packages/v4/migration/Slider/Slider.ts
+++ b/packages/v4/migration/Slider/Slider.ts
@@ -1,11 +1,11 @@
 import {
   Base,
   createContext,
+  Signal,
   withResize,
   type ChildrenCollection,
   type MountedReturn,
   type RefEvent,
-  type Signal,
 } from '../../src/index.js';
 import { SliderItem } from './SliderItem.js';
 
@@ -25,7 +25,7 @@ export interface SliderState {
  * reconnection safety nets. The signal is resolved through the DOM event
  * path, so mount order does not matter in either direction.
  */
-export const SliderContext = /* @__PURE__ */ createContext<SliderState>('slider-state');
+export const SliderContext = /* @__PURE__ */ createContext<Signal<SliderState>>('slider-state');
 
 export interface SliderProps {
   $refs: { wrapper: HTMLElement };
@@ -68,7 +68,12 @@ export class Slider extends withResize(Base)<SliderProps> {
     },
   };
 
-  state: Signal<SliderState> = this.$provide(SliderContext, { index: 0, total: 0 });
+  state: Signal<SliderState> = this.$provide(
+    SliderContext,
+    // Provided verbatim since v4 stopped wrapping: the coordinator decides
+    // its own surface, and this one is a value cell.
+    new Signal<SliderState>({ index: 0, total: 0 }),
+  );
 
   items: ChildrenCollection<SliderItem> = this.$watchChildren<SliderItem>('SliderItem', {
     added: () => this.refresh(),

--- a/packages/v4/src/services/ScrollService.spec.ts
+++ b/packages/v4/src/services/ScrollService.spec.ts
@@ -158,3 +158,62 @@ describe('useScroll(element)', () => {
     unsubscribeSecond();
   });
 });
+
+describe('isScrolling', () => {
+  it('turns on while the target is moving', async () => {
+    const el = document.createElement('div');
+    el.style.cssText = 'width:100px;height:100px;overflow:auto';
+    el.innerHTML = '<div style="width:100px;height:1000px"></div>';
+    document.body.append(el);
+
+    const service = useScroll(el);
+    const off = service.add(() => {});
+    // A scroll with no `scrollend` behind it, which is what mid-gesture
+    // looks like: a real jump starts and settles inside one frame, so the
+    // coalesced read would only ever report the settled state.
+    el.dispatchEvent(new Event('scroll'));
+    await settle();
+
+    expect(service.props().isScrolling).toBe(true);
+    off();
+    el.remove();
+  });
+
+  it('turns off once the target settles, and says so', async () => {
+    const el = document.createElement('div');
+    el.style.cssText = 'width:100px;height:100px;overflow:auto';
+    el.innerHTML = '<div style="width:100px;height:1000px"></div>';
+    document.body.append(el);
+
+    const seen: boolean[] = [];
+    const off = useScroll(el).add(({ isScrolling }) => seen.push(isScrolling));
+
+    el.scrollTop = 200;
+    // Long enough for `scrollend`, or for the quiet period standing in for
+    // it where the browser has no such event.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    off();
+    el.remove();
+
+    // The settled state is announced even though the position did not
+    // change with it — that is the whole point of the flag.
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.at(-1)).toBe(false);
+  });
+
+  it('is false again once the service is released', async () => {
+    const el = document.createElement('div');
+    el.style.cssText = 'width:100px;height:100px;overflow:auto';
+    el.innerHTML = '<div style="width:100px;height:1000px"></div>';
+    document.body.append(el);
+
+    const service = useScroll(el);
+    const off = service.add(() => {});
+    el.scrollTop = 120;
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    off();
+
+    expect(service.props().isScrolling).toBe(false);
+    el.remove();
+  });
+});

--- a/packages/v4/src/services/ScrollService.spec.ts
+++ b/packages/v4/src/services/ScrollService.spec.ts
@@ -201,6 +201,26 @@ describe('isScrolling', () => {
     expect(seen.at(-1)).toBe(false);
   });
 
+  it('stays off when a resize refreshes the measurements', async () => {
+    const el = document.createElement('div');
+    el.style.cssText = 'width:100px;height:100px;overflow:auto';
+    el.innerHTML = '<div style="width:100px;height:1000px"></div>';
+    document.body.append(el);
+
+    const service = useScroll(el);
+    const off = service.add(() => {});
+
+    // A resize re-measures the maximums, but nothing is moving — and no
+    // `scrollend` follows to take the flag back down, so treating it as a
+    // scroll would leave the service stuck reporting a scroll forever.
+    window.dispatchEvent(new Event('resize'));
+    await settle();
+
+    expect(service.props().isScrolling).toBe(false);
+    off();
+    el.remove();
+  });
+
   it('is false again once the service is released', async () => {
     const el = document.createElement('div');
     el.style.cssText = 'width:100px;height:100px;overflow:auto';

--- a/packages/v4/src/services/ScrollService.ts
+++ b/packages/v4/src/services/ScrollService.ts
@@ -30,7 +30,25 @@ export interface ScrollProps {
   isRight: boolean;
   isDown: boolean;
   isLeft: boolean;
+  /**
+   * Whether the target is still moving. It turns off on `scrollend`, which
+   * covers momentum, smooth-scrolling and snap settling alike — a component
+   * waiting for a scroll to finish should read this rather than time out on
+   * its own.
+   */
+  isScrolling: boolean;
 }
+
+/**
+ * `scrollend` where it exists — Safari only gained it recently, and there is
+ * no polyfill worth the name, so a quiet period stands in for it. Long
+ * enough not to fire between two momentum frames, short enough to feel
+ * immediate.
+ */
+const SCROLL_END_FALLBACK_DELAY = 120;
+
+const supportsScrollEnd = /* @__PURE__ */ (() =>
+  typeof window !== 'undefined' && 'onscrollend' in window)();
 
 /**
  * Where the target stands and how far it can go. The window scrolls the
@@ -74,6 +92,7 @@ function createScrollService(target: ScrollTarget): Service<ScrollProps> {
     isRight: false,
     isDown: false,
     isLeft: false,
+    isScrolling: false,
   };
 
   function update(): ScrollProps {
@@ -105,7 +124,9 @@ function createScrollService(target: ScrollTarget): Service<ScrollProps> {
     props: () => props,
     start(emit) {
       let task: ScheduledTask<void> | null = null;
-      const onScroll = () => {
+      let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const flush = () => {
         // One update per frame, in the phase where measuring is free.
         // v3 debounced instead, which cost 100 ms before the final position
         // was announced; a coalesced read always ends on the last event.
@@ -115,6 +136,23 @@ function createScrollService(target: ScrollTarget): Service<ScrollProps> {
         });
       };
 
+      const onScrollEnd = () => {
+        props.isScrolling = false;
+        // Announced on its own, since the position has not changed: a
+        // component waiting for the scroll to settle would otherwise never
+        // hear about it.
+        flush();
+      };
+
+      const onScroll = () => {
+        props.isScrolling = true;
+        if (!supportsScrollEnd) {
+          clearTimeout(fallbackTimer);
+          fallbackTimer = setTimeout(onScrollEnd, SCROLL_END_FALLBACK_DELAY);
+        }
+        flush();
+      };
+
       // Refresh before the first subscriber reads `props()`, and pick up the
       // maximums of the target as it is now.
       update();
@@ -122,13 +160,19 @@ function createScrollService(target: ScrollTarget): Service<ScrollProps> {
       // reports this scroller and no other — an inner one would otherwise
       // wake the service to emit unchanged props.
       target.addEventListener('scroll', onScroll, { passive: true });
+      if (supportsScrollEnd) {
+        target.addEventListener('scrollend', onScrollEnd);
+      }
       // Resizing changes the maximums, and therefore the progress.
       window.addEventListener('resize', onScroll, { passive: true });
 
       return () => {
         task?.cancel();
         task = null;
+        clearTimeout(fallbackTimer);
+        props.isScrolling = false;
         target.removeEventListener('scroll', onScroll);
+        target.removeEventListener('scrollend', onScrollEnd);
         window.removeEventListener('resize', onScroll);
       };
     },

--- a/packages/v4/src/services/ScrollService.ts
+++ b/packages/v4/src/services/ScrollService.ts
@@ -153,6 +153,11 @@ function createScrollService(target: ScrollTarget): Service<ScrollProps> {
         flush();
       };
 
+      // A resize changes the maximums, and therefore the progress — but
+      // nothing is moving, and no `scrollend` follows to take the flag back
+      // down. Re-measure without entering the scrolling state.
+      const onResize = () => flush();
+
       // Refresh before the first subscriber reads `props()`, and pick up the
       // maximums of the target as it is now.
       update();
@@ -163,8 +168,7 @@ function createScrollService(target: ScrollTarget): Service<ScrollProps> {
       if (supportsScrollEnd) {
         target.addEventListener('scrollend', onScrollEnd);
       }
-      // Resizing changes the maximums, and therefore the progress.
-      window.addEventListener('resize', onScroll, { passive: true });
+      window.addEventListener('resize', onResize, { passive: true });
 
       return () => {
         task?.cancel();
@@ -173,7 +177,7 @@ function createScrollService(target: ScrollTarget): Service<ScrollProps> {
         props.isScrolling = false;
         target.removeEventListener('scroll', onScroll);
         target.removeEventListener('scrollend', onScrollEnd);
-        window.removeEventListener('resize', onScroll);
+        window.removeEventListener('resize', onResize);
       };
     },
   });


### PR DESCRIPTION
Stacked behind #767, which fixes `main`.

## `scrollend` belongs in the service

"Has this stopped moving" is a question every scroll-driven component asks — a slider waiting for a smooth-scroll navigation, anything snap-based, anything deferring work until a gesture ends. Answering it once, in the service, beats each component timing out on its own.

`ScrollProps` gains **`isScrolling`**, turned off by `scrollend`, with a quiet period standing in where the browser lacks the event (Safari only gained it recently and there is no polyfill worth the name). The settled state is **emitted even though the position did not change with it** — otherwise a component waiting for the scroll to finish would never hear about it, which is the whole point of the flag.

## The Slider stops binding its own listeners

The demo Slider had this:

```js
wrapper.addEventListener('scroll', onScroll, { passive: true });
wrapper.addEventListener('scrollend', onScrollEnd);
```

It is the component that motivated giving services a target in the first place, and it had been hand-binding ever since — evidence of a gap that had already been closed. It now uses `useScroll(this.$refs.wrapper)` and has **no `addEventListener` at all**; the service does the per-frame coalescing it used to do by hand, and `isScrolling` replaces its own `scrollend` handling.

That also gives the scoped-target work a second real consumer, which is the point of dogfooding it.

## A note on the semantics

An instant programmatic jump starts *and* settles inside one frame, so the coalesced read emits the settled state — truthfully `false`. `isScrolling` reports the state at the moment of the emission, not "a scroll happened since last time"; `changedX`/`changedY` already answer that. The tests say so explicitly: one dispatches a bare `scroll` with no `scrollend` behind it to observe the moving state, the other scrolls for real and asserts the last emission is settled.

## Verification

- `npx tsgo --noEmit -p .` clean · `npx oxlint .` 0/0 · prettier clean
- **167 tests** in headless Chromium
- Checked in the live demo: manual scroll tracks the index, the Prev button navigates, and clicking a slide drives the coordinator through the exposed surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU