### PR TITLE
[Feature] Responsive component declarations for v4

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -252,6 +252,25 @@ RegistryEntry = {
 
 **`loadStrategy` did not survive** — see §11b. Deferring the import and deferring the mount are one decision, so a lazy entry carries a `mountStrategy` (standing in for the `config.mountStrategy` of a class not yet downloaded) and there is no `data-load`. Section 11 is the measurement.
 
+### Responsive component declarations — implemented
+
+The plain `data-component` token set remains unconditional. The same one-breakpoint, upward-cascading spelling as responsive options adds one responsive token set:
+
+```html
+<div
+  data-component="Action Analytics"
+  data-component:xxs="MobileMenu MobileSearch"
+  data-component:m="DesktopMenu DesktopSearch"></div>
+```
+
+At the active breakpoint the registry walks from the widest active suffix down and takes the first attribute that is present. That value is the complete responsive set: a wider value replaces every lower value rather than merging with it. An explicitly present empty value is therefore a stop — `data-component:s="TabletFeature" data-component:l=""` runs `TabletFeature` at `s` and `m`, then removes it at `l`. The effective declaration is the deduplicated union of the unconditional set and the selected responsive set.
+
+A crossing diffs that effective set against the registry's current element state. Shared names keep their controller and instance. Old-only names are terminated because they are no longer declared; crossing back creates a fresh identity. New-only names enter the normal registry pipeline, so eager and conditional mount strategies, `data-mount`, lazy manifest entries and lifecycle events keep their existing meaning. In particular, an inactive lazy declaration does not import its class.
+
+The breakpoint set makes every valid spelling enumerable. The document observer registers exact `data-component:<breakpoint>` names and replaces that filter slice after `setBreakpoints()`, never observing every document attribute and never creating one observer per responsive element. Connected elements carrying a scoped declaration share one reference-counted `useBreakpoint()` subscription; pages with plain declarations open none. Breakpoint work runs through the background lifecycle boundary, so `whenDOMSettled()` includes eager teardown, import and mount work caused by a crossing.
+
+A suffix naming no configured breakpoint is ignored and warned about once, including v3 list syntax such as `data-component:xxs:xs:s`. There is no range or breakpoint-list form: a wider replacement creates a range naturally.
+
 ### Mount strategies (#751) — implemented
 
 `mountStrategy` is the answer to #751, and it lives in the registry rather than in a decorator.
@@ -279,19 +298,19 @@ The issue's open questions, answered:
 
 ## 3. One mutation engine drives the DOM
 
-One internal engine owns one MutationObserver for component discovery, lifecycle, mount strategies, ref invalidation and declared options. Its `attributeFilter` contains the fixed framework attributes plus the option names accumulated from registered component configs, so unrelated `class`, `style` and ARIA writes create no records. It snapshots removed subtree membership when records enter its retained queue, before background processing, and processes each batch in a fixed order:
+One internal engine owns one MutationObserver for component discovery, lifecycle, mount strategies, ref invalidation and declared options. Its `attributeFilter` contains the fixed framework attributes, the exact responsive component spellings from the configured breakpoint set, and the option names accumulated from registered component configs, so unrelated `class`, `style` and ARIA writes create no records. It snapshots removed subtree membership when records enter its retained queue, before background processing, and processes each batch in a fixed order:
 
 1. destroy removed subtrees and dispose their strategies;
-2. reconcile final `data-component` and `data-mount` attributes;
+2. reconcile final plain and breakpoint-scoped `data-component` attributes and `data-mount`;
 3. deliver coalesced declared-option changes to retained mounted instances;
 4. scan added subtrees once and schedule their registered component tokens;
 5. report coalesced attribute changes to the elements which asked to watch them — see below.
 
-v3.9 re-queries every registry entry and sweeps every live instance per mutation batch. v4 reads `data-component` tokens from an inserted subtree in one pass and looks each token up in the registry.
+v3.9 re-queries every registry entry and sweeps every live instance per mutation batch. v4 resolves the effective plain-plus-responsive `data-component` token set from each inserted subtree in one pass and looks each token up in the registry.
 
-A disconnected element receives `$destroy()` and retains its instance for reinsertion. Removing one component token from a connected element is different: the DOM no longer declares that identity, so the registry calls `$terminate()`. Adding that token later creates a new instance. A moved node produces removal and addition records and deliberately completes a destroy/remount cycle with the same identity.
+A disconnected element receives `$destroy()` and retains its instance for reinsertion. Removing one component token from a connected element — by a plain or scoped attribute change, or by a breakpoint crossing — is different: the DOM no longer declares that identity, so the registry calls `$terminate()`. Adding that token later creates a new instance. A moved node produces removal and addition records and deliberately completes a destroy/remount cycle with the same identity.
 
-`whenDOMSettled()` provides an explicit completion boundary for morphing and fetch-style updates. It drains pending records, follows mutation chains created by eager lifecycle work and resolves after eager mounts and teardown have run. It does not wait for visibility, interaction, idle or media conditions, and it does not await promises returned by `mounted()`.
+`whenDOMSettled()` provides an explicit completion boundary for morphing, fetch-style updates and breakpoint crossings. It drains pending records, follows mutation chains created by eager lifecycle work and resolves after eager mounts and teardown have run. It does not wait for visibility, interaction, idle or media conditions, and it does not await promises returned by `mounted()`.
 
 ### Attributes the framework cannot name — `$watchAttributes()`
 
@@ -307,7 +326,7 @@ So the opt-in is **element-scoped**: `this.$watchAttributes(callback)` observes 
 - **Coalesced like options.** Several writes to one attribute in a batch are one change, from the first old value to the final DOM value, and a rewrite ending where it started is not a change at all — the rule `$optionChanged()` already follows.
 - Delivered as one payload object: `{ name, value, previousValue }`, raw attribute strings, `null` on either side for an absent attribute. It is the **entire** attribute set of the element, framework names included; a component narrows by prefix, which is what a `data-on:` or `data-bind:` family wants anyway.
 
-The matching surface is deliberately narrower than v3: only `data-component="Name"` declarations are discovered, with whitespace-separated tokens for several components on one element. v3's `<tk-name>` tag sugar and lowercase arbitrary-selector registrations are not kept. `data-component` still enhances native elements (`<form>`, `<a>`, `<details>`, table markup) and supports several components on one element — both impossible with custom elements as the primitive.
+The matching surface is deliberately narrower than v3: only plain and configured breakpoint-scoped `data-component` declarations are discovered, with whitespace-separated tokens for several components on one element. v3's `<tk-name>` tag sugar, breakpoint-list suffixes and lowercase arbitrary-selector registrations are not kept. `data-component` still enhances native elements (`<form>`, `<a>`, `<details>`, table markup) and supports several components on one element — both impossible with custom elements as the primitive.
 
 ## 4. Parents listen to child events
 

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -1,3 +1,4 @@
+import { componentTokens } from './component-declarations.js';
 import {
   injectContext,
   injectContextSync,
@@ -452,17 +453,15 @@ function checkPayload(event: string, payload: unknown): void {
  * The root itself is never tested against `owner`. It cannot be: ui registers
  * `FigureShopify` under the name `Figure`, so the element reading
  * `data-ref="FigureShopify.img"` sits under `data-component="Figure"`. The
- * namespace names the **class's** `config.name`, which is what the selector
- * already matched on; the walk only decides who else could have claimed it.
+ * namespace names the **class's** `config.name`, which is what the root's
+ * effective declaration matched; the walk only decides who else could have
+ * claimed it.
  */
 function belongsTo(el: Element, root: Element, owner?: string): boolean {
-  // Built before the walk, not inside it: the selector depends on `owner`
-  // alone, and the loop runs once per ancestor — for every ref, on every
-  // mount. Hoisting is what a cache would buy here, without the cache.
-  const selector = owner === undefined ? undefined : selectorFor(owner);
   let parent = el.parentElement;
   while (parent && parent !== root) {
-    if (selector === undefined ? parent.hasAttribute('data-component') : parent.matches(selector)) {
+    const declarations = componentTokens(parent);
+    if (owner === undefined ? declarations.size > 0 : declarations.has(owner)) {
       return false;
     }
     parent = parent.parentElement;

--- a/packages/v4/src/component-declarations.ts
+++ b/packages/v4/src/component-declarations.ts
@@ -1,0 +1,41 @@
+import {
+  activeBreakpoint,
+  responsiveAttributeNames,
+  responsiveScopedRawValue,
+  RESPONSIVE_SEPARATOR,
+} from './responsive-options.js';
+
+export const COMPONENT_ATTRIBUTE = 'data-component';
+
+/** Parse the whitespace-token syntax used by every component declaration. */
+function tokens(value: string | null): string[] {
+  return (value ?? '').split(/\s+/).filter(Boolean);
+}
+
+/**
+ * The component names currently declared on an element.
+ *
+ * The plain attribute is unconditional. One scoped value is selected by the
+ * responsive cascade and replaces every lower scoped value. The two sets are
+ * then combined and deduplicated here, before the registry sees them.
+ */
+export function componentTokens(el: Element): Set<string> {
+  const get = (attribute: string) => el.getAttribute(attribute);
+  const scoped = responsiveScopedRawValue(COMPONENT_ATTRIBUTE, activeBreakpoint(), get);
+  return new Set([...tokens(get(COMPONENT_ATTRIBUTE)), ...tokens(scoped)]);
+}
+
+/** Whether an element carries any component spelling, including an invalid suffix. */
+export function hasComponentAttribute(el: Element): boolean {
+  const prefix = `${COMPONENT_ATTRIBUTE}${RESPONSIVE_SEPARATOR}`;
+  return el
+    .getAttributeNames()
+    .some((attribute) => attribute === COMPONENT_ATTRIBUTE || attribute.startsWith(prefix));
+}
+
+/** Whether an element carries a scoped spelling from the configured breakpoint set. */
+export function hasResponsiveComponentAttribute(el: Element): boolean {
+  return responsiveAttributeNames(COMPONENT_ATTRIBUTE).some((attribute) =>
+    el.hasAttribute(attribute),
+  );
+}

--- a/packages/v4/src/dom-mutations.ts
+++ b/packages/v4/src/dom-mutations.ts
@@ -34,6 +34,10 @@ interface AttributeWatcherEntry {
 }
 
 const observedAttributes = new Set(['data-component', 'data-mount', 'data-ref']);
+
+function isComponentAttribute(attribute: string | null): boolean {
+  return attribute === 'data-component' || attribute?.startsWith('data-component:') === true;
+}
 const attributeWatchers = new Set<AttributeWatcherEntry>();
 let observer: MutationObserver | null = null;
 let processor: DOMMutationProcessor | null = null;
@@ -74,6 +78,33 @@ function observeDocument(): void {
 export function registerDOMOptionAttributes(attributes: Iterable<string>): void {
   let changed = false;
   for (const attribute of attributes) {
+    if (!observedAttributes.has(attribute)) {
+      observedAttributes.add(attribute);
+      changed = true;
+    }
+  }
+  if (!changed || !observer) {
+    return;
+  }
+  ingest(observer.takeRecords());
+  observeDocument();
+}
+
+/**
+ * Replace one derived slice of the exact attribute filter.
+ *
+ * Responsive attributes use this when `setBreakpoints()` replaces the named
+ * set. Existing records are retained before the observer is reconfigured.
+ */
+export function replaceDOMOptionAttributes(
+  previous: Iterable<string>,
+  next: Iterable<string>,
+): void {
+  let changed = false;
+  for (const attribute of previous) {
+    changed = observedAttributes.delete(attribute) || changed;
+  }
+  for (const attribute of next) {
     if (!observedAttributes.has(attribute)) {
       observedAttributes.add(attribute);
       changed = true;
@@ -212,7 +243,7 @@ function ingest(incoming: MutationRecord[]): void {
   const relevant = incoming.filter(
     ({ type, attributeName }) =>
       type === 'childList' ||
-      attributeName === 'data-component' ||
+      isComponentAttribute(attributeName) ||
       attributeName === 'data-mount' ||
       attributeName === 'data-ref' ||
       attributeName?.startsWith('data-option-'),
@@ -224,7 +255,7 @@ function ingest(incoming: MutationRecord[]): void {
   if (
     relevant.some(
       ({ type, attributeName }) =>
-        type === 'childList' || attributeName === 'data-component' || attributeName === 'data-ref',
+        type === 'childList' || isComponentAttribute(attributeName) || attributeName === 'data-ref',
     )
   ) {
     version += 1;

--- a/packages/v4/src/registry.ts
+++ b/packages/v4/src/registry.ts
@@ -1,5 +1,11 @@
 import { Base, resolveConfig, type BaseConstructor, type ComponentImporter } from './Base.js';
 import {
+  COMPONENT_ATTRIBUTE,
+  componentTokens,
+  hasComponentAttribute,
+  hasResponsiveComponentAttribute,
+} from './component-declarations.js';
+import {
   registerDOMOptionAttributes,
   setDOMMutationProcessor,
   trackDOMLifecycleWork,
@@ -11,11 +17,22 @@ import {
   type AppliedMountStrategy,
   type MountStrategy,
 } from './mount-strategies.js';
-import { observeResponsiveAttribute } from './responsive-options.js';
+import {
+  checkResponsiveAttributes,
+  observeResponsiveAttribute,
+  responsiveAttributeNames,
+  watchBreakpoint,
+} from './responsive-options.js';
+import { defaultScheduler, type ScheduledTask } from './scheduler.js';
+import { onBreakpointsReplaced } from './services/breakpoint.js';
 import { selectorFor } from './utils/selectors.js';
 import { kebabCase } from './utils/strings.js';
 
 const registry = new Map<string, BaseConstructor>();
+
+// Component declarations use the same finite attribute × breakpoint filter as
+// responsive options. This opens no observer and no media-query listener.
+observeResponsiveAttribute(COMPONENT_ATTRIBUTE);
 
 interface PairController {
   active: boolean;
@@ -150,13 +167,76 @@ function registerLazyChild(name: string, load: ComponentImporter): void {
   scanName(document.documentElement, name);
 }
 
-function componentTokens(el: Element): Set<string> {
-  return new Set((el.getAttribute('data-component') ?? '').split(/\s+/).filter(Boolean));
-}
-
 function declaresComponent(el: Element, name: string): boolean {
   return componentTokens(el).has(name);
 }
+
+/** Connected elements whose declarations need a breakpoint crossing. */
+const responsiveElements = new Set<HTMLElement>();
+let unwatchBreakpoints: (() => void) | null = null;
+let responsiveTask: ScheduledTask<void> | null = null;
+let pendingResponsiveElements = new Set<HTMLElement>();
+
+function syncResponsiveElement(el: HTMLElement): void {
+  if (el.isConnected && hasResponsiveComponentAttribute(el)) {
+    responsiveElements.add(el);
+    unwatchBreakpoints ??= watchBreakpoint(() => {
+      scheduleResponsiveReconciliation(responsiveElements);
+    });
+    return;
+  }
+
+  responsiveElements.delete(el);
+  if (responsiveElements.size === 0) {
+    unwatchBreakpoints?.();
+    unwatchBreakpoints = null;
+  }
+}
+
+/**
+ * Put a crossing through the same background lifecycle boundary as a DOM
+ * mutation. Coalescing matters for `setBreakpoints()`: replacing the set and
+ * refreshing the running service can both ask for the same reconciliation.
+ */
+function scheduleResponsiveReconciliation(elements: Iterable<HTMLElement>): void {
+  for (const el of elements) {
+    pendingResponsiveElements.add(el);
+  }
+  if (responsiveTask || pendingResponsiveElements.size === 0) {
+    return;
+  }
+
+  responsiveTask = defaultScheduler.background(() => {
+    const batch = pendingResponsiveElements;
+    pendingResponsiveElements = new Set();
+    for (const el of batch) {
+      if (el.isConnected) {
+        reconcileElement(el);
+      } else {
+        syncResponsiveElement(el);
+      }
+    }
+  });
+  trackDOMLifecycleWork(responsiveTask.promise);
+  const finished = () => {
+    responsiveTask = null;
+    scheduleResponsiveReconciliation([]);
+  };
+  void responsiveTask.promise.then(finished, finished);
+}
+
+onBreakpointsReplaced(() => {
+  const candidates = new Set(responsiveElements);
+  const selector = responsiveAttributeNames(COMPONENT_ATTRIBUTE)
+    .map((attribute) => `[${CSS.escape(attribute)}]`)
+    .join(',');
+  if (selector) {
+    for (const el of document.querySelectorAll<HTMLElement>(selector)) {
+      candidates.add(el);
+    }
+  }
+  scheduleResponsiveReconciliation(candidates);
+});
 
 /**
  * Register a component class. Existing matching elements are scheduled
@@ -505,6 +585,8 @@ function scheduleFor(el: HTMLElement, name: string): void {
  * `data-component` token set.
  */
 function reconcileElement(el: HTMLElement): void {
+  checkResponsiveAttributes(el, [COMPONENT_ATTRIBUTE]);
+  syncResponsiveElement(el);
   const tokens = componentTokens(el);
   const names = new Set<string>([
     ...(controllers.get(el)?.keys() ?? []),
@@ -536,12 +618,7 @@ function scan(root: Node): void {
     return;
   }
   for (const el of [root, ...root.querySelectorAll<HTMLElement>('*')]) {
-    if (
-      el.hasAttribute('data-component') ||
-      el.__base__ ||
-      controllers.has(el) ||
-      loaders.has(el)
-    ) {
+    if (hasComponentAttribute(el) || el.__base__ || controllers.has(el) || loaders.has(el)) {
       reconcileElement(el as HTMLElement);
     }
   }
@@ -558,7 +635,7 @@ function scanName(root: Element, name: string): void {
     ? [root, ...root.querySelectorAll<HTMLElement>(selector)]
     : [...root.querySelectorAll<HTMLElement>(selector)];
   for (const el of elements) {
-    scheduleFor(el as HTMLElement, name);
+    reconcileElement(el as HTMLElement);
   }
 }
 
@@ -576,6 +653,7 @@ function destroyWithin(node: Node, snapshot?: readonly Element[]): void {
     return;
   }
   for (const el of snapshot ?? [node, ...node.querySelectorAll<HTMLElement>('*')]) {
+    syncResponsiveElement(el as HTMLElement);
     const pairs = controllers.get(el);
     if (pairs) {
       for (const name of pairs.keys()) {
@@ -616,7 +694,10 @@ function processMutations(records: readonly DOMMutationRecord[]): void {
     if (record.type !== 'attributes' || !(record.target instanceof HTMLElement)) {
       continue;
     }
-    if (record.attributeName === 'data-component') {
+    if (
+      record.attributeName === COMPONENT_ATTRIBUTE ||
+      record.attributeName?.startsWith(`${COMPONENT_ATTRIBUTE}:`)
+    ) {
       declarations.add(record.target);
     } else if (record.attributeName === MOUNT_ATTRIBUTE) {
       strategies.add(record.target);

--- a/packages/v4/src/responsive-components.spec.ts
+++ b/packages/v4/src/responsive-components.spec.ts
@@ -1,0 +1,402 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Base, type BaseConfig } from './Base.js';
+import { whenDOMSettled } from './dom-mutations.js';
+import { getInstances } from './instances.js';
+import { registerComponent, registerManifest } from './registry.js';
+import { BREAKPOINTS, setBreakpoints } from './services/breakpoint.js';
+import { resetDom, settle } from './test-utils.js';
+
+let counter = 0;
+
+interface TrackedComponent extends Base {
+  mounts: number;
+  destroys: number;
+  terminations: number;
+}
+
+function defineTracked(prefix: string, config: Omit<BaseConfig, 'name'> = {}) {
+  counter += 1;
+  const name = `${prefix}${counter}`;
+
+  class Tracked extends Base {
+    static config: BaseConfig = { name, ...config };
+
+    mounts = 0;
+    destroys = 0;
+    terminations = 0;
+
+    mounted(): void {
+      this.mounts += 1;
+    }
+
+    destroyed(): void {
+      this.destroys += 1;
+    }
+
+    terminated(): void {
+      this.terminations += 1;
+    }
+  }
+
+  return { name, Tracked };
+}
+
+function register(...definitions: ReturnType<typeof defineTracked>[]): void {
+  for (const { Tracked } of definitions) {
+    registerComponent(Tracked);
+  }
+}
+
+function render(attributes: Record<string, string>): HTMLElement {
+  const el = document.createElement('div');
+  for (const [name, value] of Object.entries(attributes)) {
+    el.setAttribute(name, value);
+  }
+  document.body.append(el);
+  return el;
+}
+
+function instance(el: Element, name: string): TrackedComponent | undefined {
+  return el.__base__?.get(name) as TrackedComponent | undefined;
+}
+
+function at(name: 'small' | 'middle' | 'wide'): void {
+  const reached = { small: true, middle: name !== 'small', wide: name === 'wide' };
+  setBreakpoints({
+    small: reached.small ? '0rem' : '9999rem',
+    middle: reached.middle ? '0rem' : '9999rem',
+    wide: reached.wide ? '0rem' : '9999rem',
+  });
+}
+
+async function mediaListenerRegistrations(during: () => Promise<void>): Promise<number> {
+  const prototype = MediaQueryList.prototype;
+  const original = prototype.addEventListener;
+  let added = 0;
+  prototype.addEventListener = function patched(
+    this: MediaQueryList,
+    ...args: Parameters<typeof original>
+  ) {
+    added += 1;
+    return original.apply(this, args);
+  };
+  try {
+    await during();
+  } finally {
+    prototype.addEventListener = original;
+  }
+  return added;
+}
+
+afterEach(async () => {
+  await resetDom();
+  setBreakpoints(BREAKPOINTS);
+  await whenDOMSettled();
+});
+
+describe('responsive component declarations', () => {
+  it('unions base and scoped token sets, supports several tokens, and deduplicates names', async () => {
+    at('small');
+    const action = defineTracked('Action');
+    const analytics = defineTracked('Analytics');
+    const mobileMenu = defineTracked('MobileMenu');
+    const mobileSearch = defineTracked('MobileSearch');
+    register(action, analytics, mobileMenu, mobileSearch);
+
+    const el = render({
+      'data-component': `${action.name} ${analytics.name} ${action.name}`,
+      'data-component:small': `${mobileMenu.name} ${mobileSearch.name} ${action.name}`,
+    });
+    await whenDOMSettled();
+
+    expect([...(el.__base__?.keys() ?? [])].sort()).toEqual(
+      [action.name, analytics.name, mobileMenu.name, mobileSearch.name].sort(),
+    );
+    expect(instance(el, action.name)?.mounts).toBe(1);
+    expect(getInstances(mobileMenu.name)).toEqual([instance(el, mobileMenu.name)]);
+  });
+
+  it('replaces lower scoped sets, stops them on an empty override, and restores fresh identities', async () => {
+    at('small');
+    const base = defineTracked('BaseFeature');
+    const mobile = defineTracked('Mobile');
+    const tablet = defineTracked('Tablet');
+    register(base, mobile, tablet);
+
+    const el = render({
+      'data-component': base.name,
+      'data-component:small': mobile.name,
+      'data-component:middle': tablet.name,
+      'data-component:wide': '',
+    });
+    await whenDOMSettled();
+    const firstMobile = instance(el, mobile.name);
+    expect(firstMobile?.$isMounted).toBe(true);
+
+    at('middle');
+    await whenDOMSettled();
+    const firstTablet = instance(el, tablet.name);
+    expect(firstMobile?.$isTerminated).toBe(true);
+    expect(firstTablet?.$isMounted).toBe(true);
+    expect(instance(el, mobile.name)).toBeUndefined();
+    expect(instance(el, base.name)?.$isMounted).toBe(true);
+
+    at('wide');
+    await whenDOMSettled();
+    expect(firstTablet?.$isTerminated).toBe(true);
+    expect(instance(el, tablet.name)).toBeUndefined();
+    expect(instance(el, base.name)?.$isMounted).toBe(true);
+
+    at('small');
+    await whenDOMSettled();
+    expect(instance(el, mobile.name)).not.toBe(firstMobile);
+    expect(instance(el, mobile.name)?.$isMounted).toBe(true);
+  });
+
+  it('preserves shared instances while terminating old-only names in both crossing directions', async () => {
+    at('small');
+    const shared = defineTracked('Shared');
+    const mobile = defineTracked('Narrow');
+    const desktop = defineTracked('Desktop');
+    register(shared, mobile, desktop);
+
+    const el = render({
+      'data-component:small': `${shared.name} ${mobile.name}`,
+      'data-component:wide': `${shared.name} ${desktop.name}`,
+    });
+    await whenDOMSettled();
+    const sharedInstance = instance(el, shared.name);
+    const firstMobile = instance(el, mobile.name);
+
+    at('wide');
+    await whenDOMSettled();
+    const firstDesktop = instance(el, desktop.name);
+    expect(instance(el, shared.name)).toBe(sharedInstance);
+    expect(sharedInstance?.mounts).toBe(1);
+    expect(firstMobile?.$isTerminated).toBe(true);
+    expect(firstDesktop?.$isMounted).toBe(true);
+
+    at('small');
+    await whenDOMSettled();
+    expect(instance(el, shared.name)).toBe(sharedInstance);
+    expect(firstDesktop?.$isTerminated).toBe(true);
+    expect(instance(el, mobile.name)).not.toBe(firstMobile);
+  });
+
+  it('reconciles inactive and active scoped writes, removals, and same-batch changes', async () => {
+    at('small');
+    const first = defineTracked('First');
+    const second = defineTracked('Second');
+    const third = defineTracked('Third');
+    register(first, second, third);
+
+    const el = render({
+      'data-component:small': first.name,
+      'data-component:wide': second.name,
+    });
+    await whenDOMSettled();
+    const firstInstance = instance(el, first.name);
+
+    el.setAttribute('data-component:wide', third.name);
+    await whenDOMSettled();
+    expect(instance(el, first.name)).toBe(firstInstance);
+    expect(instance(el, second.name)).toBeUndefined();
+    expect(instance(el, third.name)).toBeUndefined();
+
+    el.setAttribute('data-component:small', second.name);
+    await whenDOMSettled();
+    expect(firstInstance?.$isTerminated).toBe(true);
+    expect(instance(el, second.name)?.$isMounted).toBe(true);
+
+    el.removeAttribute('data-component:small');
+    await whenDOMSettled();
+    expect(instance(el, second.name)).toBeUndefined();
+
+    el.setAttribute('data-component:small', first.name);
+    el.setAttribute('data-component:small', third.name);
+    await whenDOMSettled();
+    expect(instance(el, first.name)).toBeUndefined();
+    expect(instance(el, third.name)?.$isMounted).toBe(true);
+  });
+
+  it('reconciles live base writes and removals without disturbing the active scoped set', async () => {
+    at('small');
+    const base = defineTracked('BaseLive');
+    const nextBase = defineTracked('NextBase');
+    const scoped = defineTracked('ScopedLive');
+    register(base, nextBase, scoped);
+
+    const el = render({
+      'data-component': base.name,
+      'data-component:small': scoped.name,
+    });
+    await whenDOMSettled();
+    const scopedInstance = instance(el, scoped.name);
+
+    el.setAttribute('data-component', nextBase.name);
+    await whenDOMSettled();
+    expect(instance(el, base.name)).toBeUndefined();
+    expect(instance(el, nextBase.name)?.$isMounted).toBe(true);
+    expect(instance(el, scoped.name)).toBe(scopedInstance);
+
+    el.removeAttribute('data-component');
+    await whenDOMSettled();
+    expect(instance(el, nextBase.name)).toBeUndefined();
+    expect(instance(el, scoped.name)).toBe(scopedInstance);
+  });
+
+  it('keeps responsive instances across removal, reinsertion, and DOM moves', async () => {
+    at('small');
+    const feature = defineTracked('Movable');
+    register(feature);
+    const firstParent = document.createElement('section');
+    const secondParent = document.createElement('section');
+    document.body.append(firstParent, secondParent);
+    const el = document.createElement('div');
+    el.setAttribute('data-component:small', feature.name);
+    firstParent.append(el);
+    await whenDOMSettled();
+    const retained = instance(el, feature.name);
+
+    el.remove();
+    await whenDOMSettled();
+    expect(retained?.$isMounted).toBe(false);
+    expect(retained?.$isTerminated).toBe(false);
+
+    firstParent.append(el);
+    await whenDOMSettled();
+    expect(instance(el, feature.name)).toBe(retained);
+    expect(retained?.mounts).toBe(2);
+
+    secondParent.append(el);
+    await whenDOMSettled();
+    expect(instance(el, feature.name)).toBe(retained);
+    expect(retained?.mounts).toBe(3);
+    expect(retained?.destroys).toBe(2);
+  });
+
+  it('does not import a lazy declaration before activation and still applies data-mount', async () => {
+    at('small');
+    const lazy = defineTracked('LazyResponsive');
+    let imports = 0;
+    registerManifest({
+      [lazy.name]: {
+        load: async () => {
+          imports += 1;
+          return lazy.Tracked;
+        },
+        mountStrategy: 'interaction',
+      },
+    });
+    const el = render({ 'data-component:wide': lazy.name });
+    await whenDOMSettled();
+    expect(imports).toBe(0);
+
+    at('wide');
+    await whenDOMSettled();
+    expect(imports).toBe(0);
+    expect(instance(el, lazy.name)).toBeUndefined();
+
+    el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    await settle();
+    expect(imports).toBe(1);
+    expect(instance(el, lazy.name)?.$isMounted).toBe(true);
+  });
+
+  it('includes eager lazy work caused by a crossing in DOM settlement', async () => {
+    at('small');
+    const lazy = defineTracked('SettledLazy');
+    let imports = 0;
+    registerManifest({
+      [lazy.name]: async () => {
+        imports += 1;
+        return lazy.Tracked;
+      },
+    });
+    const el = render({ 'data-component:wide': lazy.name });
+    await whenDOMSettled();
+    expect(imports).toBe(0);
+
+    at('wide');
+    await whenDOMSettled();
+    expect(imports).toBe(1);
+    expect(instance(el, lazy.name)?.$isMounted).toBe(true);
+  });
+
+  it('uses class mountStrategy and lets an element data-mount override it', async () => {
+    at('small');
+    const feature = defineTracked('Strategy', { mountStrategy: 'interaction' });
+    register(feature);
+    const waiting = render({ 'data-component:wide': feature.name });
+    const eager = render({
+      'data-component:wide': feature.name,
+      'data-mount': 'eager',
+    });
+    await whenDOMSettled();
+
+    at('wide');
+    await whenDOMSettled();
+    expect(instance(waiting, feature.name)).toBeUndefined();
+    expect(instance(eager, feature.name)?.$isMounted).toBe(true);
+
+    waiting.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    await whenDOMSettled();
+    expect(instance(waiting, feature.name)?.$isMounted).toBe(true);
+  });
+
+  it('discovers declarations from a custom setBreakpoints replacement and settles their mount', async () => {
+    const feature = defineTracked('CustomBreakpoint');
+    register(feature);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const el = render({ 'data-component:desktop': feature.name });
+    await whenDOMSettled();
+    expect(instance(el, feature.name)).toBeUndefined();
+
+    setBreakpoints({ mobile: '0rem', desktop: '0rem' });
+    await whenDOMSettled();
+    const mounted = instance(el, feature.name);
+    expect(mounted?.$isMounted).toBe(true);
+
+    // The replacement also updates the document observer's exact filter.
+    el.removeAttribute('data-component:desktop');
+    await whenDOMSettled();
+    expect(mounted?.$isTerminated).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('ignores and warns once for a suffix naming no configured breakpoint', async () => {
+    const base = defineTracked('WarningBase');
+    const invalid = defineTracked('Invalid');
+    register(base, invalid);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const el = render({
+      'data-component': base.name,
+      'data-component:xxs:xs:s': invalid.name,
+    });
+    await whenDOMSettled();
+
+    expect(instance(el, base.name)?.$isMounted).toBe(true);
+    expect(instance(el, invalid.name)).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('`data-component:xxs:xs:s` names no breakpoint'),
+    );
+
+    el.setAttribute('data-component', `${base.name} ${base.name}`);
+    await whenDOMSettled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('opens no breakpoint listener for pages with plain declarations only', async () => {
+    const feature = defineTracked('PlainOnly');
+    register(feature);
+
+    const added = await mediaListenerRegistrations(async () => {
+      render({ 'data-component': feature.name });
+      await whenDOMSettled();
+    });
+
+    expect(added).toBe(0);
+  });
+});

--- a/packages/v4/src/responsive-options.ts
+++ b/packages/v4/src/responsive-options.ts
@@ -37,7 +37,7 @@
  * present. Nothing is written, which is what keeps `$options` the read-only
  * view over attributes it is everywhere else.
  */
-import { registerDOMOptionAttributes } from './dom-mutations.js';
+import { registerDOMOptionAttributes, replaceDOMOptionAttributes } from './dom-mutations.js';
 import { breakpointNames, onBreakpointsReplaced, useBreakpoint } from './services/breakpoint.js';
 import { memo } from './utils/memo.js';
 
@@ -65,17 +65,30 @@ const scopedAttributes = memo((attribute: string): readonly string[] =>
   breakpointNames().map((name) => `${attribute}${RESPONSIVE_SEPARATOR}${name}`),
 );
 
+/**
+ * The exact scoped spellings for an attribute in the current breakpoint set.
+ *
+ * Shared with component declarations because the observer filter and both
+ * cascades must derive their finite attribute set from the same model.
+ *
+ * @internal
+ */
+export function responsiveAttributeNames(attribute: string): readonly string[] {
+  return scopedAttributes(attribute);
+}
+
 /** Base attributes whose scoped spellings the one observer filters for. */
 const observed = new Set<string>();
 
 onBreakpointsReplaced(() => {
+  const previous = [...observed].flatMap((attribute) => scopedAttributes(attribute));
   scopedAttributes.clear();
   // The filter takes exact names, so a replaced set means names that were
-  // never registered. Re-derive them, or a `data-option-x:<new>` rewritten at
-  // runtime would be invisible while the plain `data-option-x` is honoured.
-  for (const attribute of observed) {
-    registerDOMOptionAttributes(scopedAttributes(attribute));
-  }
+  // never registered. Replace every derived slice, or a
+  // `data-option-x:<new>` rewritten at runtime would be invisible while stale
+  // names from the old set kept producing records.
+  const next = [...observed].flatMap((attribute) => scopedAttributes(attribute));
+  replaceDOMOptionAttributes(previous, next);
 });
 
 /**
@@ -83,9 +96,9 @@ onBreakpointsReplaced(() => {
  * spellings, so rewriting `data-option-columns:s` at runtime reports a change
  * exactly as rewriting `data-option-columns` does.
  *
- * Called by the registry for every option a registered component declares —
- * `attribute × breakpoint`, which is why the suffix names one breakpoint
- * rather than a set.
+ * Called by the registry for `data-component` and for every option a
+ * registered component declares — `attribute × breakpoint`, which is why the
+ * suffix names one breakpoint rather than a set.
  */
 export function observeResponsiveAttribute(attribute: string): void {
   observed.add(attribute);
@@ -127,6 +140,21 @@ export function responsiveRawValue(
   breakpoint: string,
   get: (name: string) => string | null,
 ): string | null {
+  return responsiveScopedRawValue(attribute, breakpoint, get) ?? get(attribute);
+}
+
+/**
+ * The scoped value in force at one breakpoint, without falling back to the
+ * plain attribute. An empty string is a present override; `null` means no
+ * scoped candidate was present.
+ *
+ * @internal
+ */
+export function responsiveScopedRawValue(
+  attribute: string,
+  breakpoint: string,
+  get: (name: string) => string | null,
+): string | null {
   const names = breakpointNames();
   const scoped = scopedAttributes(attribute);
   for (let index = names.indexOf(breakpoint); index >= 0; index -= 1) {
@@ -135,19 +163,18 @@ export function responsiveRawValue(
       return value;
     }
   }
-  return get(attribute);
+  return null;
 }
 
 /**
  * Follow the viewport, and report the breakpoint it left as well as the one it
  * reached.
  *
- * The subscription is the only thing here that costs anything at rest, which is
- * why the caller opens it per mount cycle and only for a component that can act
- * on a crossing. Reference counting does the rest: the breakpoint service holds
- * its `matchMedia` listeners while it has subscribers and releases them with
- * the last one, so a page with no responsive option — or one whose responsive
- * components have all been destroyed — listens to nothing.
+ * The subscription is the only thing here that costs anything at rest. Option
+ * effects open it per mount cycle; the registry opens one shared subscription
+ * while connected responsive declarations exist. Reference counting does the
+ * rest: the breakpoint service holds its `matchMedia` listeners while it has
+ * subscribers and releases them with the last one.
  */
 export function watchBreakpoint(callback: (previous: string) => void): () => void {
   let previous = activeBreakpoint();
@@ -165,13 +192,15 @@ export function watchBreakpoint(callback: (previous: string) => void): () => voi
  * breakpoint `xxs:xs:s`, which is in no set, so the attribute is simply never a
  * candidate and the option quietly serves its base value everywhere. That is
  * the one failure this design can produce silently, and a migration is exactly
- * when it happens — so it is said out loud, once per mount, in the same spirit
- * as the payload-shape warning: the option still resolves, this reports a
- * spelling rather than policing one.
+ * when it happens — so it is said out loud, once per element and spelling, in
+ * the same spirit as the payload-shape warning: the option still resolves,
+ * this reports a spelling rather than policing one.
  *
  * The element's attributes are scanned **once** for all of a component's
  * options rather than once per option, since `getAttributeNames()` allocates.
  */
+const warnedResponsiveAttributes = new WeakMap<Element, Set<string>>();
+
 export function checkResponsiveAttributes(el: HTMLElement, attributes: readonly string[]): void {
   if (attributes.length === 0) {
     return;
@@ -181,6 +210,15 @@ export function checkResponsiveAttributes(el: HTMLElement, attributes: readonly 
     for (const attribute of attributes) {
       const prefix = `${attribute}${RESPONSIVE_SEPARATOR}`;
       if (name.startsWith(prefix) && !names.includes(name.slice(prefix.length))) {
+        let warned = warnedResponsiveAttributes.get(el);
+        if (warned?.has(name)) {
+          break;
+        }
+        if (!warned) {
+          warned = new Set();
+          warnedResponsiveAttributes.set(el, warned);
+        }
+        warned.add(name);
         console.warn(
           `[base] \`${name}\` names no breakpoint, so it is never read. One breakpoint per attribute, cascading upwards from it — known names: ${names.join(', ')}.`,
         );

--- a/packages/v4/src/utils/selectors.spec.ts
+++ b/packages/v4/src/utils/selectors.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { BREAKPOINTS, setBreakpoints } from '../services/breakpoint.js';
 import { selectorFor } from './selectors.js';
+
+afterEach(() => setBreakpoints(BREAKPOINTS));
 
 describe('selectorFor', () => {
   it('matches whitespace-separated data-component tokens', () => {
@@ -8,5 +11,13 @@ describe('selectorFor', () => {
     expect(el.matches(selectorFor('Action'))).toBe(true);
     expect(el.matches(selectorFor('Dialog'))).toBe(true);
     expect(el.matches(selectorFor('Dia'))).toBe(false);
+  });
+
+  it('includes the exact responsive spellings from the configured breakpoint set', () => {
+    setBreakpoints({ mobile: '0rem', desktop: '80rem' });
+    const el = document.createElement('div');
+    el.setAttribute('data-component:desktop', 'Dialog');
+
+    expect(el.matches(selectorFor('Dialog'))).toBe(true);
   });
 });

--- a/packages/v4/src/utils/selectors.ts
+++ b/packages/v4/src/utils/selectors.ts
@@ -1,16 +1,24 @@
+import { COMPONENT_ATTRIBUTE } from '../component-declarations.js';
+import { responsiveAttributeNames } from '../responsive-options.js';
+
 /**
  * How a component name becomes a selector. One function, kept apart from the
  * string helpers because it encodes the attribute contract rather than a
- * spelling: `data-component` is where the registry looks, and `~=` is why more
- * than one component can be declared on an element.
+ * spelling: `data-component` and its configured responsive spellings are
+ * where the registry looks, and `~=` is why more than one component can be
+ * declared on an element.
  */
 
 /**
  * The registry selector for a component name.
  *
  * `~=` gives whitespace-token matching, so `data-component="Action Dialog"`
- * declares several components on one element.
+ * declares several components on one element. Scoped attributes are included
+ * as discovery candidates; callers still check for a mounted instance, so an
+ * inactive declaration never appears in a lookup result.
  */
 export function selectorFor(name: string): string {
-  return `[data-component~="${name}"]`;
+  return [COMPONENT_ATTRIBUTE, ...responsiveAttributeNames(COMPONENT_ATTRIBUTE)]
+    .map((attribute) => `[${CSS.escape(attribute)}~="${name}"]`)
+    .join(',');
 }


### PR DESCRIPTION
### Linked issue

No linked issue.

### Type of change

- [x] Documentation
- [x] New feature

### Description

Adds responsive v4 component declarations with the same one-breakpoint, upward cascade as responsive options.

```html
<div
  data-component="Action Analytics"
  data-component:xxs="MobileMenu MobileSearch"
  data-component:m="DesktopMenu DesktopSearch">
</div>
```

The plain tokens stay unconditional. The widest active scoped attribute replaces lower scoped sets, including an explicit empty stop. The registry unions and deduplicates the plain and selected sets.

Breakpoint crossings and live attribute changes preserve shared instances, terminate old-only declarations, and schedule new-only declarations through the existing eager, lazy, and mount-strategy pipeline. Inactive lazy declarations do not import. Crossing work joins `whenDOMSettled()`.

The central observer tracks exact configured `data-component:<breakpoint>` names and replaces that filter slice after `setBreakpoints()`. Responsive elements share one reference-counted breakpoint subscription.

### Test results

- `npm run test -w @studiometa/js-toolkit-v4 -- src/responsive-components.spec.ts src/responsive-options.spec.ts src/registry.spec.ts src/dom-mutations.spec.ts src/autoload.spec.ts src/utils/selectors.spec.ts` — 66 passed
- `npm run test:v4` — 653 passed, 1 expected failure
- `npm run lint:types -w @studiometa/js-toolkit-v4`
- `npm run lint:static` — passed with two existing warnings outside this change
- `npm run lint:fmt`
- `npm run subpaths:check`
- `npm run build:v4`
- `npm run test -w @studiometa/js-toolkit-v4 -- src/exports.spec.ts` — 2 passed

### Checklist

- [x] I have added tests.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
