### PR TITLE
[Bugfix] Share v4 in-view root identity across runtimes

### DIFF
--- a/packages/v4/src/duplicate-runtime.spec.ts
+++ b/packages/v4/src/duplicate-runtime.spec.ts
@@ -75,10 +75,23 @@ interface FixtureMessage {
         activeAfterBoth: number;
       };
       intersection: {
-        created: number;
-        activeWithBoth: number;
-        activeAfterOne: number;
-        activeAfterBoth: number;
+        sameRoot: {
+          sameService: boolean;
+          correctRoot: boolean;
+          created: number;
+          activeWithBoth: number;
+          activeAfterOne: number;
+          activeAfterBoth: number;
+        };
+        distinctRoots: {
+          separateServices: boolean;
+          correctRoots: boolean;
+          isolatedState: boolean;
+          created: number;
+          activeWithBoth: number;
+          activeAfterOne: number;
+          activeAfterBoth: number;
+        };
       };
       dragTouchAction: {
         withX: string;
@@ -232,10 +245,23 @@ describe('duplicated v4 bundles', () => {
       activeAfterBoth: 0,
     });
     expect(result.services.intersection).toEqual({
-      created: 1,
-      activeWithBoth: 1,
-      activeAfterOne: 1,
-      activeAfterBoth: 0,
+      sameRoot: {
+        sameService: true,
+        correctRoot: true,
+        created: 1,
+        activeWithBoth: 1,
+        activeAfterOne: 1,
+        activeAfterBoth: 0,
+      },
+      distinctRoots: {
+        separateServices: true,
+        correctRoots: true,
+        isolatedState: true,
+        created: 2,
+        activeWithBoth: 2,
+        activeAfterOne: 1,
+        activeAfterBoth: 0,
+      },
     });
     expect(result.services.dragTouchAction).toEqual({
       withX: 'pan-y',

--- a/packages/v4/src/services/in-view.ts
+++ b/packages/v4/src/services/in-view.ts
@@ -9,28 +9,35 @@ export interface InViewProps {
   readonly entry: IntersectionObserverEntry | null;
 }
 
-/**
- * Give an observer root a stable serialisable identity. `perTarget()` can
- * serialise the rest of `IntersectionObserverInit`, but two root elements
- * would otherwise both become `{}` and share an observation they did not ask
- * for.
- */
-const rootIds = new WeakMap<object, number>();
-let nextRootId = 1;
+interface InViewRootIdentity {
+  readonly ids: WeakMap<object, number>;
+  nextId: number;
+}
 
-function rootId(root: object): number {
-  let id = rootIds.get(root);
+interface InViewRuntimeState {
+  readonly rootIdentity: InViewRootIdentity;
+  readonly services: (target: Element, init: IntersectionObserverInit) => Service<InViewProps>;
+}
+
+/**
+ * Give an observer root a stable realm-wide serialisable identity.
+ * `perTarget()` can serialise the rest of `IntersectionObserverInit`, but two
+ * root elements would otherwise both become `{}` and share an observation
+ * they did not ask for.
+ */
+function rootId(root: object, identity: InViewRootIdentity): number {
+  let id = identity.ids.get(root);
   if (!id) {
-    id = nextRootId;
-    nextRootId += 1;
-    rootIds.set(root, id);
+    id = identity.nextId;
+    identity.nextId += 1;
+    identity.ids.set(root, id);
   }
   return id;
 }
 
-function keyOf(init: IntersectionObserverInit): string {
+function keyOf(init: IntersectionObserverInit, identity: InViewRootIdentity): string {
   const { root, ...options } = init;
-  return JSON.stringify([root ? rootId(root) : null, options]);
+  return JSON.stringify([root ? rootId(root, identity) : null, options]);
 }
 
 function createInViewService(
@@ -92,8 +99,19 @@ function createInViewService(
   });
 }
 
-const inViewServices = /* @__PURE__ */ getSharedRuntimeSlot('service:in-view', 1, () =>
-  perTarget(createInViewService, keyOf),
+const inViewState = /* @__PURE__ */ getSharedRuntimeSlot<InViewRuntimeState>(
+  'service:in-view',
+  2,
+  () => {
+    const rootIdentity: InViewRootIdentity = {
+      ids: new WeakMap(),
+      nextId: 1,
+    };
+    return {
+      rootIdentity,
+      services: perTarget(createInViewService, (init) => keyOf(init, rootIdentity)),
+    };
+  },
 );
 
 /**
@@ -112,7 +130,7 @@ export function useInView(
   target: Element,
   init: IntersectionObserverInit = {},
 ): Service<InViewProps> {
-  return inViewServices(target, init);
+  return inViewState.services(target, init);
 }
 
 /** The method `withInView()` subscribes for the component. */

--- a/packages/v4/test/runtime-harness.js
+++ b/packages/v4/test/runtime-harness.js
@@ -498,17 +498,73 @@ async function run(copyA, copyB) {
     stopResizeB();
     const resizeActiveAfterBoth = observers.resize.active;
 
-    const inViewService = copyA.useInView(serviceTarget, { threshold: 0.5 });
-    const intersectionCreatedBefore = observers.intersection.created;
-    const intersectionActiveBefore = observers.intersection.active;
-    const stopInViewA = inViewService.subscribe(() => {});
-    const stopInViewB = copyB.useInView(serviceTarget, { threshold: 0.5 }).subscribe(() => {});
-    const intersectionCreated = observers.intersection.created - intersectionCreatedBefore;
-    const intersectionActiveWithBoth = observers.intersection.active - intersectionActiveBefore;
-    stopInViewA();
-    const intersectionActiveAfterOne = observers.intersection.active - intersectionActiveBefore;
-    stopInViewB();
-    const intersectionActiveAfterBoth = observers.intersection.active - intersectionActiveBefore;
+    const sharedInViewRoot = document.createElement('section');
+    const inViewRootA = document.createElement('section');
+    const inViewRootB = document.createElement('section');
+    sharedInViewRoot.append(inViewRootA);
+    inViewRootA.append(inViewRootB);
+    inViewRootB.append(serviceTarget);
+    document.body.append(sharedInViewRoot);
+
+    // The exact same root object and equivalent options still identify one
+    // realm-wide service across independently bundled copies.
+    const sharedRootServiceA = copyA.useInView(serviceTarget, {
+      root: sharedInViewRoot,
+      threshold: 0.5,
+    });
+    const sharedRootServiceB = copyB.useInView(serviceTarget, {
+      root: sharedInViewRoot,
+      threshold: 0.5,
+    });
+    const sharedRootCreatedBefore = observers.intersection.created;
+    const sharedRootActiveBefore = observers.intersection.active;
+    const sharedRootObserverOffset = intersectionObservers.length;
+    const stopSharedRootA = sharedRootServiceA.subscribe(() => {});
+    const stopSharedRootB = sharedRootServiceB.subscribe(() => {});
+    const sharedRootObservers = intersectionObservers.slice(sharedRootObserverOffset);
+    const sharedRootCreated = observers.intersection.created - sharedRootCreatedBefore;
+    const sharedRootActiveWithBoth = observers.intersection.active - sharedRootActiveBefore;
+    stopSharedRootA();
+    const sharedRootActiveAfterOne = observers.intersection.active - sharedRootActiveBefore;
+    stopSharedRootB();
+    const sharedRootActiveAfterBoth = observers.intersection.active - sharedRootActiveBefore;
+
+    // Each copy now asks for the same target with a distinct root. A copy-local
+    // identity allocator would give both roots the same ID and silently return
+    // A's service to B.
+    const distinctRootServiceA = copyA.useInView(serviceTarget, {
+      root: inViewRootA,
+      threshold: 0.5,
+    });
+    const distinctRootServiceB = copyB.useInView(serviceTarget, {
+      root: inViewRootB,
+      threshold: 0.5,
+    });
+    let distinctRootCallsA = 0;
+    let distinctRootCallsB = 0;
+    const distinctRootCreatedBefore = observers.intersection.created;
+    const distinctRootActiveBefore = observers.intersection.active;
+    const distinctRootObserverOffset = intersectionObservers.length;
+    const stopDistinctRootA = distinctRootServiceA.subscribe(() => {
+      distinctRootCallsA += 1;
+    });
+    const stopDistinctRootB = distinctRootServiceB.subscribe(() => {
+      distinctRootCallsB += 1;
+    });
+    const distinctRootObservers = intersectionObservers.slice(distinctRootObserverOffset);
+    const observerForRootA = distinctRootObservers.find(
+      (observer) => observer.options.root === inViewRootA,
+    );
+    const observerForRootB = distinctRootObservers.find(
+      (observer) => observer.options.root === inViewRootB,
+    );
+    observerForRootA?.deliver(serviceTarget, true);
+    const distinctRootCreated = observers.intersection.created - distinctRootCreatedBefore;
+    const distinctRootActiveWithBoth = observers.intersection.active - distinctRootActiveBefore;
+    stopDistinctRootA();
+    const distinctRootActiveAfterOne = observers.intersection.active - distinctRootActiveBefore;
+    stopDistinctRootB();
+    const distinctRootActiveAfterBoth = observers.intersection.active - distinctRootActiveBefore;
 
     // Different axis options create distinct services, one from each bundled
     // copy. Their touch-action claims still belong to the realm: releasing one
@@ -576,7 +632,7 @@ async function run(copyA, copyB) {
     viewport.remove();
     viewportLazy.remove();
     responsive.remove();
-    serviceTarget.remove();
+    sharedInViewRoot.remove();
     otherTarget.remove();
     contextScope.remove();
     emitter.$terminate();
@@ -628,10 +684,28 @@ async function run(copyA, copyB) {
             activeAfterBoth: resizeActiveAfterBoth,
           },
           intersection: {
-            created: intersectionCreated,
-            activeWithBoth: intersectionActiveWithBoth,
-            activeAfterOne: intersectionActiveAfterOne,
-            activeAfterBoth: intersectionActiveAfterBoth,
+            sameRoot: {
+              sameService: sharedRootServiceA === sharedRootServiceB,
+              correctRoot:
+                sharedRootObservers.length === 1 &&
+                sharedRootObservers[0].options.root === sharedInViewRoot,
+              created: sharedRootCreated,
+              activeWithBoth: sharedRootActiveWithBoth,
+              activeAfterOne: sharedRootActiveAfterOne,
+              activeAfterBoth: sharedRootActiveAfterBoth,
+            },
+            distinctRoots: {
+              separateServices: distinctRootServiceA !== distinctRootServiceB,
+              correctRoots:
+                distinctRootObservers.length === 2 &&
+                observerForRootA !== undefined &&
+                observerForRootB !== undefined,
+              isolatedState: distinctRootCallsA === 1 && distinctRootCallsB === 0,
+              created: distinctRootCreated,
+              activeWithBoth: distinctRootActiveWithBoth,
+              activeAfterOne: distinctRootActiveAfterOne,
+              activeAfterBoth: distinctRootActiveAfterBoth,
+            },
           },
           dragTouchAction: {
             withX: touchActionWithX,


### PR DESCRIPTION
### Linked issue

No linked issue.

### Type of change

- [x] Bug fix

### Description

Move `useInView()` root identity allocation into the revision 2 realm-shared in-view runtime state. Distinct roots from independently bundled copies now keep separate services and observers, while the exact same root and equivalent options still share one service.

Extend the independent-bundle duplicate-runtime fixture to verify observer roots, service-state isolation, reference-counted cleanup, and same-root sharing.

### Validation

- `npm exec --workspace=@studiometa/js-toolkit-v4 vitest run src/services/in-view.spec.ts src/duplicate-runtime.spec.ts`
- `npm run test:runtime -w @studiometa/js-toolkit-v4`
- `npm run test:v4`
- `npm run lint`
- `npm run build`
- `npm run check:constant-subpaths -w @studiometa/js-toolkit-v4`

### Checklist

- [ ] I have linked an issue or discussion.
- [x] I have added tests.
- [x] Documentation does not need an update.
- [x] The changelog does not need an update.