### PR TITLE
Investigation(v4): where the size goes, and what could be simplified

### DIFF
--- a/packages/v4/SIMPLIFY.md
+++ b/packages/v4/SIMPLIFY.md
@@ -1,0 +1,709 @@
+# Simplify — what is over-engineered, and what only looks it (2026-08-14)
+
+Companion to `SIZE.md`. That document asked what v4 costs; this one asks what v4
+could stop doing. They are different questions with different answers, and the
+headline here is a negative result: **of everything that reads as excessive
+caution, almost none of it is. The work is documentation, not deletion.**
+
+Audited: every runtime module in `packages/v4/src`, plus what `migration/` and
+`demo/` actually consume. Method and its limits in §6.
+
+## The rule this audit was run under
+
+`SERVICES-REVIEW.md` records **17 confirmed defects** found by adversarial
+review, each fixed with a regression test. Much of what looks defensive here is
+the scar of a measured failure — `memo()` uses `has()` rather than an `undefined`
+check because the cheap version recomputes a memoised `undefined` forever; the
+services fan-out walks a snapshot because iterating the live set delivered props
+to subscribers that did not exist yet.
+
+So nothing was called unnecessary without checking three things: **does a test
+fail without it, does a comment or design doc explain it, and does `git log -S`
+show it arriving with a fix.** A yes to any one makes it justified, and the only
+question left is whether the reason is written down.
+
+Two disciplines follow, and they are what makes this list short:
+
+- Where a guard is called untested, that was established by **deleting it,
+  rebuilding and running the suite** — not by reading.
+- Where something is called unused, "no consumer in this repository" was treated
+  as **weak** evidence. v4 is a private prototype at version `0.0.0`; its
+  consumers do not exist yet, and `migration/` is ten ported families, not a user
+  base. §5 lists three exports a naive unused-symbol sweep flagged that are
+  plainly justified.
+
+---
+
+## Summary
+
+| Category                                  | Count |
+| ----------------------------------------- | ----: |
+| 1 — unjustified, remove                   |    10 |
+| 2 — justified but undocumented, document  |    19 |
+| 3 — justified and documented, leave alone |  ~115 |
+
+Plus **three latent defects** found while checking guards (§4). They are not
+over-engineering and are reported separately.
+
+`Base.ts` carries **79 JSDoc blocks in 1 950 lines** — one every 25 lines — and
+most name the naive alternative and why it fails. `context.ts` has 23 in 585
+lines, of which roughly 330 are prose; `negotiated-events.ts` 20; `registry.ts` 19. That density is why category 3 dominates, and it is why this audit found so
+little to cut.
+
+---
+
+## 1. Unjustified — remove
+
+Ordered by value. Every entry states what it costs to be wrong.
+
+### 1.1 `optionAttributes()` re-walks the prototype chain `resolveConfig()` already caches
+
+`registry.ts:290–306` walks `current.config.options` up the constructor chain by
+hand, deduplicating with a `Set`. `Base.ts:879–907` already merges `options`
+along that chain and memoises the result per constructor — and `registry.ts:1`
+**already imports `resolveConfig`**. The function collapses to
+`Object.keys(resolveConfig(ComponentClass).options ?? {})`; the `Set` exists only
+because the hand walk visits inherited configs repeatedly.
+
+- **Cost of being wrong:** none behavioural — both derivations produce the same
+  set. The risk runs the other way: this is the third config key read off the own
+  static instead of the merged one, and the other two both shipped as bugs
+  (`d5d61e6e` merge `mountStrategy` along the chain, `da40f232` register the
+  merged `config.components`).
+- **Amends `SIZE.md`:** §R7 lists this row but gates it on `resolveConfig()`
+  moving to `config.ts` as part of R2. That gate does not exist — the import edge
+  is already there — so this is a standalone ~8-line deletion available today.
+  `SIZE.md` §R7 has been corrected.
+
+### 1.2 `ingest()`'s attribute filter is dead, and it is a hazard rather than a guard
+
+`dom-mutations.ts:211–222` filters every incoming batch on
+`type === 'childList' || attributeName === 'data-component' | 'data-mount' |
+'data-ref' | startsWith('data-option-')`. The observer feeding it runs with
+`attributeFilter: [...observedAttributes]` (line 66), and `observedAttributes`
+can only ever hold those exact names: it starts as the three framework
+attributes (line 36) and grows only through `registerDOMOptionAttributes()`,
+whose two callers pass `data-option-<kebab>` (`registry.ts:295`) and its
+breakpoint-scoped spellings (`responsive-options.ts:64`). The separate
+`watchElementAttributes` observer feeds `ingestWatchedAttributes`, not this. So
+the predicate is true for every record delivered: the filter allocates a copy of
+each batch and removes nothing.
+
+_Verified two ways._ By history: `git log -S'const relevant = incoming.filter'`
+gives `e0b8ef05 feat(v4): react to live option changes`, whose diff **removes**
+`attributeFilter` and adds this filter to compensate. `2cdbc1b6 fix(v4): harden
+mutation lifecycle processing` then reintroduces a dynamic `attributeFilter` and
+adds `observedAttributes` — but leaves the filter behind. It is a leftover from a
+superseded design. By measurement: replacing it with `const relevant = incoming`
+leaves the suite green (48 files, 636 passed).
+
+- **Cost of being wrong:** the filter protects nothing and can only lose work — if
+  a future caller ever registers an attribute outside `data-option-*`, it
+  silently drops those records. Keep the `.some()` immediately after it; that one
+  genuinely discriminates (`data-mount` and `data-option-*` must not bump
+  `version`). Replace the `.filter()` with an `incoming.length === 0` early
+  return.
+
+### 1.3 `perTarget()`'s `keyOf` parameter — the consumer that asked for it rejected the helper
+
+`service.ts:267`. Added by `d7c8f01d` for "arguments that do not serialise, such
+as an `IntersectionObserverInit.root`". The consumer it names,
+`migration/utils/inView.ts`, **does not use `perTarget()` at all**: it hand-rolls
+`WeakMap<root, WeakMap<Element, Map<string, Service>>>` (`inView.ts:69–79`)
+precisely because `root` is an object that no `string` key can carry — which is
+what `keyOf` returns. All three real callers (`scroll.ts:285`, `resize.ts:123`,
+`drag.ts:404`) take the default.
+
+- **Cost of being wrong:** a future service takes a non-serialisable argument and
+  re-adds the parameter — three lines, no call site to migrate.
+
+### 1.4 The five `*MixinOptions` type aliases
+
+`raf.ts:126`, `pointer.ts:168`, `scroll.ts:325`, `resize.ts:157`, `drag.ts:430`.
+Five exported aliases with zero references anywhere — no `src/`, no `migration/`,
+no `demo/`, no spec — and no doc comment on any. Two are the _same type_ under
+two names (`RafMixinOptions` and `PointerMixinOptions` are both
+`ServiceMixinOptions<void>`). Verified by `rg` over the package: the only
+occurrences are the declarations and their five re-exports in `index.ts`.
+
+- **Cost of being wrong:** a consumer naming a mixin's options type writes
+  `ServiceMixinOptions<Element>`, which is exported and documented.
+  `DragMixinOptions` is the only one with content
+  (`DragOptions & ServiceMixinOptions<DragTarget>`); if one survives, that is it.
+
+### 1.5 `destroyWithin`'s optional `snapshot` and its fallback are unreachable
+
+`registry.ts:574` declares `snapshot?: readonly Element[]` and falls back to
+`[node, ...node.querySelectorAll('*')]` on line 578. There is one call site
+(`registry.ts:607`), and `dom-mutations.ts:241–248` populates `removedSubtrees`
+for **every** removed node passing `node instanceof Element` — the exact
+predicate `destroyWithin` itself requires before reaching the loop (line 575).
+_Verified by reading both sides._ Making the parameter required states the
+invariant in the type.
+
+- **Cost of being wrong:** a caller passing no snapshot would iterate the _live_
+  subtree instead of the removed one and miss descendants that already moved —
+  which is exactly the bug `2cdbc1b6` introduced the snapshot to fix. The
+  fallback is not merely dead: it is dead code that would reintroduce a fixed bug
+  if it ever ran. Deleting it is safer than keeping it.
+
+### 1.6 `Base.$off()` has no caller, and its only justification is a v3-continuity promise
+
+`Base.ts:1217`. Zero callers in `src/`, `migration/`, `demo/` **and the specs** —
+the only other mention in the package is `DESIGN.md:355`, "`$on`/`$off` and
+`Action`-style directives keep working unchanged". `$on()` returns its own
+teardown, and both ported families that bind listeners by hand use that
+(`migration/Action/ActionEvent.ts:274`, `migration/Track/TrackEvent.ts:275`).
+
+- **Cost of being wrong:** a userland caller keeping a listener reference to
+  remove later keeps `$on()`'s returned teardown instead — strictly less
+  bookkeeping. The real cost is the design one: `$off` is a
+  backward-compatibility affordance, and `DESIGN.md` open question 4 already
+  decided v4 ships as a full breaking major with no bridge release. Keeping it
+  contradicts that decision; removing it is the decision applied.
+
+### 1.7 `test-utils.ts` is built into `dist/` with no export path
+
+`scripts/build.js` globs `**/*.ts` excluding specs and benches, so
+`src/test-utils.ts` is emitted as `dist/test-utils.js` (3 309 B) + `.d.ts`
+(1 957 B) + `.js.map` (5 787 B). It appears in no `exports` entry, and `rg`
+confirms it is imported **only** by `*.spec.ts` files, which resolve from `src/`.
+
+- **Cost of being wrong:** nothing. No consumer can reach it — there is no
+  subpath — and the specs do not read `dist/`.
+- **Note:** genuinely a one-line change (`'!**/test-utils.ts'` in the build glob),
+  but no test covers the build script's glob, so it is reported rather than
+  committed.
+
+### 1.8 `lerp` — no consumer and no test
+
+`utils/maths.ts:62`, subpath `./utils/lerp`. Verified by `rg` over the package:
+no call site in `src/`, `migration/` or `demo/`, and no case in `maths.spec.ts`
+(which does cover `clampDampFactor`, `decayOver`, the whole inertia family,
+`damp` and `spring`). It also contradicts its own module header, which says
+`maths.ts` is "not a port of `@studiometa/js-toolkit/utils/math`: only what is
+actually used".
+
+- **Cost of being wrong:** near zero — `map(x, 0, 1, min, max)` is the same value,
+  and `map()` is used three times in `migration/`.
+- **Caveat:** this is a _public utility_, so §5's warning applies here more than
+  anywhere else on this list. It is included only because it is the single export
+  with neither a consumer nor a test.
+
+### 1.9 `scan()`'s `controllers.has(el) || loaders.has(el)` filter — probably unreachable
+
+`registry.ts:539–544`. `scan()` has one caller, `processMutations`'s `addedNodes`
+loop, on connected nodes. Controllers and loaders exist only for connected
+elements, and every disconnection disposes them — `processMutations` runs
+teardown first (`registry.ts:604–610`) and `destroyWithin` disposes everything in
+the snapshotted subtree before any addition record is processed. _Measured:_
+removing both conditions leaves the suite green (48 files, 636 passed). The
+sibling condition `el.__base__` **is** reachable and is what the comment on
+`registry.ts:531–533` describes.
+
+- **Cost of being wrong:** an element that somehow retained a stale controller
+  would never be re-reconciled, so it would not remount.
+- **Honest caveat:** a green suite is necessary, not sufficient, for an
+  unreachability claim about a `MutationObserver`-driven system. This is the one
+  entry in §1 where I would want a second opinion before deleting. The gain is
+  real but small — two `WeakMap` lookups per element on the `swap()`/morph hot
+  path.
+
+### 1.10 Two redundant `export`s
+
+`registry.ts:33` re-exports the `ComponentImporter` type that `Base.ts:96`
+already exports, for one consumer (`index.ts:116`) that can import it from
+`./Base.js`. `scheduler.ts:140` exports `class Scheduler`, which is constructed
+exactly once (line 396), is not in the `index.ts` barrel and has no subpath — so
+a second instance is not reachable as public API anyway. Both are one-word
+changes; listed for completeness.
+
+---
+
+## 2. Justified but undocumented — document
+
+This is where the value is. Every item below is **correct code**; what is missing
+is the reason, and the reason is what stops the next reader from "simplifying" it
+into a bug.
+
+### 2.1 Six error-isolation guards in `Base`'s lifecycle have no test, and their rationale is written down only for the scheduler
+
+The top finding of this audit.
+
+`Base.ts` has eleven `try`/`catch` blocks. _Measured_ by deleting all eleven,
+rebuilding and running the suite: **exactly two tests fail** —
+`Base.spec.ts:330` "isolates option effect errors and reentrant cleanup" and
+`Base.spec.ts:389` "keeps primitive defaults and attribute values as they were".
+Those cover four sites: the `JSON.parse` guard (`Base.ts:836`) and the three
+option-effect guards.
+
+The other **six have no regression test at all**. _Measured separately:_ deleting
+just those six leaves the suite fully green (48 files, 636 passed).
+
+| Site           | Guards                                 |
+| -------------- | -------------------------------------- |
+| `Base.ts:1076` | `mounted()` throwing                   |
+| `Base.ts:1121` | a mount cleanup throwing               |
+| `Base.ts:1128` | `destroyed()` throwing                 |
+| `Base.ts:1154` | a termination cleanup throwing         |
+| `Base.ts:1160` | `terminated()` throwing                |
+| `Base.ts:1737` | a late (post-destroy) cleanup throwing |
+
+They are **justified**: all six wrap user code, and error isolation is a stated
+property of this framework — one component's throw must not stop a mount sweep,
+leave the registry half-updated, or abort the other components on the page.
+
+But that property is written down for the _scheduler_ only: `DESIGN.md:622`
+("try/catch per task; a throwing task is reported and dropped, the flush
+continues") and `index.ts:24`. Nothing states it for `Base`, and nothing pins it.
+
+- **What to write, and where:** a paragraph in `DESIGN.md` §1 saying every user
+  hook and every user-returned cleanup runs under isolation, so a throwing
+  component degrades alone — plus one back-reference above `$mount()`.
+- **What to add:** one test in the shape of `Base.spec.ts:330`, with a component
+  whose `mounted()`, `destroyed()` and cleanup all throw, asserting a sibling
+  still mounts. Six guards, one test.
+- **Why this outranks the rest:** `SIZE.md` §R7 measured that deleting all eleven
+  saves 0.12 kB gzip. Someone reading only that number, and finding no test in
+  the way, has every incentive to delete them.
+
+### 2.2 `createServiceMixin` forwards its own options into the service cache key
+
+`mixin.ts:188` calls `definition.use(target(this), options)` with the **whole**
+mixin options object. `withDrag`'s `use` is
+`(target, options) => useDrag(target, options)` (`drag.ts:465`), and `useDrag` is
+`perTarget(…)`, keyed by `JSON.stringify` over the arguments. So the mixin's own
+`manual` and `immediate` become part of the service identity.
+
+_Measured_ with a throwaway probe (since deleted):
+
+```js
+useDrag(el, { manual: true }) !== useDrag(el, {}); // two services, one element
+useDrag(el, {}) === useDrag(el, {}); // same options, same service
+```
+
+Drag is the only mixin affected — the other four ignore `use()`'s second
+argument. §4.1 states what it costs at runtime.
+
+- **What to write, and where:** a line in `perTarget()`'s doc (`service.ts:255`)
+  saying the key must contain only what changes _what is observed_, and a line at
+  `mixin.ts:188` about what is forwarded.
+
+### 2.3 Two ported components hand-roll `toggle()` because their comments say v4 has no equivalent
+
+`migration/ScrollAnimation/withScrolledInView.ts:82` states that
+`$services.enable('ticked')` / `disable('ticked')` has "**no v4 equivalent**",
+and line 202 repeats it. Both then write
+`this.__unsubscribeFrame ??= useRaf().subscribe(…)` / `?.(); = null` — which is
+`toggle()` line for line. `migration/Slider/SliderItem.ts:96–108`
+(`#startTicking`/`#stopTicking`) is the same shape.
+
+`migration/REPORT.md:496` records this gap as **resolved** by `toggle()`, and
+`REPORT.md:93` maps `$services.enable('ticked')` → `toggle(…)`.
+`mixin.spec.ts:322–435` proves `withRaf(Base, { manual: true })` + `$services` is
+the second answer. The framework has two; the ported components know neither.
+
+This is also the answer to "is `toggle()` earning its place": yes — the two
+components that needed it re-implemented it because a stale comment said it did
+not exist.
+
+- **What to write, and where:** fix the comments in `withScrolledInView.ts:82,202`
+  and `SliderItem.ts:96` to point at `toggle()` and `{ manual: true }`. If the
+  ports are meant to be exemplary, use them.
+
+### 2.4 `CAPTURED_EVENTS` implements a feature two design documents say is not supported
+
+`Base.ts:187` lists nine non-bubbling events delegated from the capture phase,
+including `mouseenter`/`mouseleave`/`pointerenter`/`pointerleave`.
+`DESIGN.md:374` documents the mechanism and argues it carefully. But
+`DESIGN.md:354` says "`mouseenter`/`mouseleave` do not bubble: these two keep
+direct binding (**accepted limitation**)", and `index.ts:55–56` says "Not in this
+prototype: … non-bubbling child events (mouseenter/mouseleave)".
+
+_Read:_ the mechanism works and is tested for `focus` (`Base.spec.ts:751`) and
+`scroll` (`:884`). The four hover events have **no test and no consumer** — `rg`
+finds no `onXMouseenter`-shaped handler in `migration/` or `demo/`.
+
+This needs a decision rather than an edit: `mouseenter` fires on _every_ element
+the pointer enters, so a capture-phase listener on a component root hears far
+more than a delegated `click` does. The two docs may be recording a deliberate
+limitation the implementation quietly outgrew, or a real reservation the
+implementation ignores.
+
+- **What to write, and where:** decide, then make `DESIGN.md:354`,
+  `DESIGN.md:374` and `index.ts:55` agree. If the hover events stay, they need the
+  test the other five have.
+
+### 2.5 `DESIGN.md:402` names a consumer for `$emitExtendable()` that the ported code contradicts
+
+`rg 'emitExtendable|waitUntil'` over `migration/` and `demo/` returns nothing.
+`DESIGN.md:402` states "`Dialog` becomes `await this.$emitExtendable('close')`",
+but `migration/Dialog/Dialog.ts:109–121` uses `$emit('open')`/`$emit('close')`
+plus `Promise.all(this.transitions.map((t) => t.enter()))` over two
+`$watchChildren` collections, and its header lists three v4 decisions without
+mentioning the negotiation.
+
+The mode is **not** a removal candidate: it has 481 lines of spec, and the
+intended consumer is ui's `MotionView` (`DESIGN.md:402,424`). Note the contrast
+with the take-over mode, which is in the same position but _does_ explain itself
+— `migration/Data/dom-update.ts:12–18` says why the ported copy of ui's protocol
+stays.
+
+- **What to write, and where:** beside the Dialog claim in `DESIGN.md`, that the
+  in-repo port deliberately uses live children collections instead — so the doc
+  stops asserting a consumer the code contradicts.
+
+### 2.6 `registry.ts:516` — the registry/manifest guard before `$terminate()`
+
+Every name reaching that point via `controllers` or `loaders` is registry- or
+manifest-known by construction, so `(registry.has(name) || manifest.has(name))`
+looks redundant. It is not: `Base.ts:1030–1031` puts **every** instance into
+`el.__base__` from the constructor, including a hand-built `new Foo(el)` — which
+`migration/ScrollAnimation/ScrollAnimation.spec.ts` does. Without the guard, an
+element carrying a manually-constructed instance of an unregistered class gets
+`$terminate()`d the first time a mutation makes `scan()` visit it — and `scan()`
+visits it _because_ `el.__base__` is set (`registry.ts:541`).
+
+- **What to write, and where:** one sentence in the comment above
+  `reconcileElement` (`registry.ts:503`): the registry only ends identities it
+  owns, because `__base__` also holds hand-built instances.
+
+### 2.7 Three undocumented guards in `context.ts`, each defending against a foreign provider
+
+None has a test or a comment, and all three exist because the WICG
+`context-request` protocol is a _page-wide_ event that other libraries also
+speak. `context.ts` says so once, in the `subscribe` field comment (lines
+166–176), and never connects it to the guards it explains.
+
+| Site             | Guard                                        | What it defends against                                                                                                                      |
+| ---------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context.ts:203` | `provider instanceof Node ? provider : null` | a third-party provider calling `detail.provide()` _after_ dispatch, when `currentTarget` is `null`                                           |
+| `context.ts:394` | `detail?.key !== key`                        | a foreign `context-request` on the page — Lit's `ContextEvent` carries its fields on the event, not in `detail`                              |
+| `context.ts:334` | `providerNode === mountedEl`                 | a provider element re-announcing itself; a correct fast path, but it also means such an element can never re-answer with a _different_ value |
+
+The third is additionally contradicted by its own doc: lines 298–319 enumerate
+"exactly the set of consumers whose answer can have changed" as two `contains()`
+calls, and commit `086fe358` says "Cost is bounded by two `contains()` calls" —
+the code has three conditions.
+
+- **What to write, and where:** one clause each, plus a back-reference from all
+  three to the `subscribe` comment that already states the premise.
+
+### 2.8 `raf.ts:54` — `renders.length = 0` depends on a decision in another file
+
+`renders` is drained every frame that produced any (`raf.ts:57–58`) and pushed
+only from inside the wrapper callback (`raf.ts:83`). The one path that could push
+outside a frame is `createService`'s `{ immediate: true }` delivery
+(`service.ts:190`), which is closed only because `hasProps: () => false`
+(`raf.ts:45`). So the leading reset is a safety net whose necessity lives in a
+different module. No test targets it, and it arrives with the original feature
+commit `f8942dea`, not with a fix.
+
+- **What to write, and where:** a comment at `raf.ts:54` naming the
+  `hasProps: false` coupling — otherwise deleting it makes `raf.ts` silently
+  depend on that flag never changing.
+
+### 2.9 `scroll.ts:64` — the `typeof window` guard reads as an SSR promise
+
+`supportsScrollEnd`'s `typeof window !== 'undefined'` is the **only** environment
+guard in `packages/v4/src`, and it protects _module evaluation_: this is the only
+eager top-level `window` access in the package. Nothing in `DESIGN.md` or
+`package.json` mentions SSR, and every spec runs in Chromium, so no test
+exercises it.
+
+- **What to write, and where:** a comment at `scroll.ts:64` saying the guard is
+  for module evaluation and not a claim of SSR support — or make the probe lazy
+  (first `start()`) and delete it, which also removes an eager IIFE from a hot
+  module.
+
+### 2.10 `scheduler.ts` — a stale doc line and an unexplained `.catch`
+
+Two small ones in the same file.
+
+`scheduler.ts:218` says `whenIdle()` "resolves once every queue is empty **and no
+flush is scheduled**". `#isIdle()` checks queues only, and deliberately — the
+comment on it and the spec `never keeps whenIdle() waiting`
+(`scheduler.spec.ts:281`) both require that a tick subscription, which keeps a
+flush permanently scheduled, must not block it. The second clause is simply
+stale; drop it.
+
+`scheduler.ts:69` puts `.catch(reportError)` on `scheduler.postTask()`. Without
+it, an exception escaping `#drainBackground()` — from a `whenIdle` resolver, say
+— becomes an unhandled rejection instead of a reported error, and only on the
+native branch, not the `MessageChannel` one. The surrounding comment explains the
+choice of transport, not this catch. No test.
+
+### 2.11 `registry.ts:345` — the strategy re-check in `isCurrentPair()`
+
+The other four conditions are covered by the comment at `registry.ts:329–333`;
+this one is not, and it reads as redundant with `schedule()`'s own
+`current?.strategy === strategy` early return. Its real job is the window between
+a synchronous `data-mount` write and the background batch that reconciles it: an
+`IntersectionObserver` or `media:` trigger can fire against the old strategy in
+that gap. **Where:** one line inside `isCurrentPair`.
+
+### 2.12 `registry.ts:453` — `scheduleLoad()` re-spells `resolveStrategy()`'s precedence chain
+
+It genuinely cannot call `resolveStrategy()` (no class exists yet) and
+`DESIGN.md` §11b spells the chain out, but nothing at the site says "same chain,
+with the manifest entry standing in for the class config". The rationale lives
+250 lines away in `registerManifest`'s doc. **Where:** a one-line back-reference,
+so the two copies do not drift.
+
+### 2.13 `getHandlerNames()` has no doc comment at all
+
+`Base.ts:947–962`. The only function of its size in `Base.ts` without one, in a
+file averaging one JSDoc block every 25 lines. Two things a reader cannot infer:
+why the walk stops at `Base.prototype`, and why the value is re-read from the
+_instance_ rather than the prototype (so a handler written as a class field
+wins). **Where:** above the function.
+
+### 2.14 `withPointer` is the only one of five service mixins with no test
+
+_Verified by `rg` over the package:_ `withPointer` (`pointer.ts:186`) has zero
+references outside its own declaration, its subpath stub and the `index.ts`
+re-export — including zero in `mixin.spec.ts`, where its four siblings are
+exercised.
+
+It is **justified by symmetry**: `usePointer` alone would make `moved()` the one
+service hook with no mixin form, and the family is the documented shape
+(`index.ts:28–30`). A design reason, not an accident — so category 2, not 1.
+
+- **What to add:** the test its four siblings have. A mixin nothing exercises is
+  a mixin nobody will notice breaking.
+
+### 2.15 `viewTransition.ts` — three branches, one test
+
+`viewTransition.spec.ts` has a single case, the native happy path. Untested: the
+`typeof document.startViewTransition !== 'function'` fallback (lines 51–59), both
+`reject` fan-outs, and the `vtRunning` serialisation of a batch queued while a
+transition is in flight (lines 41–43, 62–69). The behaviour _is_ documented in
+the function's doc comment; only the coverage is thin. Worth a regression test
+rather than a change — and note the fallback is what every non-Chromium browser
+takes today.
+
+### 2.16 `registerComponent`'s duplicate-name warning has no test
+
+`registry.ts:172–175`. The code is right and documented (`DESIGN.md:900`, "like
+`customElements.define`"), and the _silent_ half — same name, same class, which
+is what terminates `registerFamily`'s recursion — is asserted by
+`autoload.spec.ts:570`. The _warning_ half, two different classes claiming one
+name, is untested, while `registerManifest`'s equivalent has two tests
+(`autoload.spec.ts:281`, `:302`). Three lines to close.
+
+### 2.17 `context.ts:355` — the document mount listener is never removed
+
+`isMountListenerAttached` is set once and never reset, so after the last
+subscription is cancelled the listener stays for the life of the page and every
+mount pays the `subscriptionIndex.size === 0` early return (line 322). The
+comment explains only that nothing is attached at import time. **Where:** say
+that detaching is deliberately not done, and why the early return is the cheaper
+trade.
+
+### 2.18 `media.ts:75` — `const key = query.trim()`
+
+Justified: `media.spec.ts:37` "shares one service per query, whatever the
+spacing" fails without it. Undocumented: the line has no comment, and the
+function's doc says only "One service per query string", which `trim()` quietly
+contradicts. A reader also cannot tell the normalisation is deliberately shallow
+— `'(min-width:30rem)'` and `'(min-width: 30rem)'` still key two services.
+
+### 2.19 Four comments that are now factually wrong
+
+Small, but each actively misleads:
+
+| Where                                 | Says                                                                                   | Actually                                                                                                                                                         |
+| ------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `migration/utils/inView.ts:37–56`     | `perTarget()` "keys a `WeakMap` by the target alone and drops the remaining arguments" | pre-`d7c8f01d` behaviour; it now keys by target **and** serialised arguments. The conclusion (it still cannot carry `root`) survives; the stated reason does not |
+| `migration/Track/AbstractTrack.ts:64` | v4 "does not ship" `memo`                                                              | `utils/memo.ts` is shipped and has a `./utils/memo` subpath                                                                                                      |
+| `SERVICES-SURFACE.md` §5              | "`props()` has one consumer in the whole package"                                      | two since `667c4a04` — `responsive-options.ts:104` is now the hottest `props()` call in the package, one per option read                                         |
+| `utils/maths.ts` header               | the file holds "only what is actually used"                                            | `lerp` (§1.8) has no consumer; `spring`/`MAX_SPRING_RATIO`/`smoothTo` are consumed only by each other, and are public API for consumers outside this repo        |
+
+The last row is worth one extra line in `maths.ts`: `smoothTo` and `spring` are
+v3-parity **public utilities** with strong specs (`smoothTo.spec.ts` is 167
+lines and documents the v3 bug it fixes), not framework internals. Saying so
+stops the next audit from flagging them.
+
+---
+
+## 3. Justified and documented — leave alone
+
+**About 115 branches**, counted across the audit: ~40 in `services/`, ~25 in
+`registry.ts`/`mount-strategies.ts`/`instances.ts`, ~25 in `Base.ts`, ~25 in
+`context.ts`/`scheduler.ts`/`swap.ts`/`dom-mutations.ts`/`decorators.ts`. Every
+one has a named regression test, a source comment stating the failure it
+prevents, or a fix commit — usually all three.
+
+Representative, one line each so the shape is visible:
+
+- **`services/`** — the snapshot fan-out with `isActive` (`service.ts:143`),
+  `Subscription` records instead of a `Set` of callbacks (`service.ts:113`),
+  raf's per-subscription render cancellation (`raf.ts:79`), `useScroll`'s
+  `documentElement` redirect (`scroll.ts:306`), resize's observer +
+  `resize`-listener pair (`resize.ts:59`), pointer's `activePointerId` filter
+  (`pointer.ts:93`), drag's four-gate click guard and `touch-action` ownership
+  check (`drag.ts:355`), and `MixedClass`'s `Pick<T, keyof T>` — which looks
+  gratuitous and is not (`mixin.ts:95` records the TS2510 it avoids;
+  `SERVICES-REVIEW.md` §6 records the TS2425 the `Omit` alternative hit).
+- **`registry.ts`** — `isClassLike()` (`registry.ts:66`, commit `64d589a7`, test
+  `autoload.spec.ts:484` — and note it uses the non-writable `prototype`
+  descriptor, naming `fn.toString()` only to explain why _that_ was rejected);
+  every branch of `resolveComponentClass()`; the never-retried `imports` map;
+  `scheduleLoad`'s `fired` latch; the two `manifest.delete(name)` calls, where the
+  second drops an _alias_ token (`autoload.spec.ts:350`).
+- **`Base.ts`** — all four dev warnings, each with a test asserting the
+  deduplication too (`toHaveBeenCalledOnce` across repeated reads); the eight
+  `$emit` type helpers, each with a JSDoc naming the alternative that fails and
+  pinned by `props.spec.ts`; both ref spellings and the namespace form, with the
+  v3 lineage and the named `@studiometa/ui` consumers; `belongsTo`/`isRefOf`; the
+  longest-name-first handler resolution.
+- **core** — `memo()`'s `has()`-over-`get()` split (`memo.ts:88`, `memo.spec.ts:20`);
+  `signal()`'s abandon-and-restart delivery loop (`context.ts:80`, four specs,
+  `REPORT.md` gap 17); the `WeakMap` + `WeakRef` subscription registry
+  (`context.ts:229`); `deliver()`'s `Object.is` short-circuit; the scheduler's
+  phase double-buffering, `[1, 40]` delta clamp, background time slice and
+  `MessageChannel` fallback; all of `swap.ts` — the shallow-clone parsing context,
+  the script-identity diff and `childrenOnly` each explained and each with a spec;
+  `whenDOMSettled()`'s microtask double-take (`dom-mutations.ts:328`).
+
+Two sit on the boundary and are left in category 3 deliberately:
+
+- **`PairController.active`** (`registry.ts:21`) flips in lockstep with the
+  map-identity check `isCurrentPair` already performs, and none of the four
+  current strategies has a teardown that re-enters synchronously. It is insurance
+  against a strategy that does not exist yet — cheap insurance, not unnecessary
+  code, but the weakest member of the category.
+- **`@read`** (`decorators.ts:262`) has no consumer in `migration/` or `demo/` —
+  only `@write` does, in `demo/components/Accordion.ts`. It is one line over the
+  shared `inPhase()` factory and the symmetric half of a pair; removing it costs
+  more than it saves.
+
+---
+
+## 4. Not over-engineering — three latent defects found while checking guards
+
+Reported here because the audit found them, not because they belong to it. None
+is fixed in this branch: each needs a regression test, and this document is an
+audit.
+
+### 4.1 One element can hold two `DragService` instances
+
+The mechanism is §2.2. The consequence: `withDrag(Base, { manual: true })` and
+`withDrag(Base)` on the same element produce two services, so that element gets
+**two `pointerdown` listeners, two `touch-action` writes, and two teardowns
+racing on `previousTouchAction`**. `target` is a function and `JSON.stringify`
+drops it, so that key is harmless; `manual` and `immediate` are not.
+
+_Measured_ with the probe in §2.2. No test covers a mixin option changing the
+service key — `drag.spec.ts:413` only varies `dampFactor`/`dragThreshold`, which
+_should_ change it. Fix: `createServiceMixin` strips `target`/`manual`/`immediate`
+before calling `use()`.
+
+### 4.2 An `<svg data-component>` mounts but never reconciles
+
+`scan()` narrows with `instanceof Element` and casts (`registry.ts:535`);
+`processMutations` narrows with `instanceof HTMLElement` (`registry.ts:616`).
+`SVGElement` extends `Element`, not `HTMLElement`.
+
+_Measured_ with a throwaway probe (since deleted): an `<svg data-component="X">`
+mounts on insertion, and a subsequent `data-option-*` write produces no
+`option<Name>Changed()` call. The same holds for `data-component` and
+`data-mount` rewrites.
+
+Either narrowing is defensible — support SVG roots, or reject them at the door.
+The two disagreeing is not.
+
+### 4.3 A one-shot `$inject` silently drops the teardown its own contract promises
+
+`ContextCallback` (`context.ts:141`) documents "**Returning a function registers
+the teardown for that answer**", and `InjectContextOptions.onProvide` is typed as
+`ContextCallback<T>` (`context.ts:163`). That promise is kept only in the
+subscribed path, through `deliver()` (`context.ts:292`). In the unsubscribed path
+the return value of `onProvide?.(...)` is discarded (`context.ts:515`), so
+`$inject(key, { onProvide: () => cleanup })` without `subscribe: true` leaks the
+cleanup with no warning. _Read:_ no test covers it — `context.spec.ts` exercises
+teardowns only under `subscribe: true` (line 707).
+
+Fix either way: honour the teardown on `cancel()`, or narrow `onProvide`'s type
+in the one-shot case and say so on `ContextCallback`.
+
+---
+
+## 5. What I expected to find and did not
+
+**A pile of dead public API. There isn't one, and the sweep that says otherwise
+is measuring the wrong thing.** A naive unused-symbol pass over `packages/v4`
+flags `registerManifest`, `until()` and `swap()` as "spec only". All three are
+wrong:
+
+- `registerManifest` is the headline lazy-loading feature, with `DESIGN.md` §11
+  behind it and 29 tests in `autoload.spec.ts`. That `migration/` declares no
+  manifest says something about the ports, not about the feature.
+- `until()` is argued for at `DESIGN.md:709` — `isScrolling` is documented as the
+  flag "a component waiting for a scroll to finish should read", and there was
+  nothing to wait _with_. `DESIGN.md:713` adds the structural reason: `toggle()`
+  and `until()` are what the uniform `Service<T>` interface is _for_, and until
+  they existed nothing consumed it.
+- `swap()` is a `DESIGN.md` §10 core primitive with its own module and four modes.
+
+The lesson for anyone repeating this audit: in a private prototype at version
+`0.0.0`, "no consumer in this repository" is not evidence. Only the combination
+of no consumer, **no test, and no design-doc paragraph** is — which is why §1 has
+ten items and not forty.
+
+**A `ServicesManager`-shaped eager import.** `SIZE.md` §2.3 already established
+v4 did not inherit v3's shape. Nothing here changed that.
+
+**Over-engineered type-level machinery.** The opposite. The `$emit` type helpers
+are the most heavily justified code in the package: each of `Emits`, `EmitName`,
+`EmitDetail`, `PayloadOf`, `EmitArgs`, `ArgsOf`, `PropsOf` carries a JSDoc naming
+the naive alternative and the exact failure it causes — deferred conditionals
+over a naked type parameter, invariance breaking `$query`'s return type. The one
+place I went looking for gratuitous cleverness is the one place every choice is
+already defended in writing.
+
+**Duplication worth collapsing.** `SIZE.md` §R7 priced it at under 0.12 kB
+gzipped; this audit reaches the same conclusion from the other direction. Of the
+seven duplicated shapes listed there, exactly one (§1.1) is worth removing, and
+for correctness rather than for size.
+
+**Both `SERVICES-SURFACE.md` findings settled.** They are not. Only two commits
+touched `services/` after 2026-08-13 (`d7c8f01d`, `991b1efc`), and neither
+touches emission phase or `props()` nullability. §4's three recommendations are
+all unadopted — `createService` still carries `R` as a type parameter only, drag
+inertia still emits inside `defaultScheduler.tick`, and `DESIGN.md` §8 still
+frames the sampled/discrete rule as open. §5 is likewise open, and its evidence
+needs the correction in §2.19.
+
+---
+
+## 6. Method, and what it does not cover
+
+- **Untested claims** were established by deleting the guard, rebuilding
+  (`npm run build:v4`, ~1.4 s) and running `npm run test:v4` (48 files, 637
+  tests, ~20 s), then reverting with `git checkout -- packages/v4/src`. Four such
+  sweeps are quoted: two in §2.1, one in §1.2, one in §1.9.
+- **Behavioural claims** (§4.1, §4.2) were established with a throwaway
+  `src/probe.spec.ts` run against the real suite and deleted afterwards. The
+  working tree carries neither.
+- **Unused claims** were established with `rg` across `src/`, `migration/`,
+  `demo/` and the specs, counting a symbol's own spec as _not_ a consumer, and
+  excluding `migration/REPORT.md` — it is prose, not a call site.
+- **Justification claims** were checked against the file's own comments,
+  `DESIGN.md`, `SERVICES-REVIEW.md`, `SERVICES-SURFACE.md`, `migration/REPORT.md`
+  and `git log -S`. Commit hashes are quoted where a guard arrived with a fix.
+
+Four limits worth stating:
+
+1. **A green suite is not a proof of unreachability.** §1.9 is flagged for that
+   reason; §1.5 and §1.2 rest on reading both sides of the one call, not on the
+   suite.
+2. **Coverage was not usable.** `vitest --coverage` reports 0 % under browser mode
+   without instrumentation, so "is there a test" was answered by deletion rather
+   than by a report. That is slower but stronger — it answers "does a test
+   _fail_", which is the question that matters.
+3. **`migration/` is ten families, not a user base.** Everything §1 says about
+   consumers is bounded by that, and §5 is the warning that follows.
+4. **Prose was not audited for accuracy beyond what the code contradicted.**
+   §2.19 lists four wrong comments, all found while checking something else.
+   There are almost certainly more.

--- a/packages/v4/SIZE.md
+++ b/packages/v4/SIZE.md
@@ -1,0 +1,475 @@
+# Size — where v4's bytes are, and what would remove them (2026-08-14)
+
+Measured against `origin/main` at `f98d3e93`, `npm run build -w @studiometa/js-toolkit-v4`,
+Node 24, esbuild bundling `packages/v4/dist`, `gzip -9`.
+
+**The headline: v4 is already under 10 kB gzipped on the metric that matters —
+9.14 kB for everything a page pays to run one component.** So the question is not
+"how do we get there", it is "what keeps it there, and what is the floor if the
+budget tightens". This document answers both, and every number in it was produced
+by building the package and measuring, not by counting lines.
+
+Everything marked _measured_ was produced by an actual build. Everything marked
+_measured on a patched build_ was produced by editing `src/`, rebuilding, measuring
+and reverting — the patch scripts are described in §6 so any number here can be
+disagreed with by re-running it.
+
+---
+
+## 1. What "under 10 kB gzipped" has to mean
+
+The number depends entirely on which of three things is counted, and the three
+differ by a factor of nine. Naming one is the first job.
+
+| Candidate                 | What it is                                                                       | Baseline _(measured)_                                                                  |
+| ------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **A — one component**     | `Base` + `registerComponent` and their transitive graph, as a bundler ships them | **9.14 kB gzip** (24.93 kB min, 8.30 kB brotli), 15 modules                            |
+| **B — critical path**     | what a `registerManifest()` bootstrap costs before the page is interactive       | **9.20 kB gzip** bundled; **45.96 kB gzip / 15 requests / 5 RTT** served as published  |
+| **C — the whole package** | every runtime export in one bundle                                               | **16.44 kB gzip** (44.94 kB min); `dist/` is 106 modules, 208.77 kB raw, 82.72 kB gzip |
+
+**This document uses A as the metric.** It is the only one of the three that
+answers a question a user asks. C is the easiest to quote and the least
+meaningful — nobody imports every export, and the package is deliberately
+unbundled so that nobody has to. B matters, but it is a _different_ budget with a
+_different_ answer, and §4 shows it is the one with the largest available
+reduction, so it is reported alongside A throughout rather than folded into it.
+
+Two things A deliberately excludes:
+
+- **Decorators.** A component written with `@on`/`@component` imports
+  `./component`, which is 9.23 kB gzip — 0.09 kB over `./registerComponent`,
+  because `decorators.ts` re-uses the graph `Base` already pulled. Adding
+  decorators to the metric would move it by 1 %, so it is left out to keep the
+  comparison to a single fixed pair.
+- **The barrel.** `import { Base } from '@studiometa/js-toolkit-v4'` is
+  15.75 kB gzip / 29 modules. That is the bundler-convenience path; it costs
+  6.6 kB more than the two subpaths a component actually needs, and it is
+  tree-shaken back down by any bundler that sees the whole graph. Quoting the
+  barrel as "v4's size" would overstate it by 72 %.
+
+### The per-export baseline
+
+The equivalent of what `.github/workflows/export-size.yml` reports in CI, run
+locally over `packages/v4`. Top 12 of 76 runtime exports, gzip kB:
+
+| Subpath                | gzip  | brotli | min   | modules |
+| ---------------------- | ----- | ------ | ----- | ------- |
+| `.`                    | 15.75 | 14.23  | 43.45 | 29      |
+| `./component`          | 9.23  | 8.35   | 25.16 | 17      |
+| `./registerManifest`   | 9.21  | 8.35   | 25.21 | 16      |
+| `./registerComponents` | 9.15  | 8.31   | 24.98 | 16      |
+| `./registerComponent`  | 9.14  | 8.30   | 24.94 | 16      |
+| `./Base`               | 7.52  | 6.79   | 19.49 | 14      |
+| `./swap`               | 3.91  | 3.55   | 9.39  | 4       |
+| `./SWAP_MODES`         | 2.99  | 2.69   | 6.99  | 4       |
+| `./withDrag`           | 2.57  | 2.34   | 6.16  | 7       |
+| `./on`                 | 2.33  | 2.08   | 5.07  | 17      |
+| `./utils`              | 2.32  | 2.13   | 5.03  | 11      |
+| `./useDrag`            | 2.25  | 2.03   | 5.38  | 7       |
+
+The 60 exports below `./useRaf` are all under 1 kB gzip; 40 of them are under
+0.3 kB. The long tail is not where the weight is.
+
+---
+
+## 2. Where the bytes are
+
+Per-module weight inside the metric-A bundle, from esbuild's metafile
+(`bytesInOutput` — post-tree-shake, pre-minify, total 25 526 B). _Measured._
+
+| Module                   |  bytes | share |
+| ------------------------ | -----: | ----: |
+| `Base.js`                | 10 491 |  41 % |
+| `registry.js`            |  4 514 |  18 % |
+| `context.js`             |  1 922 |   8 % |
+| `dom-mutations.js`       |  1 885 |   7 % |
+| `scheduler.js`           |  1 884 |   7 % |
+| `services/breakpoint.js` |    879 |   3 % |
+| `mount-strategies.js`    |    875 |   3 % |
+| `negotiated-events.js`   |    861 |   3 % |
+| `responsive-options.js`  |    753 |   3 % |
+| `viewTransition.js`      |    532 |   2 % |
+| `services/service.js`    |    394 |   2 % |
+| `utils/memo.js`          |    278 |   1 % |
+| `utils/strings.js`       |    143 |  <1 % |
+| `lifecycle-events.js`    |     50 |  <1 % |
+| `utils/selectors.js`     |     47 |  <1 % |
+
+Two structural facts follow, and they set the shape of everything in §4.
+
+### 2.1 `Base` is one indivisible unit
+
+41 % of the metric is a single class. **No bundler tree-shakes a class method.**
+`$provide`, `$domUpdate`, `$emitExtendable`, `$viewTransition`, `$watchChildren`,
+`$query`, `$closest` and `$watchAttributes` ship to a component that uses none of
+them, and they drag their imports in with them: `context.js`, `negotiated-events.js`
+and `viewTransition.js` are in the graph above _only_ because methods on `Base`
+reference them.
+
+Priced by deleting the members and rebuilding — _measured on a patched build_:
+
+| Members removed from `Base`                                    |    metric A |      saving |
+| -------------------------------------------------------------- | ----------: | ----------: |
+| baseline                                                       |     9.14 kB |           — |
+| `$provide` `$inject` `$injectSync`                             |     8.42 kB |     0.72 kB |
+| `$viewTransition` `#negotiated` `$domUpdate` `$emitExtendable` |     8.60 kB |     0.54 kB |
+| `$watchChildren` `$query` `$closest`                           |     8.88 kB |     0.26 kB |
+| `$watchAttributes`                                             |     9.03 kB |     0.11 kB |
+| **all eleven**                                                 | **7.47 kB** | **1.67 kB** |
+
+The eleven together are 18 % of the metric. They are not dead code and nothing
+here argues for deleting them — §4 R3 is about _where they live_, not whether
+they exist.
+
+### 2.2 `registry.js` imports `Base.js`, and that is the whole critical path
+
+`registry.ts:1` is `import { Base, resolveConfig, … } from './Base.js'`. `Base`
+is used for exactly one thing — `isComponentClass()`'s
+`value === Base || value.prototype instanceof Base` — and `resolveConfig()` does
+not touch `Base` at all; it walks a constructor's prototype chain and merges
+`static config` objects.
+
+That one edge means **a page whose components are all lazy still downloads `Base`
+and its entire subtree before it can register the manifest.** It is the exact
+shape `autoload` and `data-mount` were built to avoid, defeated by an
+`instanceof`.
+
+### 2.3 What v4 did _not_ inherit from v3
+
+v3's `Base/managers/ServicesManager.ts` statically imports all five `use*`
+services, so any v3 component pulls 16 of `Base`'s 36 modules for services it may
+never touch. **v4 does not have this.** _Read:_ no module in `packages/v4/src`
+statically imports more than one service. The only service that reaches a
+default component's graph is `services/breakpoint.js`, pulled by
+`responsive-options.ts:41`, and it costs 0.45 kB gzip (§4 R6). That is a 35×
+smaller version of the same shape, not a repeat of it.
+
+---
+
+## 3. What the package ships, versus what a bundler emits
+
+`dist/` is **not minified** — `packages/v4/scripts/build.js` passes no `minify`
+option, and neither does `packages/js-toolkit/scripts/build.js`. The emitted
+modules keep every JSDoc block, and v4's sources are heavily commented by design.
+
+This splits the audience in two, and only one half is described by metric A:
+
+| Consumer                        | What they download for metric A's graph    |
+| ------------------------------- | ------------------------------------------ |
+| Bundler (Vite, webpack, Rollup) | 9.14 kB gzip — it minifies and tree-shakes |
+| CDN serving files as published  | **45.96 kB gzip**, 15 requests, 5 RTT deep |
+| CDN serving files minified      | **13.23 kB gzip**, 15 requests, 5 RTT deep |
+
+_Measured_: each module of the graph gzipped individually, which is what a
+browser actually pays per request. `126.46 kB` raw becomes `29.43 kB` raw when
+the same modules are minified in place, still unbundled, still one file per
+source module.
+
+**The comments are 71 % of the CDN cost of v4.** That is by far the largest single
+number in this document, and it costs a bundler user nothing.
+
+---
+
+## 4. Ranked reductions
+
+Ranked by measured saving on the metric each one moves. "Size" is the size of the
+change, not of the saving.
+
+|     | Reduction                             | Moves        | Saving _(measured)_        | Risk    | Size |
+| --- | ------------------------------------- | ------------ | -------------------------- | ------- | ---- |
+| R1  | Ship `dist/` minified                 | B, as served | −32.7 kB gzip (−71 %)      | low     | XS   |
+| R2  | Break `registry.ts` → `Base.ts`       | B            | −5.31 kB gzip, −4 requests | low     | S    |
+| R3  | Optional `Base` methods off the class | A and B      | −1.67 kB gzip (−18 %)      | high¹   | L    |
+| R4  | Strip dev warnings from production    | A, B, CDN    | −0.74 kB gzip (−8 %)       | low²    | S–M  |
+| R5  | `morphdom` behind a dynamic import    | `./swap`     | −1.99 kB gzip (−51 %)      | low     | XS   |
+| R6  | Responsive options lazy               | A and B      | −0.81 kB gzip (−9 %)       | medium³ | M    |
+| R7  | Collapse duplicated code              | —            | **< 0.12 kB gzip**         | low     | M    |
+
+¹ On API design, not correctness — it changes the `$method` idiom. ² On
+correctness; medium on choosing a guard that does not silence the warnings for
+the audience they were written for. ³ It trades against a `DESIGN.md` decision.
+
+**Do R1, R2 and R5 now** — together they cost nothing in API surface, are all
+small, and R2 is already validated against the full test suite. **Decide R4 on
+the guard question**, not on the byte count. **Hold R3 and R6** unless the budget
+is cut below 8 kB.
+
+### R1 — Ship `dist/` minified · CDN slice 45.96 → 13.23 kB gzip (−71 %)
+
+_Measured on the emitted modules._ Minify each `dist/*.js` in place, unbundled,
+one output file per source module. The graph shape is unchanged: still 15
+requests, still 5 RTT, still one shared copy of every module across entry points.
+Combined with R2 the CDN critical path is **6.76 kB gzip over 11 requests**.
+
+- **Saving:** metric B (as served) −32.7 kB gzip. Metric A **0** — a bundler
+  already does this.
+- **Cost:** published modules stop being readable in devtools. Source maps are
+  already emitted next to them (`build.js` runs a `sourcemap: true` pass), so the
+  mitigation exists; it has to be verified to still resolve after minification.
+- **Risk:** low. Nothing about the module graph or the export map changes.
+- **Size:** one option in `packages/v4/scripts/build.js`. It is a project-wide
+  decision, though — v3 ships unminified too, and the two packages should agree.
+- **Caveat:** some CDNs (esm.sh, jsDelivr's `/+esm`) already minify what they
+  serve, so this recovers nothing for those users. It recovers everything for
+  unpkg, jsDelivr's raw file paths, and any self-hosted copy of the package.
+
+### R2 — Break the `registry.ts` → `Base.ts` edge · critical path 9.20 → 3.89 kB gzip (−58 %)
+
+_Measured on a patched build, full test suite green._ Move `resolveConfig()` and
+its `WeakMap` cache into a new `src/config.ts` — it has no runtime dependency on
+`Base`, only on the `BaseConfig`/`BaseConstructor` types — and replace
+`isComponentClass()`'s `instanceof Base` with a brand: a `COMPONENT` symbol
+declared in `config.ts` and set as a static on `Base`, which every subclass
+inherits through the constructor chain.
+
+| Metric                            | before                    | after                         |
+| --------------------------------- | ------------------------- | ----------------------------- |
+| B — manifest bootstrap, bundled   | 9.20 kB gzip              | **3.89 kB gzip**              |
+| B — manifest bootstrap, as served | 45.96 kB / 15 req / 5 RTT | **22.66 kB / 11 req / 4 RTT** |
+| A — one component                 | 9.14 kB gzip              | 9.15 kB gzip                  |
+
+- **Saving:** metric B −5.31 kB gzip and −4 requests. Metric A **+0.01 kB** —
+  one more module boundary, which is the honest price.
+- **Cost:** `instanceof Base` stops being the test for "is this a component".
+  A brand is weaker: a class that copies the static would pass. In exchange it is
+  the only test that works across two copies of the package, which `instanceof`
+  never did.
+- **Risk:** low, and evidenced — `npm run test:v4` passes on the patched build
+  (48 files, 636 passed, 1 expected fail; identical to `main`).
+- **Size:** one new ~40-line module, two edits in `Base.ts`, two in `registry.ts`.
+- **Why this is first among the real reductions:** it is the only one that moves
+  the number `autoload` exists to move, and it costs the metric-A budget nothing.
+
+### R3 — Move `Base`'s optional methods off the class · metric A 9.14 → 7.47 kB gzip (−18 %)
+
+_Measured on a patched build_ (§2.1). Eleven methods on `Base` are paid by every
+component whether or not they are called, because a class body is atomic to every
+bundler. As free functions taking the instance — `provide(this, key, value)`,
+`domUpdate(this, mutate)` — they are tree-shakeable, and the modules they pull
+(`context.js`, `negotiated-events.js`, `viewTransition.js`) leave the default
+graph with them.
+
+- **Saving:** metric A −1.67 kB gzip (−4.90 kB min). Metric B −1.66 kB.
+- **Cost:** **this is a trade, not a free win.** The `$method` idiom is the v4
+  API. `this.$provide(k, v)` reading as `provide(this, k, v)` is a real
+  ergonomic loss and a real migration, and it splits the surface into "methods"
+  and "functions on a component" with no rule a reader can guess. A middle path —
+  opt-in mixins, `class Foo extends withContext(Base)` — keeps the call sites but
+  reintroduces the mixin ceremony v4 removed.
+- **Risk:** high, on API design rather than on correctness.
+- **Size:** large. Eleven methods, their types, their docs, every call site and
+  every spec.
+- **Recommendation:** do not do this to hit 10 kB, which is already met. Keep it
+  as the answer if the budget is later cut to 8 kB.
+
+### R4 — Strip developer-mistake warnings from production builds · metric A 9.14 → 8.40 kB gzip (−8 %)
+
+_Measured on a patched build._ Ten `console.warn` sites across `Base.ts` (4),
+`registry.ts` (3), `negotiated-events.ts` (2) and `responsive-options.ts` (1),
+plus the state that exists only to deduplicate them —
+`reportedLiteralDefaults`, the `checked` set threaded through `buildRefs`, and
+`checkResponsiveAttributes()`'s whole body. Their message strings alone are
+2.4 kB of source, and prose gzips _worse_ than code relative to its size because
+it shares almost nothing with the tokens around it.
+
+| Metric               |   before |       after |
+| -------------------- | -------: | ----------: |
+| A — one component    |  9.14 kB | **8.40 kB** |
+| `./Base`             |  7.52 kB |     6.77 kB |
+| `.` barrel           | 15.75 kB |    14.98 kB |
+| CDN slice, as served | 45.96 kB |    43.95 kB |
+
+The `console.error` sites are **not** included and should not be: they report
+runtime failures in user code (`mounted()` threw, an importer rejected) and
+belong in production.
+
+- **Saving:** metric A −0.74 kB gzip.
+- **Cost:** the guard has to be strippable, and the obvious guards are all
+  compromised for v4's audience:
+  - `process.env.NODE_ENV !== 'production'` is replaced by Vite, webpack and
+    Rollup production builds, so it strips by default — but it throws
+    `ReferenceError: process is not defined` on the no-build `<script type="module">`
+    path v4 explicitly supports.
+  - `typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'`
+    is safe everywhere and still folds to `false` under a production define — but
+    it silently turns the warnings **off** for the no-build audience, which is
+    the audience the warnings were written for (`warnLiteralDefault`'s own
+    doc comment says so: "this is the same rule said out loud for the no-build
+    path, which never sees a type").
+  - v3's existing `isDev` (`packages/js-toolkit/src/utils/is.ts`) is
+    `typeof __DEV__ !== 'undefined' && __DEV__`, which no bundler folds unless
+    the consumer defines `__DEV__`. _Read:_ nothing in this repository defines it.
+    So v3's dev-stripping does nothing by default today.
+  - The only shape that keeps warnings for the no-build path _and_ strips them
+    for bundler users is **two published trees behind the `development` /
+    `production` export conditions** — which Vite and webpack both honour. That
+    is not bundling (both trees stay unbundled and one-to-one with `src/`), but
+    it doubles the published tree and the subpath generator has to emit both.
+- **Risk:** low on correctness, medium on getting the condition right.
+- **Size:** small if a single guard is chosen (10 sites + 3 helpers); medium for
+  the two-tree option (`build.js` and `scripts/generate-subpaths.js`).
+- **Recommendation:** worth doing, and the export-conditions variant is the one
+  that does not trade the feature away. Decide the guard before the sites.
+
+### R5 — Load `morphdom` only when `swap()` morphs · `./swap` 3.91 → 1.92 kB gzip (−51 %)
+
+_Measured._ `swap.ts:1` statically imports `morphdom`, but `swap.ts:100` calls it
+in one of four modes. A page that only ever uses `replace`, `before` or `after`
+downloads 1.99 kB gzip of DOM-diffing it never runs.
+
+- **Saving:** 1.99 kB gzip for every `swap()` user who does not morph. Metric A
+  and B: **0** — `swap` is not in either graph, which is the design working.
+- **Cost:** `morph` mode becomes asynchronous on first use. `swap()` already
+  returns a promise, so the signature does not change; the first morph on a page
+  gains one network round trip.
+- **Risk:** low.
+- **Size:** one `await import('morphdom')` inside the morph branch.
+
+### R6 — Make responsive options lazy · metric A 9.14 → 8.33 kB gzip (−9 %)
+
+_Measured on a patched build_ (stubbing `responsive-options.js`, which also
+removes `services/breakpoint.js` and most of `services/service.js`). Responsive
+options are unconditional by design — `DESIGN.md` states every option is one —
+and the cost of that decision is now priced: **0.81 kB gzip on every page**,
+including pages where no component declares a single breakpoint-scoped
+attribute.
+
+- **Saving:** metric A −0.81 kB gzip; metric B −0.33 kB.
+- **Cost:** **this is a trade with a design decision, not a defect.** Making it
+  lazy means either (a) the registry only wires the responsive cascade when it
+  sees a `data-option-…:<breakpoint>` attribute, which makes an attribute added
+  later at runtime invisible until something re-scans, or (b) responsive options
+  become opt-in per component, which is the "add an option that names a thing"
+  configuration the project has ruled against.
+- **Risk:** medium — (a) changes observable behaviour in a way that is hard to
+  test for and easy to hit with server-rendered fragments.
+- **Size:** medium.
+- **Recommendation:** price it, do not spend it. 0.81 kB is not worth
+  reintroducing a "did the framework see my attribute" failure mode.
+
+### R7 — Collapse the duplicated code · under 0.12 kB gzip · **not worth doing for size**
+
+There is real duplication in v4, and it is worth reading as a maintenance
+finding. It is not worth anything as a size finding, and the number says so.
+
+_Read_, the concrete pairs:
+
+| Duplication                                                                                                                                                                    | Copies |          Each |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -----: | ------------: |
+| Error-isolated "run these callbacks" (`$destroy`, `$terminate`, `#clearOptionEffects`, three identical option-cleanup blocks, `mounted`/`destroyed`/`terminated`) in `Base.ts` |      9 |    6–11 lines |
+| `WeakMap<Element, Map<string, X>>` dispose bookkeeping — `disposeController()` `registry.ts:377` vs `disposeLoader()` `registry.ts:422`                                        |      2 |     ~12 lines |
+| Singleton-service memoisation — `raf.ts:116`, `pointer.ts:158`, `breakpoint.ts:264` (`perTarget()` absorbs the keyed case; there is no equivalent for the no-argument one)     |      3 |       4 lines |
+| Instance lookup by name — `Base.$query()` `Base.ts:1224` vs `getInstances()` `instances.ts:175` (plus `$closest()` and the delegation walk)                                    |      4 |    5–12 lines |
+| `data-option-${kebabCase(name)}` composed inline — `Base.ts:786`, `registry.ts:295`                                                                                            |      2 |        1 line |
+| The resolve-all / reject-all batch tail in `viewTransition.ts:51` and `:61`                                                                                                    |      2 |      ~9 lines |
+| Config-chain walk — `resolveConfig()` `Base.ts:879` vs `optionAttributes()` `registry.ts:290`, which re-derives the merged option set `resolveConfig` already computed         |      2 | 28 / 16 lines |
+
+Priced with the crudest possible upper bound — _measured on a patched build_ that
+**deleted all eleven `try`/`catch` wrappers in `Base.ts` outright**, keeping only
+their bodies: metric A 9.14 → **9.02 kB gzip** (24.93 → 24.24 kB min). Removing
+error isolation entirely, which nobody would do, is worth 0.12 kB. Factoring the
+copies into one helper is worth strictly less than that.
+
+The reason is gzip. Minified `Base.js` is 11.4 kB, comfortably inside one 32 kB
+deflate window, so the second and third copies of an identical block cost a back
+reference rather than the block. **Duplication that a reader notices is
+duplication the compressor has already removed.** Fix these for the maintenance
+reasons — `optionAttributes()` re-deriving what `resolveConfig()` caches is a
+genuine divergence risk, and `registry.ts:85–92` flags that exact class of bug
+twice in its own comments — but do not expect the size report to move.
+
+One item on that list is worth doing _for_ R2 rather than for its own sake:
+`resolveConfig()` moving to `config.ts` is what makes `optionAttributes()`'s
+private walk look like the outlier it is.
+
+### Not recommended
+
+- **Bundling anything.** Ruled out on 2026-08-10 and nothing measured here
+  argues against that ruling: a bundled entry mixed with any subpath yields two
+  `Base` classes and the instance registry silently returns nothing. Every
+  reduction above is graph flattening, deferred loading or lazy resolution.
+- **Trimming the long tail.** 40 of the 76 exports are under 0.3 kB gzip. Merging
+  them would save nothing measurable and would cost the per-symbol subpaths that
+  make the CDN path work.
+- **Dropping `utils/memo.js`, `utils/strings.js`, `utils/selectors.js`.** 0.08,
+  0.06 and 0.01 kB gzip respectively in metric A. Below the noise floor.
+- **Deduplicating code to save bytes.** R7. Under 0.12 kB gzip for the largest
+  candidate.
+
+---
+
+## 5. Is 10 kB reachable, and what is the floor
+
+**Yes, and it is already met: 9.14 kB gzip today, with 0.86 kB of headroom.**
+
+Stacking the three reductions that do not trade a feature away — R4 (dev
+warnings), R2 (registry/`Base` flattening) and R3 (methods off the class) —
+_measured together on one patched build_:
+
+| Metric                            |             today |                       R4+R2+R3 |     +R6 |
+| --------------------------------- | ----------------: | -----------------------------: | ------: |
+| A — one component                 |           9.14 kB |                    **6.80 kB** | 6.07 kB |
+| B — manifest bootstrap, bundled   |           9.20 kB |                    **3.86 kB** | 3.53 kB |
+| B — manifest bootstrap, as served | 45.96 kB / 15 req | **6.76 kB / 11 req** (with R1) |       — |
+| `./Base` alone                    |           7.52 kB |                    **5.17 kB** |       — |
+| `.` barrel                        |          15.75 kB |                       14.33 kB |       — |
+
+**The floor for metric A is about 5.2 kB gzip**, and what makes it the floor is
+`Base` itself: 41 % of the metric is one class, and after the eleven optional
+methods are gone what remains is not optional. The mount/destroy/terminate
+lifecycle, the live `$refs` view, the `$options` readers, `$emit`/`$on`/`$off`
+and the `on<Thing><Event>` handler binding are what a component _is_. They cannot
+be tree-shaken, they cannot be deferred (a component needs them on its first
+frame), and splitting them across modules moves bytes between files without
+removing any.
+
+Below 5.2 kB the only remaining moves delete features, which is out of scope for
+this document.
+
+Headroom, stated plainly: v4 sits 0.86 kB under 10 kB with the eleven optional
+methods, the dev warnings, the responsive cascade and the `Base`-in-the-registry
+edge all still in. **The risk is not that 10 kB is unreachable — it is that the
+next feature added to `Base` costs the last 0.86 kB.** R4 and R2 together buy
+2.3 kB of headroom for a small, low-risk, fully-tested change, and that is the
+argument for doing them now rather than when the budget is already breached.
+
+---
+
+## 6. Method
+
+Every number here can be reproduced. Nothing in this document is checked into
+`packages/v4`; the measurement scripts were throwaway and are described rather
+than shipped, because the repository already has the two tools that matter.
+
+- **Per-export sizes (§1).** `packages/js-toolkit/scripts/measure-graph.js` does
+  this for v3 and takes an entry from a package's `exports` map; the same routine
+  over `packages/v4/package.json` produces the table, with `gzip -9` in place of
+  brotli. CI runs the canonical version:
+  `.github/workflows/export-size.yml` → `weareikko/export-size@1` over
+  `@studiometa/js-toolkit-v4:packages/v4` after `npm run build`.
+- **Metric A / B bundled (§1, §2).** esbuild `bundle: true, minify: true,
+format: 'esm', target: 'esnext'` over a two-line entry importing `Base` from
+  `dist/Base.js` and `registerComponent`/`registerManifest` from
+  `dist/registry.js`, then `gzipSync(level: 9)`. Per-module weight from the same
+  build's `metafile.outputs[…].inputs[…].bytesInOutput`.
+- **Metric B as served (§3).** The transitive graph walked from `dist/` with the
+  relative-specifier regex from `measure-graph.js`, each module gzipped
+  **individually** — one request, one gzip stream, which is what a browser pays.
+  Dynamic `import()` is deliberately not followed: it is a request the consumer
+  opted into, not part of the entry's cost. RTT depth is the longest import
+  chain.
+- **Removal experiments (§2.1, §4).** Two kinds. Where a module could be removed
+  wholesale, an esbuild `onLoad` plugin replaced it with a no-op module exporting
+  the same names, which prices the module _and_ everything only it pulled. Where
+  the change was inside a module (`Base`'s members, the warnings, the registry
+  edge), `src/` was patched by script, `npm run build:v4` re-run, the bundle
+  re-measured and `git checkout -- packages/v4/src` run to revert. The R2 patch
+  was additionally validated with `npm run test:v4` (48 files, 636 passed,
+  1 expected fail — identical to `main`).
+- **The duplication upper bound (R7).** A script walked `Base.ts` matching braces,
+  replaced each `try { body } catch (error) { … }` with `{ body }`, and the
+  package was rebuilt and re-measured. Eleven blocks, 0.12 kB gzip in total.
+- **What was deliberately _not_ measured.** Real-network effects. Every number
+  above is bytes and request counts; on a real connection the 5-deep import chain
+  of metric B is likely to matter more than the bytes, and R2 shortens it to 4.
+  That is a claim this document does not evidence.

--- a/packages/v4/SIZE.md
+++ b/packages/v4/SIZE.md
@@ -14,6 +14,11 @@ _measured on a patched build_ was produced by editing `src/`, rebuilding, measur
 and reverting — the patch scripts are described in §6 so any number here can be
 disagreed with by re-running it.
 
+Companion document: `SIMPLIFY.md` asks what v4 could stop _doing_ rather than
+what it costs. Where the two overlap — the duplication of §R7, the
+`registry.ts` → `Base.ts` edge of §R2 — they cross-reference rather than repeat,
+and one conclusion here was corrected by that audit (§R7).
+
 ---
 
 ## 1. What "under 10 kB gzipped" has to mean
@@ -378,9 +383,19 @@ reasons — `optionAttributes()` re-deriving what `resolveConfig()` caches is a
 genuine divergence risk, and `registry.ts:85–92` flags that exact class of bug
 twice in its own comments — but do not expect the size report to move.
 
-One item on that list is worth doing _for_ R2 rather than for its own sake:
-`resolveConfig()` moving to `config.ts` is what makes `optionAttributes()`'s
-private walk look like the outlier it is.
+`SIMPLIFY.md` §2.1 takes the same eleven `try`/`catch` blocks from the other
+side and reaches a stronger conclusion: six of them have **no regression test**,
+so the 0.12 kB above is not just a small win, it is a small win with nothing
+standing in its way. Do not take it.
+
+**Correction (2026-08-14, from `SIMPLIFY.md` §1.1).** This section originally
+said the config-chain row was worth doing _for_ R2, because `resolveConfig()`
+moving to `config.ts` is what would make `optionAttributes()`'s private walk look
+like the outlier it is. That gate does not exist: `registry.ts:1` **already
+imports `resolveConfig`**, so collapsing the hand walk to
+`Object.keys(resolveConfig(ComponentClass).options ?? {})` is a standalone
+~8-line deletion available today, independent of R2. It is still not a size win —
+it is a correctness one, and `SIMPLIFY.md` §1.1 carries it.
 
 ### Not recommended
 


### PR DESCRIPTION
Refs #780.

An investigation, not a refactor. No runtime code changes — **two documents**, `packages/v4/SIZE.md` and `packages/v4/SIMPLIFY.md`.

---

# 1. `SIZE.md` — where the bytes are

"Under 10 kB gzipped" is ambiguous, and the three plausible readings differ by a factor of nine. The document names one and reports the other two beside it:

| Metric | Baseline |
| --- | --- |
| **A — one component** (`Base` + `registerComponent` + transitive graph, as a bundler ships them) | **9.14 kB gzip** |
| B — critical path (`registerManifest()` bootstrap) | 9.20 kB gzip bundled; 45.96 kB gzip / 15 requests / 5 RTT as published |
| C — the whole package | 16.44 kB gzip; `dist/` is 106 modules, 82.72 kB gzip |

**v4 is already under 10 kB on metric A, with 0.86 kB of headroom.** The work is keeping it there, not getting there.

**Top three reductions**

1. **Ship `dist/` minified** — CDN slice 45.96 → **13.23 kB gzip** (−71 %), same request count and RTT. `dist/` ships every JSDoc block today. Costs a bundler user nothing.
2. **Break the `registry.ts` → `Base.ts` static edge** — manifest bootstrap 9.20 → **3.89 kB gzip**, 15 → 11 requests, 5 → 4 RTT. `Base` is imported for one `instanceof`. Prototyped and validated against the full suite; metric A moves +0.01 kB.
3. **Move `Base`'s eleven optional methods off the class** — metric A 9.14 → **7.47 kB gzip** (−18 %). 41 % of the metric is one class and no bundler tree-shakes a method. Presented as a trade with its cost stated, and recommended *against* for now.

Stacking everything that trades no feature away reaches **6.80 kB**; the floor is **~5.2 kB**.

---

# 2. `SIMPLIFY.md` — what is over-engineered, and what only looks it

Run under one rule, because `SERVICES-REVIEW.md` records 17 confirmed defects each fixed with a regression test: **a branch is not over-engineering because it looks defensive.** Nothing was called unnecessary without checking whether a test fails without it, whether a comment or design doc explains it, and whether `git log -S` shows it arriving with a fix.

| Category | Count |
| --- | ---: |
| 1 — unjustified, remove | 10 |
| 2 — justified but undocumented, document | 19 |
| 3 — justified and documented, leave alone | ~115 |

The headline is the negative result. `Base.ts` carries 79 JSDoc blocks in 1 950 lines, most naming the naive alternative and why it fails — which is why category 3 dominates and the removal list is short.

**Top findings**

- **Six error-isolation guards around `Base`'s lifecycle hooks have no regression test.** Measured: deleting all eleven `try`/`catch` in `Base.ts` fails exactly two tests; deleting just those six leaves the suite green. They are justified — error isolation is a real property of this framework — but it is written down for the *scheduler* only. `SIZE.md` prices deleting them at 0.12 kB, so nothing currently stands in the way of someone doing it.
- **`ingest()`'s attribute filter is dead** — the observer's `attributeFilter` already guarantees its predicate. Git history shows it as a leftover from a superseded design; it can only lose work, never protect any.
- **`optionAttributes()` re-walks a chain `resolveConfig()` already caches** — two config keys have already shipped as bugs for exactly this shape.
- Removals also cover `perTarget()`'s unused `keyOf`, five zero-reference type aliases, `destroyWithin`'s unreachable fallback, `$off()`, and `test-utils.ts` being emitted into `dist/`.

**Three latent defects** surfaced while checking guards, reported separately from the audit and each proved with a throwaway probe spec (since deleted): one element can hold two `DragService` instances; an `<svg data-component>` mounts but never reconciles; a one-shot `$inject` silently drops the teardown its own documented contract promises.

**What I expected to find and did not:** a pile of dead public API. A naive unused-symbol sweep flags `registerManifest`, `until()` and `swap()` — all three are argued for in `DESIGN.md` and heavily tested. In a private prototype at `0.0.0`, "no consumer in this repository" is not evidence.

Also answered: both `SERVICES-SURFACE.md` findings left open on purpose are **still open** — only two commits touched `services/` since, and neither addresses them.

---

`SIZE.md` was amended where the audit corrected it (§R7: the config-chain cleanup needs no module move). Both documents cross-reference rather than repeat where they overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MZV1ZifTfhQkHm4tavc5a
