### PR TITLE
feat(v4): make the page-wide case the outermost context scope

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -18,11 +18,11 @@ Five objectives structure the design:
 
 ## Decisions
 
-| Fork            | Decision                                                                                                                                                                            |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Mount primitive | **Observer-first**: `data-component` + one record-based MutationObserver. No tag or arbitrary-selector matching, no custom-element lifecycle, no separate directive system in core. |
-| Shared state    | **provide/inject ships in v4 core**, Vue-shaped, with context-protocol mechanics. The `Data*` components in ui rebuild on top of it.                                                |
-| Child events    | **Keep `on<Child><Event>` magic methods**, resolved through delegation against names declared in `config.components`.                                                               |
+| Fork            | Decision                                                                                                                                                                                                    |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mount primitive | **Observer-first**: `data-component` + one record-based MutationObserver. No tag or arbitrary-selector matching, no custom-element lifecycle, no separate directive system in core.                         |
+| Shared state    | **provide/inject ships in v4 core**, Vue-shaped, with context-protocol mechanics, plus `provideRootContext()` for the sibling case that has no ancestor. The `Data*` components in ui rebuild on top of it. |
+| Child events    | **Keep `on<Child><Event>` magic methods**, resolved through delegation against names declared in `config.components`.                                                                                       |
 
 ## 1. Independent components
 
@@ -258,7 +258,23 @@ Injection has two forms, and the difference is what the caller does about absenc
 
 Mechanics follow the WICG community context protocol: the consumer dispatches a bubbling `context-request` event with a key and callback; the nearest mounted provider answers, and replays to late requesters / re-announces on late provider mount. This fixes both criticals from the earlier `withStore` design: resolution goes through the DOM event path instead of attribute walking, and replay happens only after the provider is mounted and initialized.
 
-The `Data*` suite in @studiometa/ui (DataScope/DataBind/…) rebuilds on this primitive and drops its bespoke channel plumbing.
+The `Data*` suite in @studiometa/ui (DataScope/DataBind/…) rebuilds on this primitive and drops its bespoke channel plumbing — but only once the sibling case has somewhere to live, which needed one addition.
+
+#### The outermost scope — `provideRootContext()`
+
+Provide/inject needs an ancestor to provide from, and the sibling channel is the one case with nothing to name. `DataBind` is `withGroup(Base, { getScope: (i) => getDataScope(i.$el) })`, and `getDataScope` returns `undefined` when no `DataScope` is above it — at which point v3 fell back to a **page-global registry** hung off `globalThis`. So a bare `DataBind` binds by name across the document with no ancestor at all, and "rebuilds on provide/inject" was true for the scoped half and structurally impossible for the other.
+
+`provideRootContext(key, create)` closes it by making the page-wide case the **outermost scope of the mechanism that already exists**, rather than a second mechanism beside it. The value is provided on `document.documentElement`, so a `context-request` from anywhere reaches it by bubbling and any nearer provider still wins by `stopPropagation` — a page-wide default and a scoped override are one primitive at two depths. `create` runs at most once per key, so peers join rather than race, and nothing is created at import time: a page that never asks never gets a listener.
+
+```js
+// Scoped or page-wide, resolved the same way, nearest first.
+const channels =
+  injectContextSync(el, DataChannels) ?? provideRootContext(DataChannels, () => new Map());
+```
+
+Two consequences, both deliberate. A root provider is **not disposable** and outlives whichever instance asked first: it is page state, and tying its lifetime to the earliest consumer to mount is exactly the ordering dependency the primitive exists to remove. And `withGroup` is therefore **not ported** — its `$group` was a member `Set` with no value cell, which is why ui had to build `getDataChannel(this.$group)` on top of it; a provided registry of `Signal`s is that cell, owned by the provider, and it makes the two registries one.
+
+`context.spec.ts` carries the spike: bare peers on a name share a channel, scoped peers share a different one, names never collide, and the value is live.
 
 The reactive container is called `Signal` — the name the ecosystem settled on (Angular, Solid, Preact, the TC39 proposal), and the one @studiometa/ui already uses to describe its `Data*` suite.
 

--- a/packages/v4/src/context.spec.ts
+++ b/packages/v4/src/context.spec.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { Base } from './Base.js';
-import { Signal, createContext, provideContext } from './context.js';
+import {
+  Signal,
+  createContext,
+  injectContext,
+  injectContextSync,
+  provideContext,
+  provideRootContext,
+} from './context.js';
 import { registerComponent } from './registry.js';
 import { getInstance, renderTodoList, resetDom, settle } from './test-utils.js';
 
