### PR TITLE
fix(v4): register the merged config.components (I6)

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -89,7 +89,9 @@ The two remaining regressions are understood rather than outstanding. `$emit` pa
 
 ### `config` merges along the prototype chain
 
-`$config` walks the prototype chain and merges every config it finds, so extending a component keeps what its parents declared — the crash reported in #627. `refs`, `options` and `components` all merge (v3 merged only `options` and `emits`); scalar keys stay overridable by the most derived class. An intermediate class should annotate `static config: BaseConfig`, otherwise TypeScript infers a literal type its subclasses must match.
+`$config` walks the prototype chain and merges every config it finds, so extending a component keeps what its parents declared — the crash reported in #627. `refs`, `options` and `components` all merge (v3 merged only `options` and `emits`); scalar keys stay overridable by the most derived class, and a subclass restating a `components` key wins for that key alone. An intermediate class should annotate `static config: BaseConfig`, otherwise TypeScript infers a literal type its subclasses must match.
+
+**The registry reads the merged config too**, and reads it before any instance exists, which is why `resolveConfig()` is exported from `Base.ts`. It resolves the mount strategy of a pair (§11b) and registers the family of `config.components` (§11d) from the merged set, not the class's own static. Every subclass declares a `static config` if only for its `name`, so reading the own static made a subclass fall back to `eager` and register nothing its base declared — while its instances still announce and query those children through `$config`. A `() => import(…)` child has no registration path besides this one, so it went missing outright.
 
 ### The public surface is typed, and free
 
