### PR TITLE
[Bugfix] Snapshot scheduler tick callbacks

### DIFF
--- a/packages/v4/src/scheduler.bench.ts
+++ b/packages/v4/src/scheduler.bench.ts
@@ -241,7 +241,11 @@ class ClassScheduler implements Variant {
         delta: this.#clampDelta(frameTime),
       };
       this.#lastFrameTime = frameTime;
-      for (const callback of this.#tickCallbacks) {
+      const callbacks = [...this.#tickCallbacks];
+      for (const callback of callbacks) {
+        if (!this.#tickCallbacks.has(callback)) {
+          continue;
+        }
         try {
           callback(props);
         } catch (error) {
@@ -367,7 +371,11 @@ function createFactoryScheduler(driver: Driver): Variant {
       phase = 'tick';
       const props: TickProps = { time: frameTime, delta: clampDelta(frameTime) };
       lastFrameTime = frameTime;
-      for (const callback of tickCallbacks) {
+      const callbacks = [...tickCallbacks];
+      for (const callback of callbacks) {
+        if (!tickCallbacks.has(callback)) {
+          continue;
+        }
         try {
           callback(props);
         } catch (error) {
@@ -555,9 +563,10 @@ describe('250 reads + 250 writes in one frame', () => {
 });
 
 /**
- * The flush path with no promises in it: a tick fan-out allocates nothing per
- * subscriber, so what is left is the loop, the phase writes, the delta clamp
- * and — in the class — the brand check on every `this.#field` it touches.
+ * The flush path with no promises in it: a tick fan-out allocates one callback
+ * snapshot per frame, so what is left is the copy, the loop, the live-set
+ * checks, the phase writes, the delta clamp and — in the class — the brand
+ * check on every `this.#field` it touches.
  */
 describe('tick fan-out, 100 subscribers, 100 frames', () => {
   function body([scheduler, driver]: [Variant, Driver]) {

--- a/packages/v4/src/scheduler.spec.ts
+++ b/packages/v4/src/scheduler.spec.ts
@@ -263,6 +263,70 @@ describe('defaultScheduler.tick', () => {
     expect(seen[0]).toBe(rafTime);
   });
 
+  it('waits until the next frame to call a callback added during a tick', async () => {
+    let firstTicks = 0;
+    let addedTicks = 0;
+    const added = () => {
+      addedTicks += 1;
+    };
+    let unsubscribeAdded = (): void => {};
+    const unsubscribeFirst = defaultScheduler.tick(() => {
+      firstTicks += 1;
+      unsubscribeAdded = defaultScheduler.tick(added);
+    });
+
+    await nextFrame();
+    const afterFirstFrame = { firstTicks, addedTicks };
+    await nextFrame();
+    unsubscribeFirst();
+    unsubscribeAdded();
+
+    expect(afterFirstFrame).toEqual({ firstTicks: 1, addedTicks: 0 });
+    expect({ firstTicks, addedTicks }).toEqual({ firstTicks: 2, addedTicks: 1 });
+  });
+
+  it('skips a callback removed before its turn in the same tick', async () => {
+    const calls: string[] = [];
+    let unsubscribeSecond = (): void => {};
+    const unsubscribeFirst = defaultScheduler.tick(() => {
+      calls.push('first');
+      unsubscribeSecond();
+    });
+    unsubscribeSecond = defaultScheduler.tick(() => {
+      calls.push('second');
+    });
+
+    await nextFrame();
+    unsubscribeFirst();
+
+    expect(calls).toEqual(['first']);
+  });
+
+  it('bounds repeated callback creation to one generation per frame', async () => {
+    const unsubscribers: Array<() => void> = [];
+    let runs = 0;
+    const addCallback = () => {
+      unsubscribers.push(
+        defaultScheduler.tick(() => {
+          runs += 1;
+          if (runs < 10_000) {
+            addCallback();
+          }
+        }),
+      );
+    };
+    addCallback();
+
+    await nextFrame();
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe();
+    }
+
+    // Live Set iteration would call all 10,000 newly added callbacks in this
+    // flush. A frame snapshot runs only the generation present at its start.
+    expect(runs).toBe(1);
+  });
+
   it('stops calling a callback once it unsubscribes', async () => {
     let ticks = 0;
     const unsubscribe = defaultScheduler.tick(() => {

--- a/packages/v4/src/scheduler.ts
+++ b/packages/v4/src/scheduler.ts
@@ -314,7 +314,13 @@ export class Scheduler {
         delta: this.#clampDelta(frameTime),
       };
       this.#lastFrameTime = frameTime;
-      for (const callback of this.#tickCallbacks) {
+      const callbacks = [...this.#tickCallbacks];
+      for (const callback of callbacks) {
+        // A subscription starts on the next frame. An unsubscribe takes
+        // effect at once, including before the callback's turn in this tick.
+        if (!this.#tickCallbacks.has(callback)) {
+          continue;
+        }
         try {
           callback(props);
         } catch (error) {


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Description

Iterate a snapshot of scheduler tick callbacks for each frame. Check each callback against the live set before calling it. This makes subscriptions added during a tick start on the next frame, while an earlier unsubscribe still prevents a callback from running in the current tick.

Add regression coverage for callback addition, callback removal before its turn, and bounded repeated callback creation. Keep the scheduler benchmark variants aligned with the shipped implementation.

### Validation

- `npm run test -w @studiometa/js-toolkit-v4 -- src/scheduler.spec.ts src/services/raf.spec.ts` (26 passed)
- `npm run test:v4` (745 passed)
- `npm run lint:types`
- `npm run lint:static`
- `npm run lint:fmt`
- `npm run subpaths:check`
- `npm run build`
- `npm run bench -w @studiometa/js-toolkit-v4 -- src/scheduler.bench.ts`

The post-fix synthetic tick benchmarks remain below 0.00025 ms per frame for both the 1-subscriber and 100-subscriber class cases.

### Checklist

- [x] I have added tests.
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog.