### PR TITLE
[Bugfix] Make v4 Base lifecycle transitions atomic

### DIFF
--- a/packages/v4/src/Base.spec.ts
+++ b/packages/v4/src/Base.spec.ts
@@ -6,6 +6,7 @@ import {
   type ChildrenCollection,
   type DelegatedEvent,
   type GlobalEvent,
+  type MountedReturn,
   type OptionChange,
   type RefEvent,
 } from './Base.js';
@@ -1395,6 +1396,44 @@ describe('$watchChildren', () => {
     expect(collection.items).toEqual([exact, lateExact]);
   });
 
+  it('does not announce or retain a child destroyed from mounted()', async () => {
+    class Child extends Base {
+      static config = { name: 'WatchSelfDestroyingChild' };
+
+      mounted(): void {
+        this.$destroy();
+      }
+    }
+    class Owner extends Base {
+      static config = { name: 'WatchSelfDestroyingOwner' };
+    }
+
+    const root = document.createElement('div');
+    const childEl = root.appendChild(document.createElement('div'));
+    document.body.append(root);
+    const owner = new Owner(root);
+    const collection = owner.$watchChildren(Child);
+    owner.$mount();
+    let announcements = 0;
+    root.addEventListener(MOUNTED_EVENT, () => {
+      announcements += 1;
+    });
+
+    const child = new Child(childEl).$mount();
+    await settle();
+
+    expect(child.$isMounted).toBe(false);
+    expect(announcements).toBe(0);
+    expect(collection.size).toBe(0);
+
+    // Ignore a stale or user-created announcement for an unmounted instance.
+    childEl.dispatchEvent(
+      new CustomEvent(MOUNTED_EVENT, { bubbles: true, detail: { instance: child } }),
+    );
+    expect(collection.size).toBe(0);
+    owner.$terminate();
+  });
+
   it('does not let a deferred constructor sweep outlive termination', async () => {
     class Child extends Base {
       static config = { name: 'WatchTerminatedChild' };
@@ -1851,5 +1890,43 @@ describe('lifecycle', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(cleaned).toBe(true);
+  });
+
+  it('keeps recursive async cleanups with the mount cycle that produced them', async () => {
+    const calls: string[] = [];
+    const resolvers: Array<(result: MountedReturn) => void> = [];
+    let mounts = 0;
+
+    class Cycled extends Base {
+      static config = { name: 'CycledAsyncCleanup' };
+
+      mounted(): MountedReturn {
+        mounts += 1;
+        return new Promise<MountedReturn>((resolve) => {
+          resolvers.push((result) => resolve(result));
+        });
+      }
+    }
+
+    const el = document.createElement('div');
+    document.body.append(el);
+    const instance = new Cycled(el).$mount();
+    instance.$destroy();
+    instance.$mount();
+
+    // This nested result belongs to cycle 1. Resolving it during cycle 2 must
+    // run it now, not attach it to cycle 2.
+    resolvers[0]([Promise.resolve([() => calls.push('cleanup:1')])]);
+    await settle();
+    expect(mounts).toBe(2);
+    expect(instance.$isMounted).toBe(true);
+    expect(calls).toEqual(['cleanup:1']);
+
+    // A cleanup from the active cycle is still retained until destroy.
+    resolvers[1]([() => calls.push('cleanup:2')]);
+    await settle();
+    expect(calls).toEqual(['cleanup:1']);
+    instance.$destroy();
+    expect(calls).toEqual(['cleanup:1', 'cleanup:2']);
   });
 });

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -1203,13 +1203,23 @@ export class Base<T extends BaseProps = BaseProps> {
     this.#bindHandlers();
     this.#isMounted = true;
     this.#mountCycle += 1;
-    this.#initializeOptionEffects();
-    this.#initializeResponsiveOptions();
+    const cycle = this.#mountCycle;
+    this.#initializeOptionEffects(cycle);
+    if (!this.#isActiveMountCycle(cycle)) {
+      return this;
+    }
+    this.#initializeResponsiveOptions(cycle);
+    if (!this.#isActiveMountCycle(cycle)) {
+      return this;
+    }
     try {
-      this.#collectCleanup(this.mounted());
+      this.#collectCleanup(this.mounted(), cycle);
     } catch (error) {
       console.error('[base] `mounted()` failed:', error);
       reportToolkitError('lifecycle', error, this.$config.name, this.$el);
+    }
+    if (!this.#isActiveMountCycle(cycle)) {
+      return this;
     }
     // Announce existence to every ancestor (objective 5, layer 1).
     const detail: LifecycleEventDetail = { instance: this };
@@ -1447,7 +1457,7 @@ export class Base<T extends BaseProps = BaseProps> {
 
     const onMounted = (event: Event) => {
       const { instance } = (event as CustomEvent<LifecycleEventDetail>).detail;
-      if (matches(instance)) {
+      if (instance.$isMounted && matches(instance)) {
         add(instance);
       }
     };
@@ -1775,8 +1785,15 @@ export class Base<T extends BaseProps = BaseProps> {
     return task;
   }
 
-  #initializeOptionEffects(): void {
+  #isActiveMountCycle(cycle: number): boolean {
+    return this.#isMounted && this.#mountCycle === cycle;
+  }
+
+  #initializeOptionEffects(cycle: number): void {
     for (const [name, reader] of optionReaders.get(this) ?? []) {
+      if (!this.#isActiveMountCycle(cycle)) {
+        return;
+      }
       this.#runOptionEffect(name, reader, null, true);
     }
   }
@@ -1791,7 +1808,7 @@ export class Base<T extends BaseProps = BaseProps> {
    * nothing at rest. Only a component that has asked to be **told** holds a
    * `matchMedia` listener, and only while it is mounted.
    */
-  #initializeResponsiveOptions(): void {
+  #initializeResponsiveOptions(cycle: number): void {
     const readers = optionReaders.get(this);
     if (!readers || readers.size === 0) {
       return;
@@ -1814,7 +1831,7 @@ export class Base<T extends BaseProps = BaseProps> {
       return;
     }
 
-    this.#destroyCallbacks.push(
+    this.#collectCleanup(
       watchBreakpoint((previous) => {
         const fromElement = (attributeName: string) => this.$el.getAttribute(attributeName);
         for (const [name, reader] of readers) {
@@ -1826,6 +1843,7 @@ export class Base<T extends BaseProps = BaseProps> {
           }
         }
       }),
+      cycle,
     );
   }
 
@@ -1902,15 +1920,15 @@ export class Base<T extends BaseProps = BaseProps> {
 
   /**
    * Register the cleanup value returned by `mounted()`. Async hooks are
-   * awaited; if the instance was destroyed in the meantime, the cleanup runs
-   * right away instead of leaking.
+   * awaited; if their mount cycle ended in the meantime, the cleanup runs
+   * right away instead of leaking into a later cycle.
    */
-  #collectCleanup(result: MountedReturn): void {
+  #collectCleanup(result: MountedReturn, cycle: number): void {
     if (typeof result === 'function') {
-      if (this.#isMounted) {
+      if (this.#isActiveMountCycle(cycle)) {
         this.#destroyCallbacks.push(result);
       } else {
-        // The instance was destroyed while an async `mounted()` was pending:
+        // The originating mount cycle ended while an async result was pending:
         // run the cleanup right away instead of leaking.
         try {
           result();
@@ -1923,13 +1941,13 @@ export class Base<T extends BaseProps = BaseProps> {
     }
     if (Array.isArray(result)) {
       for (const item of result) {
-        this.#collectCleanup(item);
+        this.#collectCleanup(item, cycle);
       }
       return;
     }
     if (result instanceof Promise) {
       result
-        .then((resolved) => this.#collectCleanup(resolved))
+        .then((resolved) => this.#collectCleanup(resolved, cycle))
         .catch((error) => {
           console.error('[base] `mounted()` failed:', error);
           reportToolkitError('lifecycle', error, this.$config.name, this.$el);

--- a/packages/v4/src/registry.spec.ts
+++ b/packages/v4/src/registry.spec.ts
@@ -95,10 +95,12 @@ describe('registry', () => {
     expect(second.$isMounted).toBe(true);
   });
 
-  it('isolates a construction failure and reports it from the component element', async () => {
+  it('does not retain or reuse an instance whose derived constructor failed', async () => {
     const failure = new Error('constructor failed');
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     const events: CustomEvent<ToolkitErrorDetail>[] = [];
+    const attempts: BrokenConstruction[] = [];
+    let brokenMounts = 0;
     let healthyMounts = 0;
 
     class BrokenConstruction extends Base {
@@ -106,7 +108,12 @@ describe('registry', () => {
 
       constructor(el: HTMLElement) {
         super(el);
+        attempts.push(this);
         throw failure;
+      }
+
+      mounted(): void {
+        brokenMounts += 1;
       }
     }
 
@@ -130,19 +137,62 @@ describe('registry', () => {
     document.body.append(broken, healthy);
     await settle();
 
-    expect(error).toHaveBeenCalledOnce();
-    expect(error).toHaveBeenCalledWith(
+    expect(attempts).toHaveLength(1);
+    expect(broken.__base__?.get('BrokenConstructionErrorEvent')).toBeUndefined();
+    expect(brokenMounts).toBe(0);
+    expect(healthyMounts).toBe(1);
+
+    // Reconciliation retries construction. It must not mount the object whose
+    // derived constructor did not finish.
+    const firstAttempt = attempts[0];
+    broken.remove();
+    await settle();
+    document.body.append(broken);
+    await settle();
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[1]).not.toBe(firstAttempt);
+    expect(broken.__base__?.get('BrokenConstructionErrorEvent')).toBeUndefined();
+    expect(brokenMounts).toBe(0);
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(error).toHaveBeenLastCalledWith(
       '[registry] Failed to mount "BrokenConstructionErrorEvent":',
       failure,
     );
-    expect(events).toHaveLength(1);
-    expect(events[0].target).toBe(broken);
-    expect(events[0].detail).toEqual({
-      stage: 'mount',
-      error: failure,
-      component: 'BrokenConstructionErrorEvent',
-    });
-    expect(healthyMounts).toBe(1);
+    expect(events).toHaveLength(2);
+    expect(events.every((event) => event.target === broken)).toBe(true);
+    expect(events.every((event) => event.detail.stage === 'mount')).toBe(true);
+    expect(events.every((event) => event.detail.error === failure)).toBe(true);
+    expect(events.every((event) => event.detail.component === 'BrokenConstructionErrorEvent')).toBe(
+      true,
+    );
+    error.mockRestore();
+  });
+
+  it('preserves a valid pre-existing instance when its registry mount fails', async () => {
+    const failure = new Error('mount failed');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    class Existing extends Base {
+      static config = { name: 'ExistingMountFailure' };
+
+      $mount(): this {
+        throw failure;
+      }
+    }
+
+    registerComponent(Existing);
+    const el = document.createElement('div');
+    const instance = new Existing(el);
+    el.setAttribute('data-component', 'ExistingMountFailure');
+    document.body.append(el);
+    await settle();
+
+    expect(el.__base__?.get('ExistingMountFailure')).toBe(instance);
+    expect(error).toHaveBeenCalledWith(
+      '[registry] Failed to mount "ExistingMountFailure":',
+      failure,
+    );
     error.mockRestore();
   });
 

--- a/packages/v4/src/registry.ts
+++ b/packages/v4/src/registry.ts
@@ -455,10 +455,20 @@ function mountPair(
   if (!isCurrentPair(el, name, ComponentClass, controller)) {
     return;
   }
+  let instance = el.__base__?.get(name);
   try {
-    const instance = el.__base__?.get(name) ?? new ComponentClass(el);
+    if (!instance) {
+      instance = new ComponentClass(el);
+    }
     instance.$mount();
   } catch (error) {
+    // A derived constructor can throw after Base published `this`. Assignment
+    // above only completes for a fully constructed object, so an empty local
+    // identifies construction failure without disturbing an existing instance
+    // or a valid instance whose mount failed.
+    if (!instance) {
+      el.__base__?.delete(name);
+    }
     console.error(`[registry] Failed to mount "${name}":`, error);
     reportToolkitError('mount', error, name, el);
   }

--- a/packages/v4/src/responsive-options.spec.ts
+++ b/packages/v4/src/responsive-options.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Base, type OptionChange } from './Base.js';
+import { Base, MOUNTED_EVENT, type OptionChange } from './Base.js';
 import { registerComponent, registerManifest } from './registry.js';
 import { BREAKPOINTS, setBreakpoints } from './services/breakpoint.js';
 import { getInstance, resetDom, settle } from './test-utils.js';
@@ -435,6 +435,61 @@ describe('responsive options', () => {
     await settle();
     expect(grid.changes).toHaveLength(1);
     expect(grid.changes[0]).toMatchObject({ value: 3, previousValue: 1 });
+  });
+
+  it('stops option mount work when an initial effect destroys its cycle', async () => {
+    atSmall();
+    const calls: string[] = [];
+    let destroyOnMount = true;
+    let mountedEvents = 0;
+
+    class SelfDestroyingOption extends Base<{
+      $options: { stop: number; later: number };
+    }> {
+      static config = {
+        name: 'SelfDestroyingInitialOption',
+        options: { stop: Number, later: Number },
+      };
+
+      optionStopChanged(): void {
+        calls.push('stop');
+        if (destroyOnMount) {
+          destroyOnMount = false;
+          this.$destroy();
+        }
+      }
+
+      optionLaterChanged(): void {
+        calls.push('later');
+      }
+
+      mounted(): void {
+        calls.push('mounted');
+      }
+    }
+
+    registerComponent(SelfDestroyingOption);
+    const el = document.createElement('div');
+    el.setAttribute('data-component', 'SelfDestroyingInitialOption');
+    el.addEventListener(MOUNTED_EVENT, () => {
+      mountedEvents += 1;
+    });
+    const addedMediaListeners = await countMediaListeners(async () => {
+      document.body.append(el);
+      await settle();
+    });
+    const instance = getInstance<SelfDestroyingOption>(el, 'SelfDestroyingInitialOption');
+
+    try {
+      expect(calls).toEqual(['stop']);
+      expect(instance.$isMounted).toBe(false);
+      expect(mountedEvents).toBe(0);
+      expect(addedMediaListeners).toBe(0);
+    } finally {
+      // If the assertions run against a broken implementation, release the
+      // subscription which escaped the destroyed first cycle.
+      instance.$mount().$destroy();
+    }
   });
 
   it('reports a suffix that names no breakpoint, which is what v3 markup is', async () => {


### PR DESCRIPTION
## Summary

- Remove the partial registry entry when a new component constructor fails, without changing direct construction or valid pre-existing instances.
- Keep recursive async mount cleanups bound to their originating mount cycle.
- Stop option, responsive, hook, and announcement work when the active mount cycle ends or changes.
- Ignore mounted announcements for instances that are no longer mounted.

## Regression coverage

- A derived constructor failure cannot leave an object for later reconciliation to reuse.
- A cycle-1 async cleanup resolved during cycle 2 runs immediately and does not join cycle 2.
- A component that destroys itself in `mounted()` emits no mounted announcement and is not retained by `$watchChildren()`.
- An initial option effect that destroys its cycle skips later work and opens no breakpoint subscription.

## Verification

- `npm exec -w @studiometa/js-toolkit-v4 vitest run src/Base.spec.ts src/registry.spec.ts src/responsive-options.spec.ts` (88 passed)
- `npm run test:v4` (59 files, 746 tests passed)
- `npm run lint:types`
- `npm run lint:static` (passes with two existing `no-useless-spread` warnings)
- `npm run lint:fmt -- --no-error-on-unmatched-pattern`
- `npm run subpaths:check`
- `npm run build`