@@ -238,5 +245,104 @@ describe('provide/inject', () => {
     root.querySelector<HTMLElement>('[data-ref="remove"]')?.click();
     await settle();
     expect(countEl?.textContent).toBe('1');
+  });
+});
+
+describe('provideRootContext', () => {
+  function render(html: string): HTMLElement {
+    const el = document.createElement('div');
+    el.innerHTML = html;
+    document.body.append(el);
+    return el;
+  }
+
+  it('reaches a consumer with no provider above it', () => {
+    const key = createContext<string>('root');
+    provideRootContext(key, () => 'page');
+    const el = render('<span></span>').querySelector('span') as Element;
+
+    // The case provide/inject could not express: nothing to name as an
+    // ancestor, so v3 answered it with a separate global registry.
+    expect(injectContextSync(el, key)).toBe('page');
+  });
+
+  it('is still beaten by a nearer provider', () => {
+    const key = createContext<string>('root');
+    provideRootContext(key, () => 'page');
+    const scope = render('<span></span>');
+    provideContext(scope, key, 'scoped');
+    const el = scope.querySelector('span') as Element;
+
+    // The whole point of option 2: page-wide is the outermost scope of the
+    // mechanism that already exists, not a second one with its own rules.
+    expect(injectContextSync(el, key)).toBe('scoped');
+  });
+
+  it('creates the value once, so peers join rather than compete', () => {
+    const key = createContext<{ id: number }>('root');
+    let created = 0;
+    const first = provideRootContext(key, () => ({ id: (created += 1) }));
+    const second = provideRootContext(key, () => ({ id: (created += 1) }));
+
+    expect(created).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  it('answers a consumer that asked before it existed', async () => {
+    const key = createContext<string>('root');
+    const el = render('<span></span>').querySelector('span') as Element;
+
+    // Order independence has to hold for the root provider too: the consumer
+    // is already waiting when the value is created.
+    const { promise } = injectContext(el, key);
+    provideRootContext(key, () => 'late');
+
+    await expect(promise).resolves.toBe('late');
+  });
+
+  it('binds peers by name with or without a scope — the DataBind shape', () => {
+    // The spike this was built for. A control publishes and reads a value on a
+    // channel named by an option, sharing it with peers on the same name.
+    // v3 resolved that through `withGroup`: a scoped registry when a `DataScope`
+    // ancestor existed, a `globalThis` one when it did not.
+    type Channels = Map<string, Signal<string>>;
+    const DataChannels = createContext<Channels>('data-channels');
+
+    const channelFor = (el: Element, name: string): Signal<string> => {
+      const channels =
+        injectContextSync(el, DataChannels) ??
+        provideRootContext(DataChannels, () => new Map() as Channels);
+      let channel = channels.get(name);
+      if (!channel) {
+        channel = new Signal('');
+        channels.set(name, channel);
+      }
+      return channel;
+    };
+
+    const tree = render(`
+      <p id="bare-a"></p>
+      <p id="bare-b"></p>
+      <div id="scope">
+        <p id="scoped-a"></p>
+        <p id="scoped-b"></p>
+      </div>
+    `);
+    const at = (id: string) => tree.querySelector(`#${id}`) as Element;
+    provideContext(at('scope'), DataChannels, new Map() as Channels);
+
+    // Two bare peers, no ancestor anywhere: same name, same channel.
+    expect(channelFor(at('bare-a'), 'email')).toBe(channelFor(at('bare-b'), 'email'));
+    // Two scoped peers: same name, same channel, and *not* the page one.
+    expect(channelFor(at('scoped-a'), 'email')).toBe(channelFor(at('scoped-b'), 'email'));
+    expect(channelFor(at('scoped-a'), 'email')).not.toBe(channelFor(at('bare-a'), 'email'));
+    // Different names never collide.
+    expect(channelFor(at('bare-a'), 'name')).not.toBe(channelFor(at('bare-a'), 'email'));
+
+    // And the value is live, which is what `withGroup`'s member set never was.
+    const seen: string[] = [];
+    channelFor(at('bare-b'), 'email').subscribe((value) => seen.push(value));
+    channelFor(at('bare-a'), 'email').value = 'a@b.c';
+    expect(seen).toEqual(['a@b.c']);
   });
 });

--- a/packages/v4/src/context.ts
+++ b/packages/v4/src/context.ts
@@ -127,6 +127,50 @@ export function provideContext<T>(
   };
 }
 
+/** One root provider per key, created on demand and kept for the page. */
+const rootProviders = new Map<symbol, unknown>();
+
+/**
+ * Provide a value for the whole document, creating it on first use.
+ *
+ * This is the outermost scope, not a second mechanism: the value is provided on
+ * `document.documentElement`, so a `context-request` from anywhere reaches it by
+ * bubbling and **any nearer provider still wins**. A page-wide default and a
+ * scoped override are the same primitive at different depths.
+ *
+ * It exists because provide/inject needs an ancestor to provide from, and some
+ * things have no ancestor to name. A control that binds to its peers by a group
+ * name is the case that forced it: give it a `DataScope`-shaped wrapper and the
+ * wrapper provides, but a bare one on a page has nothing above it, and v3
+ * answered that with a separate page-global registry keyed off `globalThis`.
+ * Two registries meant two sets of semantics for one channel — this makes the
+ * global case the outermost scope of the one that already exists.
+ *
+ *     // Scoped or page-wide, resolved the same way, nearest first.
+ *     const channels =
+ *       injectContextSync(el, DataChannels) ??
+ *       provideRootContext(DataChannels, () => new Map());
+ *
+ * `create` runs at most once per key: later callers join the value the first one
+ * made, which is what lets every peer ask without coordinating. Nothing is
+ * created at import time — a page that never asks never gets a listener.
+ *
+ * A root provider is deliberately not disposable and outlives any instance that
+ * happened to ask for it first: it is page state, and tying it to whichever
+ * consumer mounted earliest is the ordering dependency this whole primitive
+ * exists to remove. Tests stay isolated by making their own key with
+ * `createContext()`, which is what a module does anyway.
+ */
+export function provideRootContext<T>(key: ContextKey<T>, create: () => T): T {
+  if (rootProviders.has(key)) {
+    return rootProviders.get(key) as T;
+  }
+  const value = create();
+  rootProviders.set(key, value);
+  provideContext(document.documentElement, key, value);
+  return value;
+}
+
 /**
  * Resolve the nearest provided value for `key`, now or when a provider
  * appears. Order-independent.

--- a/packages/v4/src/index.ts
+++ b/packages/v4/src/index.ts
@@ -63,6 +63,7 @@ export {
   injectContext,
   injectContextSync,
   provideContext,
+  provideRootContext,
   type ContextKey,
 } from './context.js';
 export { children, component, inject, on, provide, read, write } from './decorators.js';


### PR DESCRIPTION
Closes the last channel in the data-sharing taxonomy with no v4 answer: sibling↔sibling.

One commit, **282 tests** green across 28 files — two consecutive runs — typecheck clean, `oxlint` clean, prettier clean.

## The design doc asserted something half-true

`DESIGN.md` §5 said the `Data*` suite in @studiometa/ui "rebuilds on this primitive and drops its bespoke channel plumbing". Checking it against ui:

```ts
class DataBind extends withGroup<Base, DataScope>(Base, {
  getScope: (instance) => getDataScope(instance.$el),   // → DataScope | undefined
})
```

`getDataScope` returns `undefined` when no `DataScope` is above it, and `withGroup` then falls back to a **page-global registry** hung off `globalThis`. So a bare `DataBind` binds by name across the whole document with no ancestor at all — and provide/inject structurally cannot express that, because it needs an ancestor to provide from.

True for the scoped half. Impossible for the other, which is the default one.

## The fix is smaller than it sounds, because the mechanism already allowed it

A `context-request` bubbles, so it already reaches `document.documentElement`, and a provider there is reachable from anywhere while `stopPropagation` still gives a nearer scope precedence. What was missing was only a way to *declare* one, lazily.

```js
const channels =
  injectContextSync(el, DataChannels) ?? provideRootContext(DataChannels, () => new Map());
```

So the page-wide case becomes the **outermost scope of the mechanism that already exists**, rather than a second mechanism beside it: a page-wide default and a scoped override are one primitive at two depths. `create` runs at most once per key, so peers join rather than race, and nothing is created at import time — a page that never asks never gets a listener.

## Two consequences, both deliberate

- **A root provider is not disposable**, and outlives whichever instance happened to ask first. It is page state, and tying its lifetime to the earliest consumer to mount is precisely the ordering dependency this primitive exists to remove. Tests stay isolated by making their own key with `createContext()`, which is what a module does anyway.
- **`withGroup` is therefore not ported.** Its `$group` was a member `Set` with no value cell, which is why ui had to build `getDataChannel(this.$group)` on top of it. A provided registry of `Signal`s *is* that cell, owned by the provider — and it makes the two registries one. This was the predicted resolution in the original design notes: *"withGroup lacks a canonical value cell + is page-global — giving it one would unify the sibling case."*

## The spike is in the spec, not in prose

Having just caught §5 asserting something unverified, the `DataBind` shape is proved executably in `context.spec.ts` rather than described: bare peers on a name share a channel, scoped peers share a different one, names never collide, a consumer that asked before the provider existed is still answered, and the value is live — which `withGroup`'s member set never was.

## Where this leaves the taxonomy

| channel | v4 |
| --- | --- |
| parent→child, static input | `$options`, with live option changes since #771 |
| parent→child, command/read | `$query('Child')` + method |
| parent→child, continuous state | provide/inject + `Signal` |
| child→parent, event | `$emit` bubbles + delegated `on<Child><Event>` |
| child→parent, command | an exposed method through context — the `expose` pattern |
| "who is there" | `$watchChildren` |
| **sibling↔sibling** | **this PR** |

The `withStore` verdict from the original investigation (**has-serious-problems**, two criticals) is now fully obsolete: §5 already recorded that provide/inject fixes both, and this closes the one case it could not reach.

## Follow-up, not in this PR

The two private Notion design docs predate the implementation — both still name "continuous shared state" as the core unsolved concept and carry the `withStore` verdict. Now that the taxonomy is complete they can be brought to the shipped reality in one pass rather than two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU