### PR TITLE
fix(v4): reject invalid mount strategies

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -286,9 +286,11 @@ A suffix naming no configured breakpoint is ignored and warned about once, inclu
 | `in-view[:<rootMargin>]` | it intersects the viewport       | yes        |
 | `idle`                   | the main thread goes idle        | no         |
 | `interaction`            | the user first aims at it        | no         |
-| `media:<query>`          | the query matches                | yes        |
+| `media:<query>`          | the non-empty query matches      | yes        |
 
-A component declares its default with `config.mountStrategy`; any element overrides it with `data-mount`. The optional `visible:` and `in-view:` suffix is passed verbatim as `IntersectionObserverInit.rootMargin`, so `visible:200px`, `in-view:200px 0px` and `in-view:-10% 0px` use the same strategy path as their bare forms. An empty suffix is the bare strategy. No threshold, root element, JSON options or second attribute is part of this grammar.
+A component declares its default with `config.mountStrategy`; any element overrides it with `data-mount`. The accepted values are exactly `eager`, `visible`, `visible:`, `visible:<rootMargin>`, `in-view`, `in-view:`, `in-view:<rootMargin>`, `idle`, `interaction` and `media:<non-empty query>`. A viewport suffix is passed verbatim as `IntersectionObserverInit.rootMargin`, so `visible:200px`, `in-view:200px 0px` and `in-view:-10% 0px` use the same strategy path as their bare forms; the empty suffix stays compatible with the bare strategy. No threshold, root element, JSON options or second attribute is part of this grammar.
+
+An unknown value, an empty media query or a `rootMargin` rejected by the browser leaves the component unmounted instead of falling back to `eager`. The console diagnostic remains, and the registry dispatches one non-cancelable `js-toolkit:error` from the component element with the `mount` stage, component name and original error. The inert controller remains current for an unchanged invalid declaration, so reconciliation does not retry or report it again; changing the attribute replaces that controller and applies the corrected strategy normally. A failed strategy is isolated to its element/component pair and cannot stop the rest of a registry reconciliation.
 
 The issue's open questions, answered:
 

--- a/packages/v4/src/autoload.spec.ts
+++ b/packages/v4/src/autoload.spec.ts
@@ -228,6 +228,28 @@ describe('the strategy that triggers the import', () => {
     expect(instanceOf(el, name)?.$isMounted).toBe(true);
   });
 
+  it('replaces an inert invalid trigger when data-mount is corrected', async () => {
+    const { name, load, importCount } = defineLazy();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = render(name, { 'data-mount': 'eagre' });
+    registerManifest({ [name]: load });
+    await observed();
+
+    expect(importCount()).toBe(0);
+    expect(el.__base__?.get(name)).toBeUndefined();
+    expect(error).toHaveBeenCalledOnce();
+
+    el.setAttribute('data-mount', 'eagre');
+    await observed();
+    expect(error).toHaveBeenCalledOnce();
+
+    el.setAttribute('data-mount', 'eager');
+    await settle();
+    expect(importCount()).toBe(1);
+    expect(instanceOf(el, name)?.$isMounted).toBe(true);
+    error.mockRestore();
+  });
+
   it('hands a parameterized reversible override to the registry after the import', async () => {
     const { name, load, importCount } = defineLazy();
     const el = render(name, { 'data-mount': 'in-view:200px 0px' }, OFFSCREEN);

--- a/packages/v4/src/mount-strategies.spec.ts
+++ b/packages/v4/src/mount-strategies.spec.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Base, type BaseConfig } from './Base.js';
+import { JS_TOOLKIT_ERROR_EVENT, type ToolkitErrorDetail } from './errors.js';
 import { registerComponent } from './registry.js';
 import { resetDom, settle } from './test-utils.js';
 
@@ -60,7 +61,10 @@ async function observed(): Promise<void> {
   }
 }
 
