### PR TITLE
perf: shard benchmarks across two serial CI jobs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,8 +15,12 @@ permissions:
 
 jobs:
   benchmarks:
-    name: Run benchmarks
+    name: Run benchmarks (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/2', '2/2']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -29,4 +33,4 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: cd packages/js-toolkit && npm exec vitest bench -- --config vitest.bench.config.ts --run
+          run: cd packages/js-toolkit && npm exec vitest bench -- --config vitest.bench.config.ts --run --shard=${{ matrix.shard }}

--- a/packages/js-toolkit/vitest.bench.config.ts
+++ b/packages/js-toolkit/vitest.bench.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     fileParallelism: true,
-    maxWorkers: 4,
+    maxWorkers: 2,
     include: ['src/__benchmarks__/**/*.bench.ts'],
     benchmark: {
       include: ['src/__benchmarks__/**/*.bench.ts'],

--- a/packages/js-toolkit/vitest.bench.config.ts
+++ b/packages/js-toolkit/vitest.bench.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
+    fileParallelism: true,
+    maxWorkers: 4,
     include: ['src/__benchmarks__/**/*.bench.ts'],
     benchmark: {
       include: ['src/__benchmarks__/**/*.bench.ts'],

--- a/packages/js-toolkit/vitest.bench.config.ts
+++ b/packages/js-toolkit/vitest.bench.config.ts
@@ -15,8 +15,6 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
-    fileParallelism: true,
-    maxWorkers: 2,
     include: ['src/__benchmarks__/**/*.bench.ts'],
     benchmark: {
       include: ['src/__benchmarks__/**/*.bench.ts'],


### PR DESCRIPTION
## Summary

Run the CodSpeed benchmark suite as two CI shards (`1/2` and `2/2`). Each Vitest process remains serial, while the two GitHub Actions matrix jobs run independently.

## Why

The prior in-process file-worker experiment reduced local wall time, but it made CodSpeed results unsafe. The two-worker CI run reported a false 22.36% performance improvement for 2 of 141 benchmarks, warned that different runtime environments were compared, and used skipped baseline results for all 141 benchmarks. Serial processes avoid benchmark contention while CI-level sharding can still reduce the critical path.

## Validation

- `actionlint .github/workflows/benchmarks.yml`
- `npm run lint`
- `git diff --check`
- Fast shard selection check with a non-matching benchmark filter: 5 files in shard `1/2`, 5 files in shard `2/2`, 10 files in the union, and 0 overlapping files

## Merge gate

Do not merge until all of these conditions are met:

- Both shard jobs are green.
- The combined benchmark count is exactly 141, with no missing or duplicate benchmarks.
- CodSpeed groups and compares the shard results correctly, with no runtime-environment warning or skipped-baseline issue caused by sharding.
- The benchmark workflow critical-path duration improves compared with the serial single-job baseline.
