### PR TITLE
perf(v4): resolve the handler plan once per class

### DIFF
--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": [
+    "./dist/responsive-options.js",
+    "./src/responsive-options.ts"
+  ],
   "description": "v4 prototype — tested in a real browser through Vitest browser mode",
   "exports": {
     ".": {

--- a/packages/v4/src/Base.spec.ts
+++ b/packages/v4/src/Base.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   Base,
   type BaseConfig,
+  type DelegatedEvent,
   type GlobalEvent,
   type OptionChange,
   type RefEvent,
@@ -904,6 +905,213 @@ describe('onWindow<Event> / onDocument<Event> handlers', () => {
     outside.click();
     expect(instance.resized).toHaveLength(1);
     expect(instance.documentClicks).toHaveLength(1);
+  });
+});
+
+/**
+ * `#bindHandlers()` runs on every mount, and everything it resolves from the
+ * class — the sorted names, the prototype scan, which target each `on<…>`
+ * method binds to — is worked out once per constructor and shared. These pin
+ * what the sharing must not change.
+ */
+describe('the per-class handler plan', () => {
+  class PlanItem extends Base {
+    static config = { name: 'PlanItem' };
+
+    pick(): void {
+      this.$emit('pick');
+    }
+  }
+
+  class Panel extends Base<{
+    $refs: { close: HTMLButtonElement; tabs: HTMLButtonElement[] };
+  }> {
+    static config: BaseConfig = {
+      name: 'PlanPanel',
+      refs: ['close', 'tabs[]'],
+      components: { PlanItem },
+    };
+
+    ownClicks = 0;
+    closeClicks = 0;
+    tabIndexes: number[] = [];
+    picked: string[] = [];
+    resizes = 0;
+
+    onClick(): void {
+      this.ownClicks += 1;
+    }
+
+    onCloseClick(): void {
+      this.closeClicks += 1;
+    }
+
+    onTabsClick({ index }: RefEvent): void {
+      this.tabIndexes.push(index);
+    }
+
+    onPlanItemPick({ target }: DelegatedEvent<PlanItem>): void {
+      this.picked.push(target.$el.id);
+    }
+
+    onWindowResize(): void {
+      this.resizes += 1;
+    }
+  }
+
+  function markup(id: string): HTMLElement {
+    const el = document.createElement('div');
+    el.innerHTML = `
+      <button data-ref="close"></button>
+      <button data-ref="tabs[]"></button>
+      <button data-ref="tabs[]"></button>
+      <button data-ref="extra"></button>
+      <div data-component="PlanItem" id="${id}"></div>
+    `;
+    document.body.append(el);
+    return el;
+  }
+
+  function render(id: string): { el: HTMLElement; instance: Panel; item: PlanItem } {
+    const el = markup(id);
+    const instance = new Panel(el).$mount();
+    const item = new PlanItem(el.querySelector('#' + id) as HTMLElement).$mount();
+    return { el, instance, item };
+  }
+
+  const buttons = (el: HTMLElement) => [...el.querySelectorAll('button')];
+
+  it('binds two instances of one class, each to its own subtree', () => {
+    const a = render('a');
+    const b = render('b');
+
+    buttons(a.el)[0].click();
+    expect(a.instance.closeClicks).toBe(1);
+    // The own-element listener hears the same click, from the same plan.
+    expect(a.instance.ownClicks).toBe(1);
+    expect(b.instance.closeClicks).toBe(0);
+    expect(b.instance.ownClicks).toBe(0);
+
+    buttons(b.el)[2].click();
+    expect(b.instance.tabIndexes).toEqual([1]);
+    expect(a.instance.tabIndexes).toEqual([]);
+
+    b.item.pick();
+    expect(b.instance.picked).toEqual(['b']);
+    expect(a.instance.picked).toEqual([]);
+
+    window.dispatchEvent(new Event('resize'));
+    expect(a.instance.resizes).toBe(1);
+    expect(b.instance.resizes).toBe(1);
+  });
+
+  it('rebinds every kind of handler on a remount', () => {
+    const { el, instance, item } = render('remount');
+
+    instance.$destroy();
+    buttons(el)[0].click();
+    buttons(el)[1].click();
+    item.pick();
+    window.dispatchEvent(new Event('resize'));
+    expect(instance.closeClicks).toBe(0);
+    expect(instance.tabIndexes).toEqual([]);
+    expect(instance.picked).toEqual([]);
+    expect(instance.resizes).toBe(0);
+
+    instance.$mount();
+    buttons(el)[0].click();
+    buttons(el)[1].click();
+    item.pick();
+    window.dispatchEvent(new Event('resize'));
+    expect(instance.closeClicks).toBe(1);
+    expect(instance.tabIndexes).toEqual([0]);
+    expect(instance.picked).toEqual(['remount']);
+    expect(instance.resizes).toBe(1);
+  });
+
+  it('resolves a subclass against its own merged config, not its parent’s plan', () => {
+    class ExtendedPanel extends Panel {
+      static config: BaseConfig = { name: 'PlanExtendedPanel', refs: ['extra'] };
+
+      extraClicks = 0;
+
+      onExtraClick(): void {
+        this.extraClicks += 1;
+      }
+    }
+
+    const el = markup('sub');
+    const instance = new ExtendedPanel(el).$mount();
+    new PlanItem(el.querySelector('#sub') as HTMLElement).$mount();
+
+    // The subclass's own ref, declared nowhere else.
+    buttons(el)[3].click();
+    expect(instance.extraClicks).toBe(1);
+    // Everything the parent declares still resolves through the merged config.
+    buttons(el)[0].click();
+    buttons(el)[2].click();
+    expect(instance.closeClicks).toBe(1);
+    expect(instance.tabIndexes).toEqual([1]);
+
+    // And the parent's plan is untouched: `extra` is not one of its refs.
+    const parent = render('parent');
+    buttons(parent.el)[3].click();
+    buttons(parent.el)[1].click();
+    expect(parent.instance.tabIndexes).toEqual([0]);
+    expect(parent.instance.ownClicks).toBe(2);
+  });
+
+  /**
+   * The plan lists the `on<…>` names a class declares; whether one *is* a
+   * function is still asked of the instance, because a class field can
+   * shadow a prototype method with something that is not callable — and two
+   * instances of one class can therefore disagree.
+   */
+  it('skips a handler the instance shadows with a non-function', () => {
+    class Maybe extends Base {
+      static config: BaseConfig = { name: 'PlanMaybe' };
+
+      clicks = 0;
+
+      constructor(el: HTMLElement) {
+        super(el);
+        if (el.hasAttribute('data-mute')) {
+          (this as unknown as Record<string, unknown>).onClick = null;
+        }
+      }
+
+      onClick(): void {
+        this.clicks += 1;
+      }
+    }
+
+    const live = document.createElement('div');
+    const muted = document.createElement('div');
+    muted.setAttribute('data-mute', '');
+    document.body.append(live, muted);
+
+    const liveInstance = new Maybe(live).$mount();
+    const mutedInstance = new Maybe(muted).$mount();
+
+    const reported: unknown[] = [];
+    const onError = (event: ErrorEvent) => {
+      reported.push(event.error);
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+    window.addEventListener('error', onError, { capture: true });
+    try {
+      live.click();
+      muted.click();
+    } finally {
+      window.removeEventListener('error', onError, { capture: true });
+    }
+
+    expect(liveInstance.clicks).toBe(1);
+    expect(mutedInstance.clicks).toBe(0);
+    // Skipped, not bound-and-thrown: a listener calling `null` would report
+    // an error on every click of the muted element.
+    expect(reported).toEqual([]);
   });
 });
 

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -22,6 +22,7 @@ import {
   watchBreakpoint,
 } from './responsive-options.js';
 import type { MountStrategy } from './mount-strategies.js';
+import { memo } from './utils/memo.js';
 import { selectorFor } from './utils/selectors.js';
 import { kebabCase, pascalCase } from './utils/strings.js';
 import { viewTransition, type ViewTransitionUpdate } from './viewTransition.js';
@@ -948,22 +949,127 @@ function resolveGlobal(rest: string): { target: Window | Document; type: string 
   return null;
 }
 
-function getHandlerNames(instance: Base): Set<string> {
+/**
+ * Every `on<…>` name declared up a class's prototype chain, most derived
+ * first, stopping at `Base` itself.
+ *
+ * **Names only — whether one resolves to a function is asked of the
+ * instance.** A class field can shadow a prototype method with a
+ * non-function, so that question has an instance in its answer and cannot be
+ * settled here; `#bindHandlers()` asks it, per instance, per entry, at the
+ * cost of one `typeof`. What is settled here is the expensive half: the walk,
+ * the `getOwnPropertyNames()` per prototype, and the regex per name.
+ *
+ * Class fields never appear: they are own properties of the instance and this
+ * walks prototypes. An `onClick = () => {}` is not a handler in v4, which is
+ * v3's rule too.
+ */
+function handlerMethodNames(ctor: BaseConstructor): string[] {
   const names = new Set<string>();
-  let proto = Object.getPrototypeOf(instance);
+  let proto: object | null = ctor.prototype;
   while (proto && proto !== Base.prototype) {
     for (const name of Object.getOwnPropertyNames(proto)) {
-      if (
-        REGEX_HANDLER.test(name) &&
-        typeof (instance as unknown as Record<string, unknown>)[name] === 'function'
-      ) {
+      if (REGEX_HANDLER.test(name)) {
         names.add(name);
       }
     }
-    proto = Object.getPrototypeOf(proto);
+    proto = Object.getPrototypeOf(proto) as object | null;
   }
-  return names;
+  return [...names];
 }
+
+/**
+ * One resolved magic handler: which listener to create, and where, for an
+ * `on<…>` method name — everything but the instance to call it on.
+ */
+type HandlerPlanEntry = { method: string; type: string } & (
+  | { kind: 'global'; target: Window | Document }
+  /** The declared child name. */
+  | { kind: 'child'; name: string }
+  /** The **declared** ref, `[]` included: it is what `queryRefs()` takes. */
+  | { kind: 'ref'; name: string }
+  | { kind: 'own' }
+);
+
+interface HandlerPlan {
+  /** Declared child names, longest first. */
+  childNames: string[];
+  /** Declared refs, longest derived name first. */
+  refs: Array<{ name: string; definition: string }>;
+  componentName: string;
+  entries: HandlerPlanEntry[];
+}
+
+/**
+ * What `#bindHandlers()` binds for a class, worked out once for the class.
+ *
+ * `#bindHandlers()` runs on **every** `$mount()`, and under `data-mount` a
+ * component mounts and unmounts as often as it scrolls past. Almost all of
+ * that work reads the class and nothing else: the sorted child names, the
+ * mapped and sorted refs, the prototype scan, and — per handler name — the
+ * global-prefix test, the prefix match against children and refs, and the
+ * `kebabCase()` of what is left. None of it can differ between two instances
+ * of one class, so it is done for the class. What stays per mount is the
+ * closures that call `self[method]` and the `addEventListener()` calls, which
+ * is what a mount actually is.
+ *
+ * **No `clear()`, because nothing can go stale.** The plan is derived from
+ * the prototype chain, which is fixed once the class is defined, and from
+ * `resolveConfig(ctor)`, which is itself cached per constructor and so is
+ * already the same answer for the plan's whole life. A class that gained a
+ * handler after its first mount would need a new prototype, which is a new
+ * class and a new key.
+ */
+const handlerPlan = memo((ctor: BaseConstructor): HandlerPlan => {
+  const config = resolveConfig(ctor);
+  // Longest name first, so `onSliderDragStart` resolves to the declared
+  // `SliderDrag` child, not to `Slider`.
+  const byLength = (a: string, b: string) => b.length - a.length;
+  const childNames = Object.keys(config.components ?? {}).sort(byLength);
+  // `definition` is the declaration — what `config.refs` says, what `@on()`
+  // names, and what the entry carries into delegation. `name` is the derived
+  // spelling, used by `on<Ref><Event>` and by `$refs`; the two differ by the
+  // `[]` of a list ref. Neither is ever namespaced: the namespace is written
+  // on the attribute, never declared, so `isRefOf()` is what reconciles
+  // `Slider.dots[]` in the markup with `dots[]` here.
+  const refs = (config.refs ?? [])
+    .map((definition) => ({ name: refPropertyName(definition), definition }))
+    .sort((a, b) => byLength(a.name, b.name));
+
+  // The global prefixes are matched first because they are reserved; children
+  // are matched before refs, so a name declared as both resolves to the
+  // component.
+  const entries = handlerMethodNames(ctor).map((method): HandlerPlanEntry => {
+    const rest = method.slice(2);
+    const global = resolveGlobal(rest);
+    if (global) {
+      return { kind: 'global', method, type: global.type, target: global.target };
+    }
+    const startsWith = (name: string) =>
+      rest.startsWith(pascalCase(name)) && rest.length > name.length;
+    const childName = childNames.find(startsWith);
+    if (childName) {
+      return {
+        kind: 'child',
+        method,
+        type: kebabCase(rest.slice(childName.length)),
+        name: childName,
+      };
+    }
+    const ref = refs.find(({ name }) => startsWith(name));
+    if (ref) {
+      return {
+        kind: 'ref',
+        method,
+        type: kebabCase(rest.slice(ref.name.length)),
+        name: ref.definition,
+      };
+    }
+    return { kind: 'own', method, type: kebabCase(rest) };
+  });
+
+  return { childNames, refs, componentName: config.name, entries };
+});
 
 /**
  * `mounted()` may return one cleanup, several, nothing — or a promise of
@@ -1775,20 +1881,11 @@ export class Base<T extends BaseProps = BaseProps> {
    */
   #bindHandlers(): void {
     const self = this as unknown as Record<string, (payload: unknown) => void>;
-    // Longest name first, so `onSliderDragStart` resolves to the declared
-    // `SliderDrag` child, not to `Slider`.
-    const byLength = (a: string, b: string) => b.length - a.length;
-    const childNames = Object.keys(this.$config.components ?? {}).sort(byLength);
-    const componentName = this.$config.name;
-    // `definition` is the declaration — what `config.refs` says, what `@on()`
-    // names, and what the entry carries into delegation. `name` is the
-    // derived spelling, used by `on<Ref><Event>` and by `$refs`; the two
-    // differ by the `[]` of a list ref. Neither is ever namespaced: the
-    // namespace is written on the attribute, never declared, so `isRefOf()`
-    // is what reconciles `Slider.dots[]` in the markup with `dots[]` here.
-    const refs = (this.$config.refs ?? [])
-      .map((definition) => ({ name: refPropertyName(definition), definition }))
-      .sort((a, b) => byLength(a.name, b.name));
+    // Everything that reads the class and not the instance, resolved once for
+    // the class: the sorted child names, the mapped refs, and the target and
+    // event type each `on<…>` method name binds to.
+    const plan = handlerPlan(this.constructor as BaseConstructor);
+    const { childNames, refs, componentName } = plan;
 
     type Entry =
       | { kind: 'child'; name: string; invoke: (payload: DelegatedEvent) => void }
@@ -1844,7 +1941,7 @@ export class Base<T extends BaseProps = BaseProps> {
     // `onWindow<Event>` / `onDocument<Event>` names use, bubble phase and
     // per-cycle listener included.
     const registrations = this[HANDLER_REGISTRATIONS] ?? [];
-    const decorated = new Set(registrations.map(({ handler }) => handler));
+    const decorated: Set<unknown> = new Set(registrations.map(({ handler }) => handler));
     for (const { target, child, type, handler } of registrations) {
       if (target) {
         bindGlobal(target, type, (payload) => handler.call(this, payload));
@@ -1871,40 +1968,29 @@ export class Base<T extends BaseProps = BaseProps> {
     }
 
     // Magic `onWindow<Event>` / `onDocument<Event>` / `on<Child><Event>` /
-    // `on<Ref><Event>` / `on<Event>` method names — the no-build path. A
-    // method already bound through a decorator is skipped. The global
-    // prefixes are matched first because they are reserved; children are
-    // matched before refs, so a name declared as both resolves to the
-    // component.
-    for (const method of getHandlerNames(this)) {
-      if (decorated.has(self[method])) {
+    // `on<Ref><Event>` / `on<Event>` method names — the no-build path. Which
+    // one each name is was decided for the class; what is left per instance
+    // is whether it resolves to a function at all, whether a decorator
+    // already claimed it, and the closure that calls it.
+    for (const entry of plan.entries) {
+      const { method, type } = entry;
+      // Read through the instance, deliberately: a class field can shadow a
+      // prototype method with something that is not callable, and the plan
+      // lists the name either way.
+      const handler = self[method] as unknown;
+      if (typeof handler !== 'function' || decorated.has(handler)) {
         continue;
       }
-      const rest = method.slice(2);
-      const global = resolveGlobal(rest);
-      if (global) {
-        bindGlobal(global.target, global.type, (payload) => self[method](payload));
-        continue;
-      }
-      const startsWith = (name: string) =>
-        rest.startsWith(pascalCase(name)) && rest.length > name.length;
-      const childName = childNames.find(startsWith);
-      const ref = childName ? undefined : refs.find(({ name }) => startsWith(name));
-
-      if (childName) {
-        addDelegated(kebabCase(rest.slice(childName.length)), {
-          kind: 'child',
-          name: childName,
-          invoke: (payload) => self[method](payload),
-        });
-      } else if (ref) {
-        addDelegated(kebabCase(rest.slice(ref.name.length)), {
-          kind: 'ref',
-          name: ref.definition,
-          invoke: (payload) => self[method](payload),
-        });
+      if (entry.kind === 'global') {
+        bindGlobal(entry.target, type, (payload) => self[method](payload));
+      } else if (entry.kind === 'own') {
+        bindOwn(type, (event) => self[method](event));
       } else {
-        bindOwn(kebabCase(rest), (event) => self[method](event));
+        addDelegated(type, {
+          kind: entry.kind,
+          name: entry.name,
+          invoke: (payload: DelegatedEvent | RefEvent) => self[method](payload),
+        } as Entry);
       }
     }
 

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -455,9 +455,13 @@ function checkPayload(event: string, payload: unknown): void {
  * already matched on; the walk only decides who else could have claimed it.
  */
 function belongsTo(el: Element, root: Element, owner?: string): boolean {
+  // Built before the walk, not inside it: the selector depends on `owner`
+  // alone, and the loop runs once per ancestor — for every ref, on every
+  // mount. Hoisting is what a cache would buy here, without the cache.
+  const selector = owner === undefined ? undefined : selectorFor(owner);
   let parent = el.parentElement;
   while (parent && parent !== root) {
-    if (owner ? parent.matches(selectorFor(owner)) : parent.hasAttribute('data-component')) {
+    if (selector === undefined ? parent.hasAttribute('data-component') : parent.matches(selector)) {
       return false;
     }
     parent = parent.parentElement;

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -1019,8 +1019,17 @@ interface HandlerPlan {
  * already the same answer for the plan's whole life. A class that gained a
  * handler after its first mount would need a new prototype, which is a new
  * class and a new key.
+ *
+ * **`/* @__PURE__ *\/` is load-bearing, not decoration.** A top-level call is
+ * something a bundler must keep unless told otherwise, and keeping this one
+ * keeps everything it references — which is all of `Base`. Every constant
+ * subpath (`./DESTROYED_EVENT`, `./MOUNTED_EVENT`, `./SOURCE`) is a
+ * re-export *from* `Base.js` and owes its size entirely to `Base` being
+ * shaken away, so without the annotation each of them grows from 1.9 kB to
+ * 7.7 kB gzip — measured, and the reason the services already annotate their
+ * `perTarget()` calls the same way.
  */
-const handlerPlan = memo((ctor: BaseConstructor): HandlerPlan => {
+const handlerPlan = /* @__PURE__ */ memo((ctor: BaseConstructor): HandlerPlan => {
   const config = resolveConfig(ctor);
   // Longest name first, so `onSliderDragStart` resolves to the declared
   // `SliderDrag` child, not to `Slider`.

--- a/packages/v4/src/mount.bench.ts
+++ b/packages/v4/src/mount.bench.ts
@@ -154,19 +154,35 @@ describe('remount: $mount() + $destroy() on one instance', () => {
 
 /**
  * A fixed pool, cycled: a fresh element per iteration would grow the document
- * without bound over a few thousand samples, and the append would end up
- * being what is measured.
+ * without bound over a few thousand samples, and the append would end up being
+ * what is measured.
  */
 const pool = Array.from({ length: 100 }, panelElement);
 let next = 0;
 const nextElement = () => pool[next++ % pool.length];
 
-describe('first mount of a fresh instance (construction included)', () => {
+/**
+ * The previous instance is destroyed before the next is built, so exactly one
+ * is ever mounted.
+ *
+ * Leaving them mounted would leak a `window` resize listener per iteration —
+ * a few thousand of them over a run — and what the later samples measure is
+ * then the listener list, not the mount. Its `$destroy()` is inside the
+ * measured region as a result, which is the smaller distortion of the two and
+ * an equal one on both sides of a comparison.
+ */
+let live: Base | null = null;
+
+describe('construction + first mount, one instance alive at a time', () => {
   bench('Panel', () => {
-    globalThis.__benchSink = new Panel(nextElement()).$mount();
+    live?.$destroy();
+    live = new Panel(nextElement()).$mount();
+    globalThis.__benchSink = live;
   });
 
   bench('DeepPanel', () => {
-    globalThis.__benchSink = new DeepPanel(nextElement()).$mount();
+    live?.$destroy();
+    live = new DeepPanel(nextElement()).$mount();
+    globalThis.__benchSink = live;
   });
 });

--- a/packages/v4/src/mount.bench.ts
+++ b/packages/v4/src/mount.bench.ts
@@ -1,0 +1,172 @@
+/**
+ * What a mount costs, and how much of it `#bindHandlers()` was redoing.
+ *
+ * Run with `npx vitest bench --config vitest.bench.config.js` from
+ * `packages/v4`. Like the other files here, this answers a design question
+ * rather than guarding against a regression.
+ *
+ * `$mount()` is not a once-per-instance path. Under a `data-mount` strategy —
+ * `visible`, `media`, `interaction` — the same instance mounts and unmounts
+ * as the page scrolls, so every allocation and every prototype walk inside
+ * `#bindHandlers()` is paid again each time. The shapes below are the ones a
+ * real component has:
+ *
+ * - **`Panel`** — five handlers across all four resolution rules (own
+ *   element, a delegated child, a plain ref, a list ref, a global target),
+ *   two declared children, three declared refs. What a slider or a dialog
+ *   looks like.
+ * - **`Bare`** — one own-element handler and nothing declared. The floor: it
+ *   measures what a mount costs when there is almost nothing to resolve, so
+ *   the share of the saving that is `$mount()` itself rather than handler
+ *   resolution is visible.
+ * - **`DeepPanel`** — `Panel` under three intermediate subclasses, each
+ *   adding a handler. The prototype walk is the part that grows with the
+ *   class hierarchy, and mixins (`withScroll`, `withDrag`) are how a real
+ *   component gets deep.
+ *
+ * Each benchmark is a **remount**: construct once, then `$mount()`/
+ * `$destroy()` in a loop, which is the repeat path. Construction is measured
+ * separately so the two are not read as one number.
+ */
+import { bench, describe } from 'vitest';
+import { Base, type BaseConfig, type DelegatedEvent, type RefEvent } from './Base.js';
+
+/** Keeps each result observable so no benchmark is optimised away. */
+declare global {
+  // eslint-disable-next-line no-var
+  var __benchSink: unknown;
+}
+
+class Slide extends Base {
+  static config: BaseConfig = { name: 'BenchSlide' };
+}
+
+class Dot extends Base {
+  static config: BaseConfig = { name: 'BenchDot' };
+}
+
+class Panel extends Base {
+  static config: BaseConfig = {
+    name: 'BenchPanel',
+    refs: ['container', 'items[]', 'label'],
+    components: { BenchSlide: Slide, BenchDot: Dot },
+  };
+
+  count = 0;
+
+  onClick(): void {
+    this.count += 1;
+  }
+
+  onItemsClick({ index }: RefEvent): void {
+    this.count += index;
+  }
+
+  onLabelMouseover(): void {
+    this.count += 1;
+  }
+
+  onBenchSlideChange({ target }: DelegatedEvent): void {
+    this.count += target ? 1 : 0;
+  }
+
+  onWindowResize(): void {
+    this.count += 1;
+  }
+}
+
+class Bare extends Base {
+  static config: BaseConfig = { name: 'BenchBare' };
+
+  count = 0;
+
+  onClick(): void {
+    this.count += 1;
+  }
+}
+
+class PanelA extends Panel {
+  static config: BaseConfig = { name: 'BenchPanelA' };
+
+  onContainerScroll(): void {
+    this.count += 1;
+  }
+}
+
+class PanelB extends PanelA {
+  static config: BaseConfig = { name: 'BenchPanelB' };
+
+  onDocumentKeydown(): void {
+    this.count += 1;
+  }
+}
+
+class DeepPanel extends PanelB {
+  static config: BaseConfig = { name: 'BenchDeepPanel', refs: ['handle'] };
+
+  onHandlePointerdown(): void {
+    this.count += 1;
+  }
+}
+
+/** The markup a `Panel` and everything extending it reads. */
+function panelElement(): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = `
+    <div data-ref="container">
+      <button data-ref="items[]">1</button>
+      <button data-ref="items[]">2</button>
+      <button data-ref="items[]">3</button>
+      <span data-ref="label">label</span>
+      <div data-ref="handle"></div>
+      <div data-component="BenchSlide"></div>
+      <div data-component="BenchDot"></div>
+    </div>
+  `;
+  document.body.append(el);
+  return el;
+}
+
+function bareElement(): HTMLElement {
+  const el = document.createElement('div');
+  document.body.append(el);
+  return el;
+}
+
+/** One instance per shape, mounted and destroyed over and over. */
+const panel = new Panel(panelElement());
+const bare = new Bare(bareElement());
+const deep = new DeepPanel(panelElement());
+
+describe('remount: $mount() + $destroy() on one instance', () => {
+  bench('Panel — 5 handlers, 2 children, 3 refs', () => {
+    globalThis.__benchSink = panel.$mount().$destroy();
+  });
+
+  bench('Bare — 1 handler, nothing declared', () => {
+    globalThis.__benchSink = bare.$mount().$destroy();
+  });
+
+  bench('DeepPanel — 8 handlers, 4 classes deep', () => {
+    globalThis.__benchSink = deep.$mount().$destroy();
+  });
+});
+
+/**
+ * A fixed pool, cycled: a fresh element per iteration would grow the document
+ * without bound over a few thousand samples, and the append would end up
+ * being what is measured.
+ */
+const pool = Array.from({ length: 100 }, panelElement);
+let next = 0;
+const nextElement = () => pool[next++ % pool.length];
+
+describe('first mount of a fresh instance (construction included)', () => {
+  bench('Panel', () => {
+    globalThis.__benchSink = new Panel(nextElement()).$mount();
+  });
+
+  bench('DeepPanel', () => {
+    globalThis.__benchSink = new DeepPanel(nextElement()).$mount();
+  });
+});

--- a/packages/v4/src/responsive-options.spec.ts
+++ b/packages/v4/src/responsive-options.spec.ts
@@ -326,6 +326,36 @@ describe('responsive options', () => {
     expect(banner.changes[0]).toMatchObject({ value: 'dark', previousValue: 'light' });
   });
 
+  /**
+   * The one import-time side effect this module has, pinned.
+   *
+   * `onBreakpointsReplaced()` is called at module scope, and its job is
+   * exactly this: a replaced set means names that were never registered with
+   * the one observer, whose filter takes **exact** attribute names. Without
+   * the subscription the failure is silent — `data-option-columns` keeps
+   * being honoured while `data-option-columns:<new name>` is invisible — so
+   * `package.json` names this module in `sideEffects` and this is what says
+   * why.
+   */
+  it('observes a scoped spelling named by a breakpoint set installed later', async () => {
+    atSmall();
+    const root = render('<div data-component="Grid" data-option-columns="1"></div>');
+    await settle();
+    const grid = getInstance<Grid>(root.firstElementChild, 'Grid');
+    grid.changes = [];
+
+    // A name no component was ever registered against: `wide` did not exist
+    // when `Grid`'s option attributes entered the filter.
+    setBreakpoints({ small: '0rem', wide: '0rem' });
+    await settle();
+    grid.changes = [];
+
+    grid.$el.setAttribute('data-option-columns:wide', '6');
+    await settle();
+    expect(grid.changes).toHaveLength(1);
+    expect(grid.changes[0]).toMatchObject({ value: 6, previousValue: 1 });
+  });
+
   it('holds its `matchMedia` listener for the mount cycle, and no longer', async () => {
     atSmall();
     const root = render(

--- a/packages/v4/src/services/breakpoint.ts
+++ b/packages/v4/src/services/breakpoint.ts
@@ -137,8 +137,13 @@ export function onBreakpointsReplaced(callback: () => void): () => void {
 
 /**
  * The widest matching name. The set is ascending, so the last match wins.
+ *
+ * Annotated because a top-level call is retained by default, and retaining
+ * this one retains `queryList()` and the service graph behind it — which is
+ * what `./BREAKPOINTS` and `./getBreakpoints` pay for a name they never
+ * compute. Measured: 0.38 → 0.11 kB and 0.38 → 0.13 kB gzip.
  */
-const widestMatch = memo((): string => {
+const widestMatch = /* @__PURE__ */ memo((): string => {
   let match = '';
   for (const [name, query] of queryList()) {
     if (query.matches) {


### PR DESCRIPTION
Refs #780.

`#bindHandlers()` runs on **every** `$mount()`, not once per instance. Under a `data-mount` strategy a component mounts and unmounts as often as it scrolls past, so it is a repeat path — and almost everything it did read the class and nothing else.

## What was redone per mount

- `Object.keys(this.$config.components ?? {}).sort(byLength)` — allocated and sorted
- `(this.$config.refs ?? []).map(…).sort(…)` — allocated, mapped and sorted
- a walk of the whole prototype chain, `Object.getOwnPropertyNames()` per prototype, a regex per name
- per handler name: `resolveGlobal()`, the prefix match against every child name and every ref, `kebabCase()`

None of it can differ between two instances of one class. It is now worked out once per constructor with `memo()`, keyed on the constructor. What stays per mount is the closures that call `self[method]` and the `addEventListener()` calls, which is what a mount actually is.

## The instance lookup, kept

`getHandlerNames()` tested `typeof instance[name] === 'function'`, which resolves **through the instance** — a class field can shadow a prototype method with a non-function, so two instances of one class could in principle disagree, and a per-class cache would erase that.

Nothing in the tree relies on it: no v4 component, no ported family and no spec shadows an `on<…>` prototype method, v3's own `getEventMethodsByName()` (`EventsManager.ts`) does no function check at all, and a class field written as a handler (`onClick = () => {}`) was never bound anyway — it is an own property of the instance and the scan walks prototypes. The v4 place where a class field *does* have to be seen is the service mixin (`services/mixin.ts:185`), which looks a hook up by a *known* name rather than enumerating.

It is kept regardless, because keeping it is nearly free: **the plan lists names, and `#bindHandlers()` asks the instance**, one `typeof` per entry. The expensive half — the walk, the `getOwnPropertyNames()`, the regex — is what the memo removes. A spec pins the behaviour, and it fails if the check is dropped.

## Invalidation

No `clear()`, and nothing calls one. The plan is derived from the prototype chain, fixed once a class is defined, and from `resolveConfig(ctor)`, which is itself cached per constructor and so already returns the same answer for the plan's whole life. A class that gained a handler afterwards would need a new prototype, which is a new class and a new key.

## Speed

`packages/v4/src/mount.bench.ts`, Chromium, `$mount()` + `$destroy()` on one instance — the repeat path. Two runs each side, medians:

| shape | before | after | before | after | |
| --- | ---: | ---: | ---: | ---: | ---: |
| Panel — 5 handlers, 2 children, 3 refs | 44.0k ops/s | 88.0k ops/s | 22.5 µs | 11.4 µs | **1.99x** |
| Bare — 1 handler, nothing declared | 137k ops/s | 196k ops/s | 7.3 µs | 5.1 µs | **1.43x** |
| DeepPanel — 8 handlers, 4 classes deep | 24.6k ops/s | 43.4k ops/s | 40.7 µs | 23.0 µs | **1.77x** |

The `Bare` row is the floor and reads as it should: with one handler and nothing declared there is barely anything to resolve, and the remaining 1.43x is the sorts and the prototype walk that ran even then.

Construction + first mount, measured separately so the two are not read as one number:

| shape | before | after | before | after | |
| --- | ---: | ---: | ---: | ---: | ---: |
| Panel | 33.3k ops/s | 51.4k ops/s | 30.0 µs | 19.5 µs | **1.54x** |
| DeepPanel | 16.6k ops/s | 26.0k ops/s | 60.2 µs | 38.5 µs | **1.57x** |

The first version of this benchmark reported that row as flat. It was wrong, and review caught it: it mounted without destroying, leaking a `window` resize listener per iteration, so its later samples measured the listener list rather than the mount. With one instance alive at a time the path improves ~1.6x, less than the remount path because construction — `buildOptions()`, `buildRefs()` — is in it and is untouched.

## Size — a regression this PR caused, and two it found

The first push regressed **every** export by ~5.8 kB gzip. `const handlerPlan = memo(…)` is a top-level call, a bundler cannot prove one side-effect free, and keeping it keeps everything it references — which is all of `Base`. Every constant subpath is a re-export *from* `Base.js` and owes its size entirely to `Base` being shaken away, so all of them converged on `Base`'s own size. Fixed with `/* @__PURE__ */`, the same annotation `services/drag.ts`, `scroll.ts` and `resize.ts` already put on their `perTarget()` calls, and the fix restores the baseline **byte for byte** on its own.

Chasing it turned up two more, both shipped as their own commits:

- **`widestMatch` in `services/breakpoint.ts` was the same bug, pre-existing from #783** — an unannotated top-level `memo()` pinning `queryList()` and the service graph behind it. `./BREAKPOINTS` 0.38 → 0.11 kB, `./getBreakpoints` 0.38 → 0.13 kB.
- **v4 never declared `sideEffects`**, while `packages/js-toolkit` has since forever. Now declared, in the **array form** naming the one module that genuinely has an import-time effect: `responsive-options.ts` registers a breakpoint-replacement subscription at module scope. Under a blanket `false` a bundler may drop that call and the failure is silent — options keep working until `setBreakpoints()` installs a name that was never registered with the one mutation observer, after which `data-option-x:<new>` is invisible while the plain `data-option-x` is honoured. A new spec pins exactly that, and fails with exactly that symptom when the subscription is removed. `./on` is what the carve-out costs: 2.25 kB rather than the 0.67 kB a blanket `false` would give, because it reaches the module through `Base` — still below `main`.

The third unannotated `memo()`, `scopedAttributes` in `responsive-options.ts`, is deliberately left alone: its module has the genuine side effect above, so it is retained whatever the memo is marked, and annotating it moves no measured byte.

### Net effect on export size, against `main`

Per subpath, esbuild bundle + minify, `gzip -9` — the local equivalent of the CI report, and it reproduces `SIZE.md`'s documented baseline exactly (`./Base` 7.52, `./swap` 3.91, `./SWAP_MODES` 2.99, `./on` 2.33). 21 of 76 exports moved; **55 are unchanged, and none grew except the six that carry `Base`.**

| subpath | main | after | diff |
| --- | ---: | ---: | ---: |
| `./MOUNTED_EVENT` | 1.86 kB | 0.07 kB | −1.79 |
| `./DESTROYED_EVENT` | 1.87 kB | 0.08 kB | −1.79 |
| `./write` | 1.89 kB | 0.12 kB | −1.77 |
| `./read` | 1.89 kB | 0.12 kB | −1.76 |
| `./provide` | 1.94 kB | 0.18 kB | −1.76 |
| `./inject` | 1.93 kB | 0.17 kB | −1.76 |
| `./children` | 1.97 kB | 0.22 kB | −1.75 |
| `./MOUNT_ATTRIBUTE` | 0.91 kB | 0.07 kB | −0.84 |
| `./DRAG_MODES` | 0.98 kB | 0.16 kB | −0.82 |
| `./SWAP_MODES` | 2.99 kB | 2.19 kB | −0.80 |
| `./BREAKPOINTS` | 0.38 kB | 0.11 kB | −0.26 |
| `./getBreakpoints` | 0.38 kB | 0.13 kB | −0.24 |
| `./HANDLER_REGISTRATIONS` | 1.86 kB | 1.77 kB | −0.09 |
| `./on` | 2.33 kB | 2.25 kB | −0.09 |
| `./SOURCE` | 1.84 kB | 1.76 kB | −0.09 |
| `./Base` | 7.52 kB | 7.64 kB | **+0.12** |
| `./registerComponent` | 9.14 kB | 9.26 kB | **+0.12** |
| `./registerComponents` | 9.15 kB | 9.28 kB | **+0.12** |
| `./registerManifest` | 9.21 kB | 9.33 kB | **+0.12** |
| `./component` | 9.23 kB | 9.34 kB | **+0.12** |
| `(barrel)` | 15.75 kB | 15.86 kB | **+0.12** |

The +0.12 kB is the plan's own code and nothing else — it matches the +116 B the CI report gave `Base` when everything else was broken. Summed over all 76 exports: 123.19 → 108.30 kB.

## Also here

`belongsTo()` rebuilt `selectorFor(owner)` inside the ancestor loop — once per ancestor, per namespaced ref, per mount. Hoisted out of the loop, in its own commit. Not memoised: a loop-invariant hoist is strictly better than a cache here. It does not move the mount numbers above, because the `owner` form is only reached for namespaced refs, which the benchmark shape does not use.

## Tests

Four new specs in `Base.spec.ts` under `the per-class handler plan`, on top of the existing coverage for remount, global bind/unbind and delegation:

- two instances of one class each bind to their own subtree, from the shared plan — own, delegated child, delegated list ref, and global
- every kind of handler rebinds on a remount
- a subclass resolves against its own merged config, and does not disturb its parent's plan
- an instance shadowing a prototype handler with a non-function is skipped, and no listener is bound that would throw

Plus one in `responsive-options.spec.ts` pinning the import-time subscription the `sideEffects` carve-out exists for.

Full v4 suite (48 files, 641 passing + 1 expected fail), `tsc --noEmit`, `oxlint`, `oxfmt --check` and `subpaths:check` are green. The two `unicorn(no-useless-spread)` warnings in `packages/v4/src/context.ts:93` and `packages/js-toolkit/src/autoload/loader.ts:467` are pre-existing and untouched.

`DESIGN.md` is unchanged: it documents the resolution rules, which are identical, and never described the per-mount recomputation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MZV1ZifTfhQkHm4tavc5a