@@ -838,7 +840,7 @@ static config = {
 };
 ```
 
-`registerComponent()` already walked the map to register the family. It now **defers** a thunk instead of resolving it: the value becomes a lazy entry of the same registry, under its key, and every step after that is the one 11c already built — `scheduleFor()` finds the name, the element's `data-mount` decides when, `importComponent()` imports once per name whichever element triggered it, `registerComponent()` takes over when the class arrives. Nothing new observes, schedules or imports.
+`registerComponent()` already walked the map — the merged one, so a subclass registers its base's family — to register it. It now **defers** a thunk instead of resolving it: the value becomes a lazy entry of the same registry, under its key, and every step after that is the one 11c already built — `scheduleFor()` finds the name, the element's `data-mount` decides when, `importComponent()` imports once per name whichever element triggered it, `registerComponent()` takes over when the class arrives. Nothing new observes, schedules or imports.
 
 **Why the object shape is what makes this work.** The key supplies the component name, and a thunk cannot until it resolves. So a lazy child is a name the registry knows with nothing downloaded — the same knowledge a manifest entry carries, read out of the parent's own source instead of a separate file. The name set `on<Child><Event>` resolution reads is `Object.keys()`, so a lazy value changes nothing there either.
 

--- a/packages/v4/src/autoload.spec.ts
+++ b/packages/v4/src/autoload.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Base, type BaseConfig } from './Base.js';
+import { Base, type BaseConfig, type BaseConstructor } from './Base.js';
 import { whenDOMSettled } from './dom-mutations.js';
 import { getInstances } from './instances.js';
 import { registerComponent, registerManifest } from './registry.js';
@@ -499,5 +499,88 @@ describe('a dynamic import declared in config.components', () => {
       `[registry] "${parentName}" declares "${childName}" as neither a component class nor an importer, ignoring.`,
     );
     error.mockRestore();
+  });
+});
+
+/** Every subclass declares a `static config` of its own, if only for `name`. */
+function defineSubclass(Parent: BaseConstructor, components?: BaseConfig['components']) {
+  counter += 1;
+  const name = `Sub${counter}`;
+
+  class Sub extends Parent {
+    static config: BaseConfig = components ? { name, components } : { name };
+  }
+
+  return { name, Sub };
+}
+
+describe('the family a subclass inherits', () => {
+  it('registers a class child its base declared', async () => {
+    counter += 1;
+    const childName = `Inherited${counter}`;
+
+    class Child extends Base {
+      static config: BaseConfig = { name: childName };
+    }
+
+    const { Parent } = defineParent({ [childName]: Child });
+    const { Sub } = defineSubclass(Parent);
+
+    // The base is never registered: the subclass alone carries the family.
+    registerComponent(Sub);
+    const el = render(childName);
+    await settle();
+
+    expect(instanceOf(el, childName)).toBeInstanceOf(Child);
+  });
+
+  it('registers a lazy child its base declared', async () => {
+    const child = defineLazy();
+    const { Parent } = defineParent({ [child.name]: child.load });
+    const { Sub } = defineSubclass(Parent);
+
+    registerComponent(Sub);
+    const el = render(child.name);
+    await settle();
+
+    // A thunk has no other registration path, so the subclass loses the
+    // child entirely when registration reads the own config.
+    expect(child.importCount()).toBe(1);
+    expect(instanceOf(el, child.name)?.$isMounted).toBe(true);
+  });
+
+  it('lets a subclass override one key without dropping the rest', async () => {
+    const kept = defineLazy();
+    const overridden = defineLazy();
+    const stale = vi.fn();
+    const { Parent } = defineParent({ [kept.name]: kept.load, [overridden.name]: stale });
+    const { Sub } = defineSubclass(Parent, { [overridden.name]: overridden.Lazy });
+
+    registerComponent(Sub);
+    const keptEl = render(kept.name);
+    const overriddenEl = render(overridden.name);
+    await settle();
+
+    expect(stale).not.toHaveBeenCalled();
+    expect(instanceOf(overriddenEl, overridden.name)).toBeInstanceOf(overridden.Lazy);
+    expect(kept.importCount()).toBe(1);
+    expect(instanceOf(keptEl, kept.name)?.$isMounted).toBe(true);
+  });
+
+  it('registers a shared family once when the base registers too', async () => {
+    const child = defineLazy();
+    const { Parent } = defineParent({ [child.name]: child.load });
+    const { Sub } = defineSubclass(Parent);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    registerComponent(Parent);
+    registerComponent(Sub);
+    const el = render(child.name);
+    await settle();
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(child.importCount()).toBe(1);
+    expect(instanceOf(el, child.name)?.$isMounted).toBe(true);
+    warn.mockRestore();
   });
 });

--- a/packages/v4/src/registry.ts
+++ b/packages/v4/src/registry.ts
@@ -81,6 +81,21 @@ function isClassLike(value: (...args: never[]) => unknown): boolean {
  * Register the family a component declares in `config.components`, where a
  * value is the child's class or a thunk importing it.
  *
+ * The **merged** config, not `ComponentClass.config` — the same fix `mountStrategy`
+ * needed. Every subclass declares a `static config` of its own, if only for
+ * `name`, so reading the own static made registering a subclass register
+ * nothing its base declared, while `$config` and `on<Child><Event>` resolution
+ * read the merged set. A subclass therefore mounted children its own instances
+ * announce and query, and since a `() => import(…)` child has no other
+ * registration path, a subclass lost its base's lazy children outright.
+ *
+ * Registering the same family twice — a base and its subclass both declaring
+ * it — costs nothing: `registerComponent()` returns on a name already mapped
+ * to that very class, and `registerLazyChild()` on a name already known. That
+ * guard is also what terminates the recursion, because the name is mapped
+ * *before* the family is walked, so a cycle (A declares B, B declares A)
+ * closes on the second visit.
+ *
  * **A class is a function too**, so the two are told apart the way
  * `resolveComponentClass()` already tells a class from anything else an
  * importer resolved to: `isComponentClass()`, the prototype chain. It is the
@@ -96,14 +111,15 @@ function isClassLike(value: (...args: never[]) => unknown): boolean {
  * alone, and the child is its own chunk.
  */
 function registerFamily(ComponentClass: BaseConstructor): void {
-  for (const [name, Child] of Object.entries(ComponentClass.config.components ?? {})) {
+  const { name, components } = resolveConfig(ComponentClass);
+  for (const [childName, Child] of Object.entries(components ?? {})) {
     if (isComponentClass(Child)) {
       registerComponent(Child);
     } else if (typeof Child === 'function' && !isClassLike(Child)) {
-      registerLazyChild(name, Child);
+      registerLazyChild(childName, Child);
     } else {
       console.error(
-        `[registry] "${ComponentClass.config.name}" declares "${name}" as neither a component class nor an importer, ignoring.`,
+        `[registry] "${name}" declares "${childName}" as neither a component class nor an importer, ignoring.`,
       );
     }
   }
@@ -145,8 +161,9 @@ function declaresComponent(el: Element, name: string): boolean {
  * Register a component class. Existing matching elements are scheduled
  * right away; future ones are scheduled when they enter the DOM. When each
  * instance actually mounts is the strategy's call — see `data-mount`.
- * The family declared in `config.components` registers too: a class right
- * away, a `() => import(…)` thunk as a lazy entry.
+ * The family declared in the **merged** `config.components` registers too: a
+ * class right away, a `() => import(…)` thunk as a lazy entry — so a subclass
+ * registers what its base declared.
  */
 export function registerComponent(ComponentClass: BaseConstructor): void {
   const { name } = ComponentClass.config;


### PR DESCRIPTION
Addresses **I6** of #780. Does not close the issue.

## The bug

`registerFamily()` read `ComponentClass.config.components` — the class's **own** static — while `resolveConfig()` merges the map along the prototype chain. Every subclass declares a `static config` if only for its `name`, so **registering a subclass registered nothing its base declared**, even though `$config` and `on<Child><Event>` resolution already read the merged set. The subclass's instances announced and queried children the registry never mounted.

This is B6's shape for a different field: `resolveStrategy()` had the same disagreement for `mountStrategy` and was fixed in #785 by calling `resolveConfig()`. The fix here is the same call.

## What it changes beyond the one-liner

- **Class children too, not only lazy ones.** A subclass now registers its base's whole family. That is the right behaviour because `$config` already merges: the family a subclass inherits is the family its instances have. The difference in severity is that a class child could survive the old read by another registration path (a manifest, a `registerComponents()` call), while a `() => import('./Child.js')` child added by #786 has **no other path** — a subclass lost its base's lazy children outright.
- **Recursion and repeat registration.** `resolveConfig()` walks the prototype chain, so a base and its subclass can now register the same family. The existing guards are enough, and no new one was added: `registerComponent()` returns on a name already mapped to that very class — silently, since it is the same class, so no spurious "already registered" warning — and `registerLazyChild()` returns on a name already known. That guard is also what terminates recursion, because `registry.set(name, ComponentClass)` runs **before** `registerFamily()`, so a cycle (A declares B, B declares A) closes on its second visit. A regression test asserts a base and its subclass registering one shared family import it once and warn nothing.
- **Merge semantics for `components` are real.** `resolveConfig()` spreads the maps (`{ ...merged.components, ...own.components }`) rather than taking the nearest one, and the most derived class wins **per key**. A test covers a subclass overriding one key while the base's other key still registers.

The error message for a bad entry now names the merged config's `name`, matching what the registry reads.

## Tests

Four in `packages/v4/src/autoload.spec.ts`, where family registration already lives — the first three fail on `main`:

- a subclass registers its base's **class** children;
- a subclass registers its base's **lazy** children (the I5 path);
- a subclass overrides one key without dropping the rest;
- a base and its subclass registering the same family register it once, quietly.

## Verification

Full v4 suite (601 passed, 1 expected fail), `tsc --noEmit`, `oxlint`, `oxfmt --check` and `subpaths:check` all green. The two `unicorn(no-useless-spread)` warnings in `packages/v4/src/context.ts:93` and `packages/js-toolkit/src/autoload/loader.ts:467` are pre-existing on `main` and untouched.

`packages/v4/DESIGN.md` gains the rule under "`config` merges along the prototype chain" — the registry reads the merged config, for the strategy and for the family — and §11d says the walked map is the merged one. `packages/v4/migration/REPORT.md` is deliberately untouched.

#783 also touches `registry.ts`, so a merge pass is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MZV1ZifTfhQkHm4tavc5a