### PR TITLE
[Bugfix] Cancel reentrant toggle startup

### DIFF
--- a/packages/v4/src/services/toggle.spec.ts
+++ b/packages/v4/src/services/toggle.spec.ts
@@ -155,4 +155,111 @@ describe('toggle', () => {
     expect(handle.isActive).toBe(false);
     expect(calls).toEqual(['subscribe', 'unsubscribe']);
   });
+
+  it('honours a synchronous stop while the subscription is starting', () => {
+    const activity: boolean[] = [];
+    let cleanups = 0;
+    let handle!: ReturnType<typeof toggle>;
+    handle = toggle(() => {
+      activity.push(handle.isActive);
+      handle.stop();
+      activity.push(handle.isActive);
+      return () => {
+        cleanups += 1;
+      };
+    });
+
+    handle.start();
+    expect(activity).toEqual([true, false]);
+    expect(handle.isActive).toBe(false);
+    expect(cleanups).toBe(1);
+
+    handle.stop();
+    expect(cleanups).toBe(1);
+  });
+
+  it('can restart after a synchronous startup stop', () => {
+    let subscriptions = 0;
+    let cleanups = 0;
+    let stopDuringStart = true;
+    let handle!: ReturnType<typeof toggle>;
+    handle = toggle(() => {
+      subscriptions += 1;
+      if (stopDuringStart) {
+        handle.stop();
+      }
+      return () => {
+        cleanups += 1;
+      };
+    });
+
+    handle.start();
+    expect(handle.isActive).toBe(false);
+    expect([subscriptions, cleanups]).toEqual([1, 1]);
+
+    stopDuringStart = false;
+    handle.start();
+    expect(handle.isActive).toBe(true);
+    expect([subscriptions, cleanups]).toEqual([2, 1]);
+
+    handle.stop();
+    expect(handle.isActive).toBe(false);
+    expect([subscriptions, cleanups]).toEqual([2, 2]);
+  });
+
+  it('keeps nested starts idempotent and repeated startup stops pending once', () => {
+    let subscriptions = 0;
+    let cleanups = 0;
+    let handle!: ReturnType<typeof toggle>;
+    handle = toggle(() => {
+      subscriptions += 1;
+      handle.start();
+      handle.start();
+      handle.stop();
+      handle.stop();
+      handle.start();
+      return () => {
+        cleanups += 1;
+        handle.stop();
+      };
+    });
+
+    handle.start();
+    expect(handle.isActive).toBe(false);
+    expect([subscriptions, cleanups]).toEqual([1, 1]);
+
+    handle.start();
+    expect(handle.isActive).toBe(false);
+    expect([subscriptions, cleanups]).toEqual([2, 2]);
+  });
+
+  it('resets the starting state when subscribe throws', () => {
+    let shouldThrow = true;
+    let subscriptions = 0;
+    let cleanups = 0;
+    let handle!: ReturnType<typeof toggle>;
+    handle = toggle(() => {
+      subscriptions += 1;
+      expect(handle.isActive).toBe(true);
+      if (shouldThrow) {
+        throw new Error('subscribe failed');
+      }
+      return () => {
+        cleanups += 1;
+      };
+    });
+
+    expect(() => handle.start()).toThrow('subscribe failed');
+    expect(handle.isActive).toBe(false);
+    handle.stop();
+
+    shouldThrow = false;
+    handle.start();
+    expect(handle.isActive).toBe(true);
+    expect(subscriptions).toBe(2);
+
+    handle.stop();
+    expect(handle.isActive).toBe(false);
+    expect(cleanups).toBe(1);
+  });
 });

--- a/packages/v4/src/services/toggle.ts
+++ b/packages/v4/src/services/toggle.ts
@@ -46,17 +46,40 @@ export interface Toggle {
  */
 export function toggle(subscribe: () => Unsubscribe): Toggle {
   let unsubscribe: Unsubscribe | null = null;
+  let isStarting = false;
+  let stopPending = false;
 
   return {
     get isActive() {
-      return unsubscribe !== null;
+      return unsubscribe !== null || (isStarting && !stopPending);
     },
     start: () => {
-      unsubscribe ??= subscribe();
+      if (unsubscribe !== null || isStarting) {
+        return;
+      }
+
+      isStarting = true;
+      try {
+        const cleanup = subscribe();
+        if (stopPending) {
+          cleanup();
+        } else {
+          unsubscribe = cleanup;
+        }
+      } finally {
+        isStarting = false;
+        stopPending = false;
+      }
     },
     stop: () => {
-      unsubscribe?.();
+      if (isStarting) {
+        stopPending = true;
+        return;
+      }
+
+      const cleanup = unsubscribe;
       unsubscribe = null;
+      cleanup?.();
     },
   };
 }


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Track startup explicitly so a synchronous `stop()` request made inside `subscribe()` cancels the returned subscription at once. Startup counts as active until `stop()` is requested. Nested starts remain idempotent, repeated stops clean up once, failed subscriptions reset the handle, and stopped handles can restart.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog.

### Verification

- `npm run test:v4 -- src/services/toggle.spec.ts`
- `npm run test:v4`
- `npm run lint:types`
- `npm run lint:static`
- `npm run lint:fmt`
- `npm run subpaths:check`
- `npm run build`