-afterEach(resetDom);
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await resetDom();
+});
 
 describe('eager (default)', () => {
   it('mounts as soon as the element is in the DOM', async () => {
@@ -269,6 +273,72 @@ describe('dynamic data-mount', () => {
     el.setAttribute('data-mount', 'eager');
     await settle();
     expect(instanceOf(el, name)?.$isMounted).toBe(true);
+  });
+});
+
+describe('invalid data-mount', () => {
+  it.each(['eagre', 'media:', 'visible:not-a-root-margin'])(
+    'keeps %j inert, reports it once, and accepts a later correction',
+    async (strategy) => {
+      const { name } = defineTracked();
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const events: CustomEvent<ToolkitErrorDetail>[] = [];
+      const el = document.createElement('div');
+      el.setAttribute('data-component', name);
+      el.setAttribute('data-mount', strategy);
+      el.addEventListener(JS_TOOLKIT_ERROR_EVENT, (event) => {
+        event.preventDefault();
+        events.push(event as CustomEvent<ToolkitErrorDetail>);
+      });
+      document.body.append(el);
+
+      await observed();
+
+      expect(el.__base__?.get(name)).toBeUndefined();
+      expect(error).toHaveBeenCalledOnce();
+      const failure = error.mock.calls[0]?.[1];
+      expect(failure).toBeInstanceOf(Error);
+      expect(error).toHaveBeenCalledWith(
+        `[mount-strategy] Failed to apply "${strategy}":`,
+        failure,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        target: el,
+        cancelable: false,
+        defaultPrevented: false,
+      });
+      expect(events[0].detail).toEqual({ stage: 'mount', error: failure, component: name });
+
+      // A same-value mutation reconciles the element, but the inert controller
+      // remains current and must not report or schedule itself again.
+      el.setAttribute('data-mount', strategy);
+      await observed();
+      expect(error).toHaveBeenCalledOnce();
+      expect(events).toHaveLength(1);
+
+      el.setAttribute('data-mount', 'eager');
+      await settle();
+      expect(instanceOf(el, name)?.$isMounted).toBe(true);
+    },
+  );
+
+  it('does not stop a valid sibling in the same reconciliation batch', async () => {
+    const broken = defineTracked();
+    const healthy = defineTracked();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const brokenEl = document.createElement('div');
+    brokenEl.setAttribute('data-component', broken.name);
+    brokenEl.setAttribute('data-mount', 'in-view:not-a-root-margin');
+    const healthyEl = document.createElement('div');
+    healthyEl.setAttribute('data-component', healthy.name);
+    document.body.append(brokenEl, healthyEl);
+
+    await observed();
+
+    expect(brokenEl.__base__?.get(broken.name)).toBeUndefined();
+    expect(instanceOf(healthyEl, healthy.name)?.$isMounted).toBe(true);
   });
 });
 

--- a/packages/v4/src/mount-strategies.ts
+++ b/packages/v4/src/mount-strategies.ts
@@ -52,11 +52,21 @@ export interface MountStrategyHooks {
   destroy(): void;
 }
 
-export interface AppliedMountStrategy {
-  dispose(): void;
-  /** Work which mounts eagerly; conditional strategies never expose one. */
-  eagerWork?: Promise<unknown>;
-}
+export type AppliedMountStrategy =
+  | {
+      readonly valid: true;
+      dispose(): void;
+      /** Work which mounts eagerly; conditional strategies never expose one. */
+      eagerWork?: Promise<unknown>;
+      error?: never;
+    }
+  | {
+      readonly valid: false;
+      dispose(): void;
+      eagerWork?: never;
+      /** The same error reported to the console. */
+      error: unknown;
+    };
 
 interface ViewportMountStrategy {
   isReversible: boolean;
@@ -64,7 +74,7 @@ interface ViewportMountStrategy {
 }
 
 /** Parse the two viewport strategy forms at their shared execution seam. */
-function parseViewportMountStrategy(strategy: MountStrategy): ViewportMountStrategy | undefined {
+function parseViewportMountStrategy(strategy: string): ViewportMountStrategy | undefined {
   const separator = strategy.indexOf(':');
   const name = separator < 0 ? strategy : strategy.slice(0, separator);
   if (name !== 'visible' && name !== 'in-view') {
@@ -72,6 +82,12 @@ function parseViewportMountStrategy(strategy: MountStrategy): ViewportMountStrat
   }
   const rootMargin = separator < 0 ? undefined : strategy.slice(separator + 1) || undefined;
   return { isReversible: name === 'in-view', rootMargin };
+}
+
+/** Keep an invalid strategy inert while exposing the exact reported failure. */
+function rejectMountStrategy(strategy: string, error: unknown): AppliedMountStrategy {
+  console.error(`[mount-strategy] Failed to apply "${strategy}":`, error);
+  return { valid: false, dispose() {}, error };
 }
 
 /**
@@ -84,7 +100,7 @@ function parseViewportMountStrategy(strategy: MountStrategy): ViewportMountStrat
  */
 export function applyMountStrategy(
   el: HTMLElement,
-  strategy: MountStrategy,
+  strategy: string,
   { mount, destroy }: MountStrategyHooks,
 ): AppliedMountStrategy {
   const viewport = parseViewportMountStrategy(strategy);
@@ -109,11 +125,10 @@ export function applyMountStrategy(
     } catch (error) {
       // The browser owns the rootMargin grammar. Report author errors without
       // changing the requested mount policy or stopping registry reconciliation.
-      console.error(`[mount-strategy] Failed to apply "${strategy}":`, error);
-      return { dispose() {} };
+      return rejectMountStrategy(strategy, error);
     }
     observer.observe(el);
-    return { dispose: () => observer.disconnect() };
+    return { valid: true, dispose: () => observer.disconnect() };
   }
 
   if (strategy === 'idle') {
@@ -121,10 +136,10 @@ export function applyMountStrategy(
     // lane is already budgeted, so it is a fair fallback.
     if (typeof requestIdleCallback !== 'function') {
       const task = defaultScheduler.background(mount);
-      return { dispose: () => task.cancel() };
+      return { valid: true, dispose: () => task.cancel() };
     }
     const handle = requestIdleCallback(() => mount());
-    return { dispose: () => cancelIdleCallback(handle) };
+    return { valid: true, dispose: () => cancelIdleCallback(handle) };
   }
 
   if (strategy === 'interaction') {
@@ -140,19 +155,31 @@ export function applyMountStrategy(
     for (const type of INTENT_EVENTS) {
       el.addEventListener(type, onIntent, { once: true });
     }
-    return { dispose: teardown };
+    return { valid: true, dispose: teardown };
   }
 
   if (strategy.startsWith('media:')) {
-    const query = matchMedia(strategy.slice('media:'.length));
+    const source = strategy.slice('media:'.length);
+    if (source.trim().length === 0) {
+      return rejectMountStrategy(
+        strategy,
+        new TypeError('The media mount strategy requires a non-empty query.'),
+      );
+    }
+    const query = matchMedia(source);
     const sync = () => (query.matches ? mount() : destroy());
     query.addEventListener('change', sync);
     sync();
-    return { dispose: () => query.removeEventListener('change', sync) };
+    return {
+      valid: true,
+      dispose: () => query.removeEventListener('change', sync),
+    };
   }
 
-  // `eager`, and anything unrecognised: mount as soon as the scheduler's
-  // background lane gets to it.
+  if (strategy !== 'eager') {
+    return rejectMountStrategy(strategy, new TypeError(`Unknown mount strategy "${strategy}".`));
+  }
+
   const task = defaultScheduler.background(mount);
-  return { dispose: () => task.cancel(), eagerWork: task.promise };
+  return { valid: true, dispose: () => task.cancel(), eagerWork: task.promise };
 }

--- a/packages/v4/src/mount-strategies.unit.spec.ts
+++ b/packages/v4/src/mount-strategies.unit.spec.ts
@@ -55,6 +55,7 @@ describe('applyMountStrategy viewport parameters', () => {
   afterEach(() => {
     globalThis.IntersectionObserver = NativeIntersectionObserver;
     document.body.innerHTML = '';
+    vi.restoreAllMocks();
   });
 
   it('passes the visible suffix as the exact root margin and remains one-shot', () => {
@@ -131,7 +132,28 @@ describe('applyMountStrategy viewport parameters', () => {
     );
     expect(hooks.mount).not.toHaveBeenCalled();
     expect(hooks.destroy).not.toHaveBeenCalled();
+    expect(applied).toMatchObject({ valid: false, error: failure });
     expect(() => applied.dispose()).not.toThrow();
     error.mockRestore();
   });
+
+  it.each(['eagre', 'media:', 'media:   '])(
+    'rejects invalid strategy %j without mounting it',
+    (strategy) => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const hooks = { mount: vi.fn(), destroy: vi.fn() };
+
+      const applied = applyMountStrategy(document.createElement('div'), strategy, hooks);
+
+      expect(applied.valid).toBe(false);
+      expect(applied.error).toBeInstanceOf(TypeError);
+      expect(error).toHaveBeenCalledWith(
+        `[mount-strategy] Failed to apply "${strategy}":`,
+        applied.error,
+      );
+      expect(hooks.mount).not.toHaveBeenCalled();
+      expect(hooks.destroy).not.toHaveBeenCalled();
+      expect(() => applied.dispose()).not.toThrow();
+    },
+  );
 });

--- a/packages/v4/src/registry.ts
+++ b/packages/v4/src/registry.ts
@@ -38,7 +38,7 @@ observeResponsiveAttribute(COMPONENT_ATTRIBUTE);
 interface PairController {
   active: boolean;
   dispose(): void;
-  strategy: MountStrategy;
+  strategy: string;
 }
 
 /**
@@ -62,6 +62,7 @@ export type ComponentManifest = Record<string, ComponentImporter | ComponentMani
 
 interface LoadController {
   dispose(): void;
+  strategy: string;
 }
 
 /**
@@ -418,12 +419,8 @@ function optionAttributes(ComponentClass: BaseConstructor): string[] {
  * made every subclass of a strategy-declaring component fall back to `eager`
  * — silently, since it still worked, it just mounted everywhere.
  */
-function resolveStrategy(el: Element, ComponentClass: BaseConstructor): MountStrategy {
-  return (
-    (el.getAttribute(MOUNT_ATTRIBUTE) as MountStrategy | null) ??
-    resolveConfig(ComponentClass).mountStrategy ??
-    'eager'
-  );
+function resolveStrategy(el: Element, ComponentClass: BaseConstructor): string {
+  return el.getAttribute(MOUNT_ATTRIBUTE) ?? resolveConfig(ComponentClass).mountStrategy ?? 'eager';
 }
 
 /**
@@ -517,6 +514,9 @@ function schedule(el: HTMLElement, name: string, ComponentClass: BaseConstructor
     destroy: () => destroyPair(el, name, ComponentClass, controller),
   });
   controller.dispose = applied.dispose;
+  if (!applied.valid) {
+    reportToolkitError('mount', applied.error, name, el);
+  }
   trackDOMLifecycleWork(applied.eagerWork);
 }
 
@@ -540,7 +540,7 @@ function disposeLoader(el: Element, name: string): void {
  * satisfied it, so the new controller mounts without waiting for a second
  * visibility, idle or interaction trigger.
  */
-function completeOneShotLoad(el: HTMLElement, name: string, strategy: MountStrategy): void {
+function completeOneShotLoad(el: HTMLElement, name: string, strategy: string): void {
   if (
     strategy !== 'visible' &&
     !strategy.startsWith('visible:') &&
@@ -572,18 +572,26 @@ function completeOneShotLoad(el: HTMLElement, name: string, strategy: MountStrat
  */
 function scheduleLoad(el: HTMLElement, name: string): void {
   const entry = manifest.get(name);
-  let pending = loaders.get(el);
-  if (!entry || pending?.has(name)) {
+  if (!entry) {
     return;
+  }
+
+  const strategy = el.getAttribute(MOUNT_ATTRIBUTE) ?? entry.mountStrategy ?? 'eager';
+  let pending = loaders.get(el);
+  const current = pending?.get(name);
+  if (current?.strategy === strategy) {
+    return;
+  }
+  if (current) {
+    disposeLoader(el, name);
+    pending = loaders.get(el);
   }
   if (!pending) {
     pending = new Map();
     loaders.set(el, pending);
   }
 
-  const strategy =
-    (el.getAttribute(MOUNT_ATTRIBUTE) as MountStrategy | null) ?? entry.mountStrategy ?? 'eager';
-  const controller: LoadController = { dispose() {} };
+  const controller: LoadController = { dispose() {}, strategy };
   pending.set(name, controller);
 
   let fired = false;
@@ -609,6 +617,9 @@ function scheduleLoad(el: HTMLElement, name: string): void {
     destroy() {},
   });
   controller.dispose = applied.dispose;
+  if (!applied.valid) {
+    reportToolkitError('mount', applied.error, name, el);
+  }
   // `media:` evaluates synchronously, so the trigger may already have fired
   // against the no-op teardown installed above.
   if (fired) {


### PR DESCRIPTION
## Summary

- accept only the documented mount strategy grammar and keep invalid values inert
- report each invalid registry application through the non-cancelable `js-toolkit:error` mount contract while preserving console diagnostics
- retain inert loaded and lazy controllers so unchanged values do not retry, then replace them after an attribute correction
- isolate browser-rejected viewport margins from sibling reconciliation
- document the invalid mount-strategy policy in `packages/v4/DESIGN.md`

## Validation

- focused mount, registry, and autoload browser tests: 69 passed
- `npm run test:v4`: 750 passed
- `npm run test:runtime -w @studiometa/js-toolkit-v4`: 4 passed
- `npm run lint`
- `npm run build`
- `npm run check:constant-subpaths -w @studiometa/js-toolkit-v4`
