### PR TITLE
test(v4): wait for the media query emit, not for a live read

### DIFF
--- a/packages/v4/src/services/media.spec.ts
+++ b/packages/v4/src/services/media.spec.ts
@@ -5,7 +5,6 @@ import { cdp } from 'vitest/browser';
 import type {} from '@vitest/browser-playwright';
 import { settle } from '../test-utils.js';
 import { useMediaQuery, usePrefersReducedMotion, type MediaQueryProps } from './media.js';
-import { until } from './until.js';
 
 /**
  * A media feature the page cannot change from the inside — the reader sets it in
@@ -59,12 +58,25 @@ describe('useMediaQuery', () => {
     expect(service.props().matches).toBe(false);
 
     const seen: boolean[] = [];
-    const unsubscribe = service.subscribe(({ matches }) => seen.push(matches));
+    // Waiting on the emit itself rather than on a predicate. `props()` reads the
+    // `MediaQueryList` live — deliberately, so a caller can branch without
+    // subscribing — so it reports the crossing the moment the emulation applies,
+    // before the `change` event has reached anyone. `until()` resolves on
+    // current props that already match, so it would resolve off that live read
+    // with `seen` still empty. It passed on timing alone.
+    let emitted!: () => void;
+    const hasEmitted = new Promise<void>((resolve) => {
+      emitted = resolve;
+    });
+    const unsubscribe = service.subscribe(({ matches }) => {
+      seen.push(matches);
+      emitted();
+    });
 
     // The reader turns motion down mid-session, which is why this is a service
     // and not a boolean read once at load time.
     await emulateReducedMotion('reduce');
-    await until(service, ({ matches }) => matches);
+    await hasEmitted;
     expect(seen).toEqual([true]);
     expect(service.props().matches).toBe(true);
 


### PR DESCRIPTION
A flake that #775 introduced and that only shows once it is on `main`.

## What happened

`media.spec.ts` asserts that a `prefers-reduced-motion` crossing reaches its subscribers, and waited for it like this:

```ts
await emulateReducedMotion('reduce');
await until(service, ({ matches }) => matches);
expect(seen).toEqual([true]);
```

Those are two different events. `props()` reads the `MediaQueryList` **live** — deliberately, so a caller can branch once without subscribing, which is most of why the service is useful — so it reports the crossing the moment the CDP emulation applies, before the `change` event has reached any subscriber. `until()` resolves on current props that already match. So it resolved off the live read, with `seen` still empty.

It passed twice on the branch and once in CI on timing alone, and failed on the **first** run after the merge.

## The fix

Wait on the emit itself, through a promise the subscriber resolves. Four consecutive runs of the file and two of the full suite, green.

**The implementation is unchanged.** A live `props()` over a `MediaQueryList` is documented and intended — the spec was asserting one thing and waiting on another.

## Why it took a merge to surface

Neither branch's CI had both changes: #774 added three Slider components and #775 changed the resize service's first emission. I rebased #775 onto #774 and ran the combined suite twice before merging, which is what caught the resize interaction being safe — but this race is timing, so two green runs said nothing about it. The first post-merge run found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqH6T9mNAPYGjQjj7Y9XmU