### PR TITLE
[Bugfix] Make v4 service startup reentrant

### DIFF
--- a/packages/v4/src/services/service.spec.ts
+++ b/packages/v4/src/services/service.spec.ts
@@ -50,6 +50,95 @@ describe('createService', () => {
     expect(calls).toEqual(['start', 'stop', 'start']);
   });
 
+  it('joins a subscription created by a synchronous startup emit to the same run', () => {
+    const calls: string[] = [];
+    const service = createService<number>({
+      props: () => 1,
+      start(emit) {
+        calls.push('start');
+        emit(1);
+        return () => calls.push('stop');
+      },
+    });
+
+    let didNest = false;
+    let unsubscribeNested = () => {};
+    const unsubscribeFirst = service.subscribe(() => {
+      if (!didNest) {
+        didNest = true;
+        unsubscribeNested = service.subscribe(() => {});
+      }
+    });
+
+    expect(calls).toEqual(['start']);
+    unsubscribeFirst();
+    expect(calls).toEqual(['start']);
+    unsubscribeNested();
+    expect(calls).toEqual(['start', 'stop']);
+  });
+
+  it('restarts after a reentrant startup run is fully released', () => {
+    const calls: string[] = [];
+    const service = createService<number>({
+      props: () => 1,
+      start(emit) {
+        calls.push('start');
+        emit(1);
+        return () => calls.push('stop');
+      },
+    });
+
+    function subscribeRun() {
+      let didNest = false;
+      let unsubscribeNested = () => {};
+      const unsubscribeFirst = service.subscribe(() => {
+        if (!didNest) {
+          didNest = true;
+          unsubscribeNested = service.subscribe(() => {});
+        }
+      });
+      return () => {
+        unsubscribeFirst();
+        unsubscribeNested();
+      };
+    }
+
+    subscribeRun()();
+    subscribeRun()();
+    expect(calls).toEqual(['start', 'stop', 'start', 'stop']);
+  });
+
+  it('rolls back a subscriber when startup throws and can recover', () => {
+    const startupError = new Error('startup failed');
+    const failedCalls: number[] = [];
+    const recoveredCalls: number[] = [];
+    let starts = 0;
+    let stops = 0;
+    const service = createService<number>({
+      props: () => starts,
+      start(emit) {
+        starts += 1;
+        if (starts === 1) {
+          throw startupError;
+        }
+        emit(starts);
+        return () => {
+          stops += 1;
+        };
+      },
+    });
+
+    expect(() => service.subscribe((value) => failedCalls.push(value))).toThrow(startupError);
+
+    const unsubscribe = service.subscribe((value) => recoveredCalls.push(value));
+    expect(starts).toBe(2);
+    expect(failedCalls).toEqual([]);
+    expect(recoveredCalls).toEqual([2]);
+
+    unsubscribe();
+    expect(stops).toBe(1);
+  });
+
   it('ignores a repeated unsubscribe', () => {
     const calls: string[] = [];
     const service = createService<number>({

--- a/packages/v4/src/services/service.ts
+++ b/packages/v4/src/services/service.ts
@@ -138,6 +138,7 @@ export function createService<T, R = void>({
   hasProps,
 }: ServiceDefinition<T>): Service<T, R> {
   const subscriptions = new Set<Subscription<T, R>>();
+  let state: 'idle' | 'starting' | 'running' = 'idle';
   let stop: Unsubscribe | null = null;
 
   function emit(current: T): void {
@@ -175,7 +176,27 @@ export function createService<T, R = void>({
     subscribe(callback, { immediate = false } = {}) {
       const subscription: Subscription<T, R> = { callback, isActive: true };
       subscriptions.add(subscription);
-      stop ??= start(emit);
+      if (state === 'idle') {
+        // Mark the run before calling user code: `start()` may emit at once,
+        // and a callback may subscribe again from inside that emit. The nested
+        // subscription joins this run instead of starting a second source.
+        state = 'starting';
+        try {
+          stop = start(emit);
+          state = 'running';
+        } catch (error) {
+          // Nobody can have subscribed before this startup attempt: an idle
+          // service has no holders. Roll back this subscriber and any nested
+          // ones that joined the failed run, then leave the service restartable.
+          for (const joined of subscriptions) {
+            joined.isActive = false;
+          }
+          subscriptions.clear();
+          stop = null;
+          state = 'idle';
+          throw error;
+        }
+      }
       // After `start()`, never before: starting is what makes `props()`
       // current — the scroll service measures its target there, the breakpoint
       // service asks its media queries — so delivering first would hand out
@@ -210,8 +231,13 @@ export function createService<T, R = void>({
         if (subscriptions.size > 0) {
           return;
         }
-        stop?.();
+        if (state !== 'running') {
+          return;
+        }
+        const release = stop;
         stop = null;
+        state = 'idle';
+        release?.();
       };
     },
   };


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Description

Mark a `createService()` run as starting before calling its source. A subscription created by a synchronous startup emit now joins that run instead of starting and leaking a second source. Roll back subscriptions atomically when startup throws so the service can start again.

Add regression coverage for nested startup subscriptions, cleanup, restart, and startup-throw recovery.

### Test evidence

- `npm exec --workspace=@studiometa/js-toolkit-v4 -- vitest run src/services/service.spec.ts`
- `npm run test:v4`
- `npm run lint:types`
- `npm run lint:static`
- `npm run lint:fmt`
- `npm run subpaths:check`
- `npm run build`
- `npm run bench --workspace=@studiometa/js-toolkit-v4 -- --run src/services/service.bench.ts`

### Checklist

- [x] I have added tests.
- [x] No public documentation change is required.
- [x] No changelog change is required.