### PR TITLE
feat(v4): port the next batch of utils from v3

### DIFF
--- a/packages/v4/migration/Accordion/AccordionItem.ts
+++ b/packages/v4/migration/Accordion/AccordionItem.ts
@@ -1,5 +1,5 @@
 import { Base } from '../../src/index.js';
-import { transition, type ClassesOrStyles } from '../utils/transition.js';
+import { transition, type ClassesOrStyles } from '../../src/utils/transition.js';
 import { uid } from '../utils/uid.js';
 
 export type AccordionItemStates = Partial<Record<'open' | 'active' | 'closed', ClassesOrStyles>>;

--- a/packages/v4/migration/Dialog/Dialog.ts
+++ b/packages/v4/migration/Dialog/Dialog.ts
@@ -1,7 +1,7 @@
 import { Base, type ChildrenCollection } from '../../src/index.js';
 import { Transition, type Transitionable } from '../Transition/Transition.js';
 import { ViewTransition } from '../Transition/ViewTransition.js';
-import { saveActiveElement, trapFocus, untrapFocus } from '../utils/focus.js';
+import { saveActiveElement, trapFocus, untrapFocus } from '../../src/utils/focus.js';
 
 export interface DialogProps {
   $el: HTMLDialogElement;

--- a/packages/v4/migration/Slider/SliderDots.ts
+++ b/packages/v4/migration/Slider/SliderDots.ts
@@ -4,7 +4,7 @@ import {
   leaveTransition,
   TRANSITION_OPTIONS,
   type TransitionOptions,
-} from '../utils/transition.js';
+} from '../../src/utils/transition.js';
 import { SliderContext } from './Slider.js';
 
 export interface SliderDotsProps {

--- a/packages/v4/migration/Transition/Transition.ts
+++ b/packages/v4/migration/Transition/Transition.ts
@@ -4,7 +4,7 @@ import {
   leaveTransition,
   TRANSITION_OPTIONS,
   type TransitionOptions,
-} from '../utils/transition.js';
+} from '../../src/utils/transition.js';
 
 export interface TransitionProps {
   $options: TransitionOptions;

--- a/packages/v4/migration/index.ts
+++ b/packages/v4/migration/index.ts
@@ -12,7 +12,6 @@ export * from './Track/index.js';
 export * from './Transition/index.js';
 export * from './utils/deepmerge.js';
 export * from './utils/easings.js';
-export * from './utils/focus.js';
 export * from './utils/inView.js';
 export * from './utils/keyframes.js';
 export * from '../src/utils/maths.js';

--- a/packages/v4/migration/index.ts
+++ b/packages/v4/migration/index.ts
@@ -17,5 +17,4 @@ export * from './utils/inView.js';
 export * from './utils/keyframes.js';
 export * from '../src/utils/maths.js';
 export * from './utils/throttle.js';
-export * from './utils/transition.js';
 export * from './utils/uid.js';

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -516,6 +516,18 @@
       "types": "./dist/subpaths/utils/withTrailingSlash.d.ts",
       "import": "./dist/subpaths/utils/withTrailingSlash.js"
     },
+    "./utils/debounce": {
+      "types": "./dist/subpaths/utils/debounce.d.ts",
+      "import": "./dist/subpaths/utils/debounce.js"
+    },
+    "./utils/throttle": {
+      "types": "./dist/subpaths/utils/throttle.d.ts",
+      "import": "./dist/subpaths/utils/throttle.js"
+    },
+    "./utils/wait": {
+      "types": "./dist/subpaths/utils/wait.d.ts",
+      "import": "./dist/subpaths/utils/wait.js"
+    },
     "./utils/matrix": {
       "types": "./dist/subpaths/utils/matrix.d.ts",
       "import": "./dist/subpaths/utils/matrix.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -415,6 +415,18 @@
     "./utils/pascalCase": {
       "types": "./dist/subpaths/utils/pascalCase.d.ts",
       "import": "./dist/subpaths/utils/pascalCase.js"
+    },
+    "./utils/matrix": {
+      "types": "./dist/subpaths/utils/matrix.d.ts",
+      "import": "./dist/subpaths/utils/matrix.js"
+    },
+    "./utils/transform": {
+      "types": "./dist/subpaths/utils/transform.d.ts",
+      "import": "./dist/subpaths/utils/transform.js"
+    },
+    "./utils/TRANSFORM_PROPS": {
+      "types": "./dist/subpaths/utils/TRANSFORM_PROPS.d.ts",
+      "import": "./dist/subpaths/utils/TRANSFORM_PROPS.js"
     }
   },
   "scripts": {

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -464,6 +464,46 @@
       "types": "./dist/subpaths/utils/upperCase.d.ts",
       "import": "./dist/subpaths/utils/upperCase.js"
     },
+    "./utils/withLeadingCharacters": {
+      "types": "./dist/subpaths/utils/withLeadingCharacters.d.ts",
+      "import": "./dist/subpaths/utils/withLeadingCharacters.js"
+    },
+    "./utils/withLeadingSlash": {
+      "types": "./dist/subpaths/utils/withLeadingSlash.d.ts",
+      "import": "./dist/subpaths/utils/withLeadingSlash.js"
+    },
+    "./utils/withoutLeadingCharacters": {
+      "types": "./dist/subpaths/utils/withoutLeadingCharacters.d.ts",
+      "import": "./dist/subpaths/utils/withoutLeadingCharacters.js"
+    },
+    "./utils/withoutLeadingCharactersRecursive": {
+      "types": "./dist/subpaths/utils/withoutLeadingCharactersRecursive.d.ts",
+      "import": "./dist/subpaths/utils/withoutLeadingCharactersRecursive.js"
+    },
+    "./utils/withoutLeadingSlash": {
+      "types": "./dist/subpaths/utils/withoutLeadingSlash.d.ts",
+      "import": "./dist/subpaths/utils/withoutLeadingSlash.js"
+    },
+    "./utils/withoutTrailingCharacters": {
+      "types": "./dist/subpaths/utils/withoutTrailingCharacters.d.ts",
+      "import": "./dist/subpaths/utils/withoutTrailingCharacters.js"
+    },
+    "./utils/withoutTrailingCharactersRecursive": {
+      "types": "./dist/subpaths/utils/withoutTrailingCharactersRecursive.d.ts",
+      "import": "./dist/subpaths/utils/withoutTrailingCharactersRecursive.js"
+    },
+    "./utils/withoutTrailingSlash": {
+      "types": "./dist/subpaths/utils/withoutTrailingSlash.d.ts",
+      "import": "./dist/subpaths/utils/withoutTrailingSlash.js"
+    },
+    "./utils/withTrailingCharacters": {
+      "types": "./dist/subpaths/utils/withTrailingCharacters.d.ts",
+      "import": "./dist/subpaths/utils/withTrailingCharacters.js"
+    },
+    "./utils/withTrailingSlash": {
+      "types": "./dist/subpaths/utils/withTrailingSlash.d.ts",
+      "import": "./dist/subpaths/utils/withTrailingSlash.js"
+    },
     "./utils/matrix": {
       "types": "./dist/subpaths/utils/matrix.d.ts",
       "import": "./dist/subpaths/utils/matrix.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -436,13 +436,33 @@
       "types": "./dist/subpaths/utils/smoothTo.d.ts",
       "import": "./dist/subpaths/utils/smoothTo.js"
     },
+    "./utils/camelCase": {
+      "types": "./dist/subpaths/utils/camelCase.d.ts",
+      "import": "./dist/subpaths/utils/camelCase.js"
+    },
+    "./utils/capitalize": {
+      "types": "./dist/subpaths/utils/capitalize.d.ts",
+      "import": "./dist/subpaths/utils/capitalize.js"
+    },
     "./utils/kebabCase": {
       "types": "./dist/subpaths/utils/kebabCase.d.ts",
       "import": "./dist/subpaths/utils/kebabCase.js"
     },
+    "./utils/lowerCase": {
+      "types": "./dist/subpaths/utils/lowerCase.d.ts",
+      "import": "./dist/subpaths/utils/lowerCase.js"
+    },
     "./utils/pascalCase": {
       "types": "./dist/subpaths/utils/pascalCase.d.ts",
       "import": "./dist/subpaths/utils/pascalCase.js"
+    },
+    "./utils/snakeCase": {
+      "types": "./dist/subpaths/utils/snakeCase.d.ts",
+      "import": "./dist/subpaths/utils/snakeCase.js"
+    },
+    "./utils/upperCase": {
+      "types": "./dist/subpaths/utils/upperCase.d.ts",
+      "import": "./dist/subpaths/utils/upperCase.js"
     },
     "./utils/matrix": {
       "types": "./dist/subpaths/utils/matrix.d.ts",

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -560,6 +560,18 @@
       "types": "./dist/subpaths/utils/memo.d.ts",
       "import": "./dist/subpaths/utils/memo.js"
     },
+    "./utils/random": {
+      "types": "./dist/subpaths/utils/random.d.ts",
+      "import": "./dist/subpaths/utils/random.js"
+    },
+    "./utils/randomInt": {
+      "types": "./dist/subpaths/utils/randomInt.d.ts",
+      "import": "./dist/subpaths/utils/randomInt.js"
+    },
+    "./utils/randomItem": {
+      "types": "./dist/subpaths/utils/randomItem.d.ts",
+      "import": "./dist/subpaths/utils/randomItem.js"
+    },
     "./utils/selectorFor": {
       "types": "./dist/subpaths/utils/selectorFor.d.ts",
       "import": "./dist/subpaths/utils/selectorFor.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -336,6 +336,34 @@
       "types": "./dist/subpaths/viewTransition.d.ts",
       "import": "./dist/subpaths/viewTransition.js"
     },
+    "./utils/isBoolean": {
+      "types": "./dist/subpaths/utils/isBoolean.d.ts",
+      "import": "./dist/subpaths/utils/isBoolean.js"
+    },
+    "./utils/isDefined": {
+      "types": "./dist/subpaths/utils/isDefined.d.ts",
+      "import": "./dist/subpaths/utils/isDefined.js"
+    },
+    "./utils/isFunction": {
+      "types": "./dist/subpaths/utils/isFunction.d.ts",
+      "import": "./dist/subpaths/utils/isFunction.js"
+    },
+    "./utils/isNull": {
+      "types": "./dist/subpaths/utils/isNull.d.ts",
+      "import": "./dist/subpaths/utils/isNull.js"
+    },
+    "./utils/isNumber": {
+      "types": "./dist/subpaths/utils/isNumber.d.ts",
+      "import": "./dist/subpaths/utils/isNumber.js"
+    },
+    "./utils/isObject": {
+      "types": "./dist/subpaths/utils/isObject.d.ts",
+      "import": "./dist/subpaths/utils/isObject.js"
+    },
+    "./utils/isString": {
+      "types": "./dist/subpaths/utils/isString.d.ts",
+      "import": "./dist/subpaths/utils/isString.js"
+    },
     "./utils/clamp": {
       "types": "./dist/subpaths/utils/clamp.d.ts",
       "import": "./dist/subpaths/utils/clamp.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -436,6 +436,18 @@
       "types": "./dist/subpaths/utils/easeOutSine.d.ts",
       "import": "./dist/subpaths/utils/easeOutSine.js"
     },
+    "./utils/saveActiveElement": {
+      "types": "./dist/subpaths/utils/saveActiveElement.d.ts",
+      "import": "./dist/subpaths/utils/saveActiveElement.js"
+    },
+    "./utils/trapFocus": {
+      "types": "./dist/subpaths/utils/trapFocus.d.ts",
+      "import": "./dist/subpaths/utils/trapFocus.js"
+    },
+    "./utils/untrapFocus": {
+      "types": "./dist/subpaths/utils/untrapFocus.d.ts",
+      "import": "./dist/subpaths/utils/untrapFocus.js"
+    },
     "./utils/historyPush": {
       "types": "./dist/subpaths/utils/historyPush.d.ts",
       "import": "./dist/subpaths/utils/historyPush.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -660,6 +660,26 @@
       "types": "./dist/subpaths/utils/wait.d.ts",
       "import": "./dist/subpaths/utils/wait.js"
     },
+    "./utils/enterTransition": {
+      "types": "./dist/subpaths/utils/enterTransition.d.ts",
+      "import": "./dist/subpaths/utils/enterTransition.js"
+    },
+    "./utils/leaveTransition": {
+      "types": "./dist/subpaths/utils/leaveTransition.d.ts",
+      "import": "./dist/subpaths/utils/leaveTransition.js"
+    },
+    "./utils/setClassesOrStyles": {
+      "types": "./dist/subpaths/utils/setClassesOrStyles.d.ts",
+      "import": "./dist/subpaths/utils/setClassesOrStyles.js"
+    },
+    "./utils/transition": {
+      "types": "./dist/subpaths/utils/transition.d.ts",
+      "import": "./dist/subpaths/utils/transition.js"
+    },
+    "./utils/TRANSITION_OPTIONS": {
+      "types": "./dist/subpaths/utils/TRANSITION_OPTIONS.d.ts",
+      "import": "./dist/subpaths/utils/TRANSITION_OPTIONS.js"
+    },
     "./utils/matrix": {
       "types": "./dist/subpaths/utils/matrix.d.ts",
       "import": "./dist/subpaths/utils/matrix.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -392,6 +392,10 @@
       "types": "./dist/subpaths/utils/clampDampFactor.d.ts",
       "import": "./dist/subpaths/utils/clampDampFactor.js"
     },
+    "./utils/createRange": {
+      "types": "./dist/subpaths/utils/createRange.d.ts",
+      "import": "./dist/subpaths/utils/createRange.js"
+    },
     "./utils/damp": {
       "types": "./dist/subpaths/utils/damp.d.ts",
       "import": "./dist/subpaths/utils/damp.js"
@@ -403,6 +407,10 @@
     "./utils/DEFAULT_DAMP_FACTOR": {
       "types": "./dist/subpaths/utils/DEFAULT_DAMP_FACTOR.d.ts",
       "import": "./dist/subpaths/utils/DEFAULT_DAMP_FACTOR.js"
+    },
+    "./utils/fold": {
+      "types": "./dist/subpaths/utils/fold.d.ts",
+      "import": "./dist/subpaths/utils/fold.js"
     },
     "./utils/inertiaDecay": {
       "types": "./dist/subpaths/utils/inertiaDecay.d.ts",
@@ -436,9 +444,21 @@
       "types": "./dist/subpaths/utils/MAX_SPRING_RATIO.d.ts",
       "import": "./dist/subpaths/utils/MAX_SPRING_RATIO.js"
     },
+    "./utils/mean": {
+      "types": "./dist/subpaths/utils/mean.d.ts",
+      "import": "./dist/subpaths/utils/mean.js"
+    },
+    "./utils/round": {
+      "types": "./dist/subpaths/utils/round.d.ts",
+      "import": "./dist/subpaths/utils/round.js"
+    },
     "./utils/spring": {
       "types": "./dist/subpaths/utils/spring.d.ts",
       "import": "./dist/subpaths/utils/spring.js"
+    },
+    "./utils/wrap": {
+      "types": "./dist/subpaths/utils/wrap.d.ts",
+      "import": "./dist/subpaths/utils/wrap.js"
     },
     "./utils/memo": {
       "types": "./dist/subpaths/utils/memo.d.ts",

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -336,6 +336,18 @@
       "types": "./dist/subpaths/viewTransition.d.ts",
       "import": "./dist/subpaths/viewTransition.js"
     },
+    "./utils/historyPush": {
+      "types": "./dist/subpaths/utils/historyPush.d.ts",
+      "import": "./dist/subpaths/utils/historyPush.js"
+    },
+    "./utils/historyReplace": {
+      "types": "./dist/subpaths/utils/historyReplace.d.ts",
+      "import": "./dist/subpaths/utils/historyReplace.js"
+    },
+    "./utils/objectToURLSearchParams": {
+      "types": "./dist/subpaths/utils/objectToURLSearchParams.d.ts",
+      "import": "./dist/subpaths/utils/objectToURLSearchParams.js"
+    },
     "./utils/isBoolean": {
       "types": "./dist/subpaths/utils/isBoolean.d.ts",
       "import": "./dist/subpaths/utils/isBoolean.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -340,6 +340,102 @@
       "types": "./dist/subpaths/utils/createElement.d.ts",
       "import": "./dist/subpaths/utils/createElement.js"
     },
+    "./utils/createEaseInOut": {
+      "types": "./dist/subpaths/utils/createEaseInOut.d.ts",
+      "import": "./dist/subpaths/utils/createEaseInOut.js"
+    },
+    "./utils/createEaseOut": {
+      "types": "./dist/subpaths/utils/createEaseOut.d.ts",
+      "import": "./dist/subpaths/utils/createEaseOut.js"
+    },
+    "./utils/easeInCirc": {
+      "types": "./dist/subpaths/utils/easeInCirc.d.ts",
+      "import": "./dist/subpaths/utils/easeInCirc.js"
+    },
+    "./utils/easeInCubic": {
+      "types": "./dist/subpaths/utils/easeInCubic.d.ts",
+      "import": "./dist/subpaths/utils/easeInCubic.js"
+    },
+    "./utils/easeInExpo": {
+      "types": "./dist/subpaths/utils/easeInExpo.d.ts",
+      "import": "./dist/subpaths/utils/easeInExpo.js"
+    },
+    "./utils/easeInOutCirc": {
+      "types": "./dist/subpaths/utils/easeInOutCirc.d.ts",
+      "import": "./dist/subpaths/utils/easeInOutCirc.js"
+    },
+    "./utils/easeInOutCubic": {
+      "types": "./dist/subpaths/utils/easeInOutCubic.d.ts",
+      "import": "./dist/subpaths/utils/easeInOutCubic.js"
+    },
+    "./utils/easeInOutExpo": {
+      "types": "./dist/subpaths/utils/easeInOutExpo.d.ts",
+      "import": "./dist/subpaths/utils/easeInOutExpo.js"
+    },
+    "./utils/easeInOutQuad": {
+      "types": "./dist/subpaths/utils/easeInOutQuad.d.ts",
+      "import": "./dist/subpaths/utils/easeInOutQuad.js"
+    },
+    "./utils/easeInOutQuart": {
+      "types": "./dist/subpaths/utils/easeInOutQuart.d.ts",
+      "import": "./dist/subpaths/utils/easeInOutQuart.js"
+    },
+    "./utils/easeInOutQuint": {
+      "types": "./dist/subpaths/utils/easeInOutQuint.d.ts",
+      "import": "./dist/subpaths/utils/easeInOutQuint.js"
+    },
+    "./utils/easeInOutSine": {
+      "types": "./dist/subpaths/utils/easeInOutSine.d.ts",
+      "import": "./dist/subpaths/utils/easeInOutSine.js"
+    },
+    "./utils/easeInQuad": {
+      "types": "./dist/subpaths/utils/easeInQuad.d.ts",
+      "import": "./dist/subpaths/utils/easeInQuad.js"
+    },
+    "./utils/easeInQuart": {
+      "types": "./dist/subpaths/utils/easeInQuart.d.ts",
+      "import": "./dist/subpaths/utils/easeInQuart.js"
+    },
+    "./utils/easeInQuint": {
+      "types": "./dist/subpaths/utils/easeInQuint.d.ts",
+      "import": "./dist/subpaths/utils/easeInQuint.js"
+    },
+    "./utils/easeInSine": {
+      "types": "./dist/subpaths/utils/easeInSine.d.ts",
+      "import": "./dist/subpaths/utils/easeInSine.js"
+    },
+    "./utils/easeLinear": {
+      "types": "./dist/subpaths/utils/easeLinear.d.ts",
+      "import": "./dist/subpaths/utils/easeLinear.js"
+    },
+    "./utils/easeOutCirc": {
+      "types": "./dist/subpaths/utils/easeOutCirc.d.ts",
+      "import": "./dist/subpaths/utils/easeOutCirc.js"
+    },
+    "./utils/easeOutCubic": {
+      "types": "./dist/subpaths/utils/easeOutCubic.d.ts",
+      "import": "./dist/subpaths/utils/easeOutCubic.js"
+    },
+    "./utils/easeOutExpo": {
+      "types": "./dist/subpaths/utils/easeOutExpo.d.ts",
+      "import": "./dist/subpaths/utils/easeOutExpo.js"
+    },
+    "./utils/easeOutQuad": {
+      "types": "./dist/subpaths/utils/easeOutQuad.d.ts",
+      "import": "./dist/subpaths/utils/easeOutQuad.js"
+    },
+    "./utils/easeOutQuart": {
+      "types": "./dist/subpaths/utils/easeOutQuart.d.ts",
+      "import": "./dist/subpaths/utils/easeOutQuart.js"
+    },
+    "./utils/easeOutQuint": {
+      "types": "./dist/subpaths/utils/easeOutQuint.d.ts",
+      "import": "./dist/subpaths/utils/easeOutQuint.js"
+    },
+    "./utils/easeOutSine": {
+      "types": "./dist/subpaths/utils/easeOutSine.d.ts",
+      "import": "./dist/subpaths/utils/easeOutSine.js"
+    },
     "./utils/historyPush": {
       "types": "./dist/subpaths/utils/historyPush.d.ts",
       "import": "./dist/subpaths/utils/historyPush.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -336,6 +336,10 @@
       "types": "./dist/subpaths/viewTransition.d.ts",
       "import": "./dist/subpaths/viewTransition.js"
     },
+    "./utils/createElement": {
+      "types": "./dist/subpaths/utils/createElement.d.ts",
+      "import": "./dist/subpaths/utils/createElement.js"
+    },
     "./utils/historyPush": {
       "types": "./dist/subpaths/utils/historyPush.d.ts",
       "import": "./dist/subpaths/utils/historyPush.js"

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -16,7 +16,7 @@ import {
 import type { MountStrategy } from './mount-strategies.js';
 import { memo } from './utils/memo.js';
 import { selectorFor } from './utils/selectors.js';
-import { kebabCase, pascalCase } from './utils/strings.js';
+import { capitalize, kebabCase } from './utils/strings.js';
 
 const REGEX_HANDLER = /^on[A-Z]/;
 
@@ -668,7 +668,7 @@ const handlerPlan = /* @__PURE__ */ memo((ctor: BaseConstructor): HandlerPlan =>
       return { kind: 'global', method, type: global.type, target: global.target };
     }
     const startsWith = (name: string) =>
-      rest.startsWith(pascalCase(name)) && rest.length > name.length;
+      rest.startsWith(capitalize(name)) && rest.length > name.length;
     const childName = childNames.find(startsWith);
     if (childName) {
       return {
@@ -1171,7 +1171,7 @@ export class Base<T extends BaseProps = BaseProps> {
     let announces = false;
     for (const name of readers.keys()) {
       announces ||=
-        typeof (this as unknown as Record<string, unknown>)[`option${pascalCase(name)}Changed`] ===
+        typeof (this as unknown as Record<string, unknown>)[`option${capitalize(name)}Changed`] ===
         'function';
     }
     if (!announces) {
@@ -1213,7 +1213,7 @@ export class Base<T extends BaseProps = BaseProps> {
       return;
     }
 
-    const method = `option${pascalCase(name)}Changed`;
+    const method = `option${capitalize(name)}Changed`;
     const handler = (this as unknown as Record<string, unknown>)[method];
     if (typeof handler !== 'function') {
       return;

--- a/packages/v4/src/subpaths/utils/TRANSFORM_PROPS.ts
+++ b/packages/v4/src/subpaths/utils/TRANSFORM_PROPS.ts
@@ -1,0 +1,1 @@
+export { TRANSFORM_PROPS, TRANSFORM_PROPS as default } from '../../utils/transform.js';

--- a/packages/v4/src/subpaths/utils/TRANSITION_OPTIONS.ts
+++ b/packages/v4/src/subpaths/utils/TRANSITION_OPTIONS.ts
@@ -1,0 +1,1 @@
+export { TRANSITION_OPTIONS, TRANSITION_OPTIONS as default } from '../../utils/transition.js';

--- a/packages/v4/src/subpaths/utils/camelCase.ts
+++ b/packages/v4/src/subpaths/utils/camelCase.ts
@@ -1,0 +1,1 @@
+export { camelCase, camelCase as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/capitalize.ts
+++ b/packages/v4/src/subpaths/utils/capitalize.ts
@@ -1,0 +1,1 @@
+export { capitalize, capitalize as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/createEaseInOut.ts
+++ b/packages/v4/src/subpaths/utils/createEaseInOut.ts
@@ -1,0 +1,1 @@
+export { createEaseInOut, createEaseInOut as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/createEaseOut.ts
+++ b/packages/v4/src/subpaths/utils/createEaseOut.ts
@@ -1,0 +1,1 @@
+export { createEaseOut, createEaseOut as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/createElement.ts
+++ b/packages/v4/src/subpaths/utils/createElement.ts
@@ -1,0 +1,1 @@
+export { createElement, createElement as default } from '../../utils/dom.js';

--- a/packages/v4/src/subpaths/utils/createRange.ts
+++ b/packages/v4/src/subpaths/utils/createRange.ts
@@ -1,0 +1,1 @@
+export { createRange, createRange as default } from '../../utils/maths.js';

--- a/packages/v4/src/subpaths/utils/debounce.ts
+++ b/packages/v4/src/subpaths/utils/debounce.ts
@@ -1,0 +1,1 @@
+export { debounce, debounce as default } from '../../utils/timing.js';

--- a/packages/v4/src/subpaths/utils/easeInCirc.ts
+++ b/packages/v4/src/subpaths/utils/easeInCirc.ts
@@ -1,0 +1,1 @@
+export { easeInCirc, easeInCirc as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInCubic.ts
+++ b/packages/v4/src/subpaths/utils/easeInCubic.ts
@@ -1,0 +1,1 @@
+export { easeInCubic, easeInCubic as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInExpo.ts
+++ b/packages/v4/src/subpaths/utils/easeInExpo.ts
@@ -1,0 +1,1 @@
+export { easeInExpo, easeInExpo as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInOutCirc.ts
+++ b/packages/v4/src/subpaths/utils/easeInOutCirc.ts
@@ -1,0 +1,1 @@
+export { easeInOutCirc, easeInOutCirc as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInOutCubic.ts
+++ b/packages/v4/src/subpaths/utils/easeInOutCubic.ts
@@ -1,0 +1,1 @@
+export { easeInOutCubic, easeInOutCubic as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInOutExpo.ts
+++ b/packages/v4/src/subpaths/utils/easeInOutExpo.ts
@@ -1,0 +1,1 @@
+export { easeInOutExpo, easeInOutExpo as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInOutQuad.ts
+++ b/packages/v4/src/subpaths/utils/easeInOutQuad.ts
@@ -1,0 +1,1 @@
+export { easeInOutQuad, easeInOutQuad as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInOutQuart.ts
+++ b/packages/v4/src/subpaths/utils/easeInOutQuart.ts
@@ -1,0 +1,1 @@
+export { easeInOutQuart, easeInOutQuart as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInOutQuint.ts
+++ b/packages/v4/src/subpaths/utils/easeInOutQuint.ts
@@ -1,0 +1,1 @@
+export { easeInOutQuint, easeInOutQuint as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInOutSine.ts
+++ b/packages/v4/src/subpaths/utils/easeInOutSine.ts
@@ -1,0 +1,1 @@
+export { easeInOutSine, easeInOutSine as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInQuad.ts
+++ b/packages/v4/src/subpaths/utils/easeInQuad.ts
@@ -1,0 +1,1 @@
+export { easeInQuad, easeInQuad as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInQuart.ts
+++ b/packages/v4/src/subpaths/utils/easeInQuart.ts
@@ -1,0 +1,1 @@
+export { easeInQuart, easeInQuart as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInQuint.ts
+++ b/packages/v4/src/subpaths/utils/easeInQuint.ts
@@ -1,0 +1,1 @@
+export { easeInQuint, easeInQuint as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeInSine.ts
+++ b/packages/v4/src/subpaths/utils/easeInSine.ts
@@ -1,0 +1,1 @@
+export { easeInSine, easeInSine as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeLinear.ts
+++ b/packages/v4/src/subpaths/utils/easeLinear.ts
@@ -1,0 +1,1 @@
+export { easeLinear, easeLinear as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeOutCirc.ts
+++ b/packages/v4/src/subpaths/utils/easeOutCirc.ts
@@ -1,0 +1,1 @@
+export { easeOutCirc, easeOutCirc as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeOutCubic.ts
+++ b/packages/v4/src/subpaths/utils/easeOutCubic.ts
@@ -1,0 +1,1 @@
+export { easeOutCubic, easeOutCubic as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeOutExpo.ts
+++ b/packages/v4/src/subpaths/utils/easeOutExpo.ts
@@ -1,0 +1,1 @@
+export { easeOutExpo, easeOutExpo as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeOutQuad.ts
+++ b/packages/v4/src/subpaths/utils/easeOutQuad.ts
@@ -1,0 +1,1 @@
+export { easeOutQuad, easeOutQuad as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeOutQuart.ts
+++ b/packages/v4/src/subpaths/utils/easeOutQuart.ts
@@ -1,0 +1,1 @@
+export { easeOutQuart, easeOutQuart as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeOutQuint.ts
+++ b/packages/v4/src/subpaths/utils/easeOutQuint.ts
@@ -1,0 +1,1 @@
+export { easeOutQuint, easeOutQuint as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/easeOutSine.ts
+++ b/packages/v4/src/subpaths/utils/easeOutSine.ts
@@ -1,0 +1,1 @@
+export { easeOutSine, easeOutSine as default } from '../../utils/easings.js';

--- a/packages/v4/src/subpaths/utils/enterTransition.ts
+++ b/packages/v4/src/subpaths/utils/enterTransition.ts
@@ -1,0 +1,1 @@
+export { enterTransition, enterTransition as default } from '../../utils/transition.js';

--- a/packages/v4/src/subpaths/utils/fold.ts
+++ b/packages/v4/src/subpaths/utils/fold.ts
@@ -1,0 +1,1 @@
+export { fold, fold as default } from '../../utils/maths.js';

--- a/packages/v4/src/subpaths/utils/historyPush.ts
+++ b/packages/v4/src/subpaths/utils/historyPush.ts
@@ -1,0 +1,1 @@
+export { historyPush, historyPush as default } from '../../utils/history.js';

--- a/packages/v4/src/subpaths/utils/historyReplace.ts
+++ b/packages/v4/src/subpaths/utils/historyReplace.ts
@@ -1,0 +1,1 @@
+export { historyReplace, historyReplace as default } from '../../utils/history.js';

--- a/packages/v4/src/subpaths/utils/isBoolean.ts
+++ b/packages/v4/src/subpaths/utils/isBoolean.ts
@@ -1,0 +1,1 @@
+export { isBoolean, isBoolean as default } from '../../utils/is.js';

--- a/packages/v4/src/subpaths/utils/isDefined.ts
+++ b/packages/v4/src/subpaths/utils/isDefined.ts
@@ -1,0 +1,1 @@
+export { isDefined, isDefined as default } from '../../utils/is.js';

--- a/packages/v4/src/subpaths/utils/isFunction.ts
+++ b/packages/v4/src/subpaths/utils/isFunction.ts
@@ -1,0 +1,1 @@
+export { isFunction, isFunction as default } from '../../utils/is.js';

--- a/packages/v4/src/subpaths/utils/isNull.ts
+++ b/packages/v4/src/subpaths/utils/isNull.ts
@@ -1,0 +1,1 @@
+export { isNull, isNull as default } from '../../utils/is.js';

--- a/packages/v4/src/subpaths/utils/isNumber.ts
+++ b/packages/v4/src/subpaths/utils/isNumber.ts
@@ -1,0 +1,1 @@
+export { isNumber, isNumber as default } from '../../utils/is.js';

--- a/packages/v4/src/subpaths/utils/isObject.ts
+++ b/packages/v4/src/subpaths/utils/isObject.ts
@@ -1,0 +1,1 @@
+export { isObject, isObject as default } from '../../utils/is.js';

--- a/packages/v4/src/subpaths/utils/isString.ts
+++ b/packages/v4/src/subpaths/utils/isString.ts
@@ -1,0 +1,1 @@
+export { isString, isString as default } from '../../utils/is.js';

--- a/packages/v4/src/subpaths/utils/leaveTransition.ts
+++ b/packages/v4/src/subpaths/utils/leaveTransition.ts
@@ -1,0 +1,1 @@
+export { leaveTransition, leaveTransition as default } from '../../utils/transition.js';

--- a/packages/v4/src/subpaths/utils/lowerCase.ts
+++ b/packages/v4/src/subpaths/utils/lowerCase.ts
@@ -1,0 +1,1 @@
+export { lowerCase, lowerCase as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/matrix.ts
+++ b/packages/v4/src/subpaths/utils/matrix.ts
@@ -1,0 +1,1 @@
+export { matrix, matrix as default } from '../../utils/transform.js';

--- a/packages/v4/src/subpaths/utils/mean.ts
+++ b/packages/v4/src/subpaths/utils/mean.ts
@@ -1,0 +1,1 @@
+export { mean, mean as default } from '../../utils/maths.js';

--- a/packages/v4/src/subpaths/utils/objectToURLSearchParams.ts
+++ b/packages/v4/src/subpaths/utils/objectToURLSearchParams.ts
@@ -1,0 +1,1 @@
+export { objectToURLSearchParams, objectToURLSearchParams as default } from '../../utils/history.js';

--- a/packages/v4/src/subpaths/utils/random.ts
+++ b/packages/v4/src/subpaths/utils/random.ts
@@ -1,0 +1,1 @@
+export { random, random as default } from '../../utils/random.js';

--- a/packages/v4/src/subpaths/utils/randomInt.ts
+++ b/packages/v4/src/subpaths/utils/randomInt.ts
@@ -1,0 +1,1 @@
+export { randomInt, randomInt as default } from '../../utils/random.js';

--- a/packages/v4/src/subpaths/utils/randomItem.ts
+++ b/packages/v4/src/subpaths/utils/randomItem.ts
@@ -1,0 +1,1 @@
+export { randomItem, randomItem as default } from '../../utils/random.js';

--- a/packages/v4/src/subpaths/utils/round.ts
+++ b/packages/v4/src/subpaths/utils/round.ts
@@ -1,0 +1,1 @@
+export { round, round as default } from '../../utils/maths.js';

--- a/packages/v4/src/subpaths/utils/saveActiveElement.ts
+++ b/packages/v4/src/subpaths/utils/saveActiveElement.ts
@@ -1,0 +1,1 @@
+export { saveActiveElement, saveActiveElement as default } from '../../utils/focus.js';

--- a/packages/v4/src/subpaths/utils/setClassesOrStyles.ts
+++ b/packages/v4/src/subpaths/utils/setClassesOrStyles.ts
@@ -1,0 +1,1 @@
+export { setClassesOrStyles, setClassesOrStyles as default } from '../../utils/transition.js';

--- a/packages/v4/src/subpaths/utils/snakeCase.ts
+++ b/packages/v4/src/subpaths/utils/snakeCase.ts
@@ -1,0 +1,1 @@
+export { snakeCase, snakeCase as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/throttle.ts
+++ b/packages/v4/src/subpaths/utils/throttle.ts
@@ -1,0 +1,1 @@
+export { throttle, throttle as default } from '../../utils/timing.js';

--- a/packages/v4/src/subpaths/utils/transform.ts
+++ b/packages/v4/src/subpaths/utils/transform.ts
@@ -1,0 +1,1 @@
+export { transform, transform as default } from '../../utils/transform.js';

--- a/packages/v4/src/subpaths/utils/transition.ts
+++ b/packages/v4/src/subpaths/utils/transition.ts
@@ -1,0 +1,1 @@
+export { transition, transition as default } from '../../utils/transition.js';

--- a/packages/v4/src/subpaths/utils/trapFocus.ts
+++ b/packages/v4/src/subpaths/utils/trapFocus.ts
@@ -1,0 +1,1 @@
+export { trapFocus, trapFocus as default } from '../../utils/focus.js';

--- a/packages/v4/src/subpaths/utils/untrapFocus.ts
+++ b/packages/v4/src/subpaths/utils/untrapFocus.ts
@@ -1,0 +1,1 @@
+export { untrapFocus, untrapFocus as default } from '../../utils/focus.js';

--- a/packages/v4/src/subpaths/utils/upperCase.ts
+++ b/packages/v4/src/subpaths/utils/upperCase.ts
@@ -1,0 +1,1 @@
+export { upperCase, upperCase as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/wait.ts
+++ b/packages/v4/src/subpaths/utils/wait.ts
@@ -1,0 +1,1 @@
+export { wait, wait as default } from '../../utils/timing.js';

--- a/packages/v4/src/subpaths/utils/withLeadingCharacters.ts
+++ b/packages/v4/src/subpaths/utils/withLeadingCharacters.ts
@@ -1,0 +1,1 @@
+export { withLeadingCharacters, withLeadingCharacters as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withLeadingSlash.ts
+++ b/packages/v4/src/subpaths/utils/withLeadingSlash.ts
@@ -1,0 +1,1 @@
+export { withLeadingSlash, withLeadingSlash as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withTrailingCharacters.ts
+++ b/packages/v4/src/subpaths/utils/withTrailingCharacters.ts
@@ -1,0 +1,1 @@
+export { withTrailingCharacters, withTrailingCharacters as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withTrailingSlash.ts
+++ b/packages/v4/src/subpaths/utils/withTrailingSlash.ts
@@ -1,0 +1,1 @@
+export { withTrailingSlash, withTrailingSlash as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withoutLeadingCharacters.ts
+++ b/packages/v4/src/subpaths/utils/withoutLeadingCharacters.ts
@@ -1,0 +1,1 @@
+export { withoutLeadingCharacters, withoutLeadingCharacters as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withoutLeadingCharactersRecursive.ts
+++ b/packages/v4/src/subpaths/utils/withoutLeadingCharactersRecursive.ts
@@ -1,0 +1,1 @@
+export { withoutLeadingCharactersRecursive, withoutLeadingCharactersRecursive as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withoutLeadingSlash.ts
+++ b/packages/v4/src/subpaths/utils/withoutLeadingSlash.ts
@@ -1,0 +1,1 @@
+export { withoutLeadingSlash, withoutLeadingSlash as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withoutTrailingCharacters.ts
+++ b/packages/v4/src/subpaths/utils/withoutTrailingCharacters.ts
@@ -1,0 +1,1 @@
+export { withoutTrailingCharacters, withoutTrailingCharacters as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withoutTrailingCharactersRecursive.ts
+++ b/packages/v4/src/subpaths/utils/withoutTrailingCharactersRecursive.ts
@@ -1,0 +1,1 @@
+export { withoutTrailingCharactersRecursive, withoutTrailingCharactersRecursive as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/withoutTrailingSlash.ts
+++ b/packages/v4/src/subpaths/utils/withoutTrailingSlash.ts
@@ -1,0 +1,1 @@
+export { withoutTrailingSlash, withoutTrailingSlash as default } from '../../utils/strings.js';

--- a/packages/v4/src/subpaths/utils/wrap.ts
+++ b/packages/v4/src/subpaths/utils/wrap.ts
@@ -1,0 +1,1 @@
+export { wrap, wrap as default } from '../../utils/maths.js';

--- a/packages/v4/src/utils/dom.spec.ts
+++ b/packages/v4/src/utils/dom.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createElement } from './dom.js';
+
+describe('createElement', () => {
+  it('creates a div by default', () => {
+    expect(createElement().outerHTML).toBe('<div></div>');
+  });
+
+  it('creates the given tag, custom elements included', () => {
+    expect(createElement('a').outerHTML).toBe('<a></a>');
+    expect(createElement('custom-element').outerHTML).toBe('<custom-element></custom-element>');
+  });
+
+  it('sets attributes, with their names in kebab-case', () => {
+    expect(createElement('a', { href: '#', dataOptionFoo: 'foo' }).outerHTML).toBe(
+      '<a href="#" data-option-foo="foo"></a>',
+    );
+  });
+
+  it('sets a data object as data- attributes', () => {
+    expect(createElement('div', { data: { optionFoo: 'foo', option_bar: 'bar' } }).outerHTML).toBe(
+      '<div data-option-foo="foo" data-option-bar="bar"></div>',
+    );
+  });
+
+  it('reads a string, a node or an array as content', () => {
+    expect(createElement('a', 'hello world').outerHTML).toBe('<a>hello world</a>');
+    expect(createElement('a', createElement('span')).outerHTML).toBe('<a><span></span></a>');
+    expect(createElement('a', ['hello world', createElement('span')]).outerHTML).toBe(
+      '<a>hello world<span></span></a>',
+    );
+  });
+
+  it('takes attributes and content together', () => {
+    expect(createElement('a', { href: '#' }, [createElement('span')]).outerHTML).toBe(
+      '<a href="#"><span></span></a>',
+    );
+    expect(createElement('a', { href: '#' }, 'hello world').outerHTML).toBe(
+      '<a href="#">hello world</a>',
+    );
+  });
+
+  it('escapes the content it is given', () => {
+    expect(createElement('div', '<script>alert(1)</script>').innerHTML).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+  });
+});

--- a/packages/v4/src/utils/dom.ts
+++ b/packages/v4/src/utils/dom.ts
@@ -1,0 +1,69 @@
+import { isObject, isString } from './is.js';
+import { kebabCase } from './strings.js';
+
+interface AnyHTMLElementTagNameMap extends HTMLElementTagNameMap {
+  [key: string]: HTMLElement;
+}
+
+/** What an element can be given as content: markup-free text, nodes, or both. */
+export type CreateElementChildren = string | Node | Array<string | Node>;
+
+export interface CreateElementAttributes {
+  /** Set as `data-` attributes, each name in `kebab-case`. */
+  data?: Record<string, string>;
+  [key: string]: string | Record<string, string> | undefined;
+}
+
+/**
+ * Create an element, with its attributes and its content.
+ *
+ * The second argument is read as content when it is a string, a node or an
+ * array — an element with content and no attribute needs no empty object.
+ *
+ * @example
+ * ```js
+ * createElement(); // <div></div>
+ * createElement('a', { href: '#' }); // <a href="#"></a>
+ * createElement('a', 'link'); // <a>link</a>
+ * createElement('a', { href: '#' }, [createElement('span')]); // <a href="#"><span></span></a>
+ * ```
+ */
+export function createElement<T extends keyof AnyHTMLElementTagNameMap = 'div'>(
+  tag?: T,
+  children?: CreateElementChildren,
+): AnyHTMLElementTagNameMap[T];
+export function createElement<T extends keyof AnyHTMLElementTagNameMap = 'div'>(
+  tag?: T,
+  attributes?: CreateElementAttributes,
+  children?: CreateElementChildren,
+): AnyHTMLElementTagNameMap[T];
+export function createElement<T extends keyof AnyHTMLElementTagNameMap = 'div'>(
+  tag?: T,
+  attributes: CreateElementChildren | CreateElementAttributes = {},
+  children: CreateElementChildren | null = null,
+): AnyHTMLElementTagNameMap[T] {
+  const element = document.createElement((tag as string) ?? 'div');
+
+  let content = children;
+  let attrs = attributes;
+  if (content === null && (Array.isArray(attrs) || isString(attrs) || attrs instanceof Node)) {
+    content = attrs;
+    attrs = {};
+  }
+
+  for (const [name, value] of Object.entries(attrs as CreateElementAttributes)) {
+    if (isString(value)) {
+      element.setAttribute(kebabCase(name), value);
+    } else if (name === 'data' && isObject(value)) {
+      for (const [dataName, dataValue] of Object.entries(value)) {
+        element.setAttribute(`data-${kebabCase(dataName)}`, dataValue as string);
+      }
+    }
+  }
+
+  if (content) {
+    element.append(...(Array.isArray(content) ? content : [content]));
+  }
+
+  return element as AnyHTMLElementTagNameMap[T];
+}

--- a/packages/v4/src/utils/easings.spec.ts
+++ b/packages/v4/src/utils/easings.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import * as easings from './easings.js';
+import { createEaseInOut, createEaseOut, easeLinear, type EasingFunction } from './easings.js';
+
+const named = Object.entries(easings).filter((entry): entry is [string, EasingFunction] =>
+  entry[0].startsWith('ease'),
+);
+
+describe('every easing', () => {
+  it.each(named)('%s starts at 0 and ends at 1', (_name, ease) => {
+    expect(ease(0)).toBe(0);
+    expect(ease(1)).toBe(1);
+  });
+
+  it.each(named)('%s stays in range and never goes back', (_name, ease) => {
+    let previous = 0;
+    for (let progress = 0; progress <= 1; progress += 0.01) {
+      const value = ease(progress);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+      expect(value).toBeGreaterThanOrEqual(previous);
+      previous = value;
+    }
+  });
+});
+
+describe('easeLinear', () => {
+  it('answers the progress it is given', () => {
+    expect(easeLinear(0.25)).toBe(0.25);
+  });
+});
+
+describe('createEaseOut', () => {
+  it('mirrors the ease-in function', () => {
+    const out = createEaseOut((progress) => progress ** 2);
+    expect(out(0.5)).toBeCloseTo(0.75, 10);
+    expect(out(0.25)).toBeCloseTo(1 - 0.75 ** 2, 10);
+  });
+});
+
+describe('createEaseInOut', () => {
+  it('runs the ease-in over the first half and its mirror over the second', () => {
+    const inOut = createEaseInOut((progress) => progress ** 2);
+    expect(inOut(0)).toBe(0);
+    expect(inOut(0.25)).toBeCloseTo(0.125, 10);
+    expect(inOut(0.5)).toBeCloseTo(0.5, 10);
+    expect(inOut(0.75)).toBeCloseTo(0.875, 10);
+    expect(inOut(1)).toBe(1);
+  });
+});
+
+describe('the eased shapes', () => {
+  it('accelerates on an ease-in and decelerates on an ease-out', () => {
+    expect(easings.easeInQuad(0.5)).toBeLessThan(0.5);
+    expect(easings.easeOutQuad(0.5)).toBeGreaterThan(0.5);
+    expect(easings.easeInOutQuad(0.5)).toBeCloseTo(0.5, 10);
+  });
+
+  it('steepens with the exponent', () => {
+    expect(easings.easeInCubic(0.5)).toBeLessThan(easings.easeInQuad(0.5));
+    expect(easings.easeInQuart(0.5)).toBeLessThan(easings.easeInCubic(0.5));
+    expect(easings.easeInQuint(0.5)).toBeLessThan(easings.easeInQuart(0.5));
+  });
+});

--- a/packages/v4/src/utils/easings.ts
+++ b/packages/v4/src/utils/easings.ts
@@ -1,0 +1,77 @@
+/**
+ * Easing functions: they shape a `0 → 1` progress and answer in the same
+ * range. The `in` form is the source, and the `out` and `in-out` forms are
+ * derived from it.
+ */
+
+/** Takes a progress between `0` and `1`, answers an eased value in that range. */
+export type EasingFunction = (progress: number) => number;
+
+/** Mirror an ease-in function into its ease-out counterpart. */
+export function createEaseOut(easeIn: EasingFunction): EasingFunction {
+  return (progress) => 1 - easeIn(1 - progress);
+}
+
+/** Join an ease-in function with its mirror, each over half the progress. */
+export function createEaseInOut(easeIn: EasingFunction): EasingFunction {
+  return (progress) => {
+    if (progress === 0 || progress === 1) return progress;
+    return progress < 0.5 ? easeIn(progress * 2) / 2 : 1 - easeIn((1 - progress) * 2) / 2;
+  };
+}
+
+/** No easing: the progress is the value. */
+export function easeLinear(progress: number): number {
+  return progress;
+}
+
+export function easeInQuad(progress: number): number {
+  return progress ** 2;
+}
+
+export const easeOutQuad = /* @__PURE__ */ createEaseOut(easeInQuad);
+export const easeInOutQuad = /* @__PURE__ */ createEaseInOut(easeInQuad);
+
+export function easeInCubic(progress: number): number {
+  return progress ** 3;
+}
+
+export const easeOutCubic = /* @__PURE__ */ createEaseOut(easeInCubic);
+export const easeInOutCubic = /* @__PURE__ */ createEaseInOut(easeInCubic);
+
+export function easeInQuart(progress: number): number {
+  return progress ** 4;
+}
+
+export const easeOutQuart = /* @__PURE__ */ createEaseOut(easeInQuart);
+export const easeInOutQuart = /* @__PURE__ */ createEaseInOut(easeInQuart);
+
+export function easeInQuint(progress: number): number {
+  return progress ** 5;
+}
+
+export const easeOutQuint = /* @__PURE__ */ createEaseOut(easeInQuint);
+export const easeInOutQuint = /* @__PURE__ */ createEaseInOut(easeInQuint);
+
+export function easeInSine(progress: number): number {
+  // Exact at the end, which the cosine is not.
+  return progress === 1 ? 1 : 1 - Math.cos((progress * Math.PI) / 2);
+}
+
+export const easeOutSine = /* @__PURE__ */ createEaseOut(easeInSine);
+export const easeInOutSine = /* @__PURE__ */ createEaseInOut(easeInSine);
+
+export function easeInCirc(progress: number): number {
+  return 1 - Math.sqrt(1 - progress * progress);
+}
+
+export const easeOutCirc = /* @__PURE__ */ createEaseOut(easeInCirc);
+export const easeInOutCirc = /* @__PURE__ */ createEaseInOut(easeInCirc);
+
+export function easeInExpo(progress: number): number {
+  // Exact at the start, where the power would answer 1/1024.
+  return progress === 0 ? 0 : 2 ** (10 * (progress - 1));
+}
+
+export const easeOutExpo = /* @__PURE__ */ createEaseOut(easeInExpo);
+export const easeInOutExpo = /* @__PURE__ */ createEaseInOut(easeInExpo);

--- a/packages/v4/src/utils/focus.spec.ts
+++ b/packages/v4/src/utils/focus.spec.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { saveActiveElement, trapFocus, untrapFocus } from './focus.js';
+
+const created: Element[] = [];
+
+function render(html: string): HTMLElement {
+  const element = document.createElement('div');
+  element.innerHTML = html;
+  document.body.append(element);
+  created.push(element);
+  return element;
+}
+
+/** A `Tab` press the trap can act on. */
+function tab(shiftKey = false): KeyboardEvent {
+  return new KeyboardEvent('keydown', { key: 'Tab', shiftKey, cancelable: true });
+}
+
+afterEach(() => {
+  for (const element of created.splice(0)) element.remove();
+  untrapFocus();
+});
+
+describe('trapFocus', () => {
+  it('ignores every key but Tab', () => {
+    const element = render('<button id="a"></button>');
+    const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true });
+    trapFocus(element, event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('focuses the first focusable element when the focus is outside', () => {
+    const element = render('<button id="a"></button><button id="b"></button>');
+    const event = tab();
+    trapFocus(element, event);
+    expect(document.activeElement?.id).toBe('a');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('wraps forwards from the last element and backwards from the first', () => {
+    const element = render('<button id="a"></button><button id="b"></button>');
+    const [first, last] = [...element.querySelectorAll('button')];
+
+    last.focus();
+    const forwards = tab();
+    trapFocus(element, forwards);
+    expect(document.activeElement).toBe(first);
+    expect(forwards.defaultPrevented).toBe(true);
+
+    const backwards = tab(true);
+    trapFocus(element, backwards);
+    expect(document.activeElement).toBe(last);
+    expect(backwards.defaultPrevented).toBe(true);
+  });
+
+  it('lets the browser move the focus inside the element', () => {
+    const element = render('<button id="a"></button><button id="b"></button>');
+    element.querySelector<HTMLElement>('#a')?.focus();
+    const event = tab();
+    trapFocus(element, event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('skips what tab navigation cannot reach', () => {
+    const element = render(`
+      <button id="a" disabled></button>
+      <a id="b">no href</a>
+      <button id="c" tabindex="-1"></button>
+      <button id="d"></button>
+    `);
+    trapFocus(element, tab());
+    expect(document.activeElement?.id).toBe('d');
+  });
+
+  it('does nothing when the element holds nothing focusable', () => {
+    const element = render('<p>text</p>');
+    const event = tab();
+    expect(() => trapFocus(element, event)).not.toThrow();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe('saveActiveElement and untrapFocus', () => {
+  it('gives the focus back to what had it', () => {
+    const outside = render('<button id="outside"></button>');
+    const trap = render('<button id="inside"></button>');
+    const before = outside.querySelector<HTMLElement>('#outside');
+
+    before?.focus();
+    saveActiveElement();
+
+    trapFocus(trap, tab());
+    expect(document.activeElement?.id).toBe('inside');
+
+    untrapFocus();
+    expect(document.activeElement).toBe(before);
+  });
+
+  it('restores what had the focus when the trap started, without saving first', () => {
+    const outside = render('<button id="outside"></button>');
+    const trap = render('<button id="inside"></button>');
+    const before = outside.querySelector<HTMLElement>('#outside');
+
+    before?.focus();
+    trapFocus(trap, tab());
+    untrapFocus();
+    expect(document.activeElement).toBe(before);
+  });
+
+  it('forgets the saved element, so a second call is a no-op', () => {
+    const outside = render('<button id="outside"></button>');
+    const other = render('<button id="other"></button>');
+
+    outside.querySelector<HTMLElement>('#outside')?.focus();
+    saveActiveElement();
+    untrapFocus();
+
+    const target = other.querySelector<HTMLElement>('#other');
+    target?.focus();
+    untrapFocus();
+    expect(document.activeElement).toBe(target);
+  });
+});

--- a/packages/v4/src/utils/focus.ts
+++ b/packages/v4/src/utils/focus.ts
@@ -1,10 +1,13 @@
+import { getSharedRuntimeSlot } from '../shared-runtime.js';
+
+/** What tab navigation can reach, in document order. */
 const FOCUSABLE = [
   'a[href]:not([tabindex^="-"]):not([inert])',
   'area[href]:not([tabindex^="-"]):not([inert])',
-  'input:not([disabled]):not([inert])',
-  'select:not([disabled]):not([inert])',
-  'textarea:not([disabled]):not([inert])',
-  'button:not([disabled]):not([inert])',
+  'input:not([disabled]):not([tabindex^="-"]):not([inert])',
+  'select:not([disabled]):not([tabindex^="-"]):not([inert])',
+  'textarea:not([disabled]):not([tabindex^="-"]):not([inert])',
+  'button:not([disabled]):not([tabindex^="-"]):not([inert])',
   'iframe:not([tabindex^="-"]):not([inert])',
   'audio:not([tabindex^="-"]):not([inert])',
   'video:not([tabindex^="-"]):not([inert])',
@@ -12,13 +15,19 @@ const FOCUSABLE = [
   '[tabindex]:not([tabindex^="-"]):not([inert])',
 ].join(', ');
 
-let focusedBefore: Element | null = null;
+/**
+ * What had the focus before the trap. There is one focus on the page, so
+ * evaluated package copies must save and restore through the same slot.
+ */
+const state = /* @__PURE__ */ getSharedRuntimeSlot('focus', 1, () => ({
+  focusedBefore: null as Element | null,
+}));
 
 /**
  * Remember what had the focus, to restore it later.
  */
 export function saveActiveElement(): void {
-  focusedBefore = document.activeElement;
+  state.focusedBefore = document.activeElement;
 }
 
 /**
@@ -29,7 +38,7 @@ export function trapFocus(el: HTMLElement, event: KeyboardEvent): void {
     return;
   }
 
-  focusedBefore ??= document.activeElement;
+  state.focusedBefore ??= document.activeElement;
 
   const focusable = [...el.querySelectorAll<HTMLElement>(FOCUSABLE)];
   if (focusable.length === 0) {
@@ -58,8 +67,8 @@ export function trapFocus(el: HTMLElement, event: KeyboardEvent): void {
  * Give the focus back to whatever had it before the trap.
  */
 export function untrapFocus(): void {
-  if (focusedBefore instanceof HTMLElement) {
-    focusedBefore.focus();
+  if (state.focusedBefore instanceof HTMLElement) {
+    state.focusedBefore.focus();
   }
-  focusedBefore = null;
+  state.focusedBefore = null;
 }

--- a/packages/v4/src/utils/history.spec.ts
+++ b/packages/v4/src/utils/history.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { historyPush, historyReplace, objectToURLSearchParams } from './history.js';
+
+describe('objectToURLSearchParams', () => {
+  it('writes flat values', () => {
+    expect(objectToURLSearchParams({ a: 'foo', b: 1, c: true }, '').toString()).toBe(
+      'a=foo&b=1&c=true',
+    );
+  });
+
+  it('writes arrays and objects as bracketed names', () => {
+    expect(objectToURLSearchParams({ a: ['foo', 'bar'] }, '').toString()).toBe(
+      'a%5B0%5D=foo&a%5B1%5D=bar',
+    );
+    expect(objectToURLSearchParams({ a: { b: { c: 'foo' } } }, '').toString()).toBe(
+      'a%5Bb%5D%5Bc%5D=foo',
+    );
+  });
+
+  it('deletes a param set to an empty value', () => {
+    expect(objectToURLSearchParams({ a: '' }, 'a=foo&b=bar').toString()).toBe('b=bar');
+    expect(objectToURLSearchParams({ a: null }, 'a=foo').toString()).toBe('');
+    expect(objectToURLSearchParams({ a: undefined }, 'a=foo').toString()).toBe('');
+  });
+
+  it('merges into the given search', () => {
+    expect(objectToURLSearchParams({ b: 'two' }, 'a=one').toString()).toBe('a=one&b=two');
+    expect(objectToURLSearchParams({ a: 'two' }, 'a=one').toString()).toBe('a=two');
+  });
+
+  it('merges into the current search by default', () => {
+    history.replaceState({}, '', '?a=one');
+    expect(objectToURLSearchParams({ b: 'two' }).toString()).toBe('a=one&b=two');
+  });
+});
+
+describe('historyPush and historyReplace', () => {
+  let initial: string;
+
+  beforeEach(() => {
+    initial = location.href;
+    history.replaceState({}, '', '/base?a=one#section');
+  });
+
+  afterEach(() => {
+    history.replaceState({}, '', initial);
+  });
+
+  it('keeps the parts the caller does not name', () => {
+    historyReplace({ path: '/other' });
+    expect(location.pathname).toBe('/other');
+    expect(location.search).toBe('?a=one');
+    expect(location.hash).toBe('#section');
+  });
+
+  it('merges an object into the current search', () => {
+    historyReplace({ search: { b: 'two' } });
+    expect(location.search).toBe('?a=one&b=two');
+  });
+
+  it('replaces the search when given a URLSearchParams', () => {
+    historyReplace({ search: new URLSearchParams('c=three') });
+    expect(location.search).toBe('?c=three');
+  });
+
+  it('accepts a hash with or without its number sign', () => {
+    historyReplace({ hash: 'other' });
+    expect(location.hash).toBe('#other');
+    historyReplace({ hash: '#third' });
+    expect(location.hash).toBe('#third');
+  });
+
+  it('drops the search when every param is emptied', () => {
+    historyReplace({ search: { a: '' } });
+    expect(location.search).toBe('');
+    expect(location.hash).toBe('#section');
+  });
+
+  it('stores the state and adds an entry only when pushing', () => {
+    const { length } = history;
+    historyReplace({ path: '/replaced' }, { step: 1 });
+    expect(history.state).toEqual({ step: 1 });
+    expect(history.length).toBe(length);
+
+    historyPush({ path: '/pushed' }, { step: 2 });
+    expect(history.state).toEqual({ step: 2 });
+    expect(location.pathname).toBe('/pushed');
+    expect(history.length).toBe(length + 1);
+
+    history.back();
+  });
+});

--- a/packages/v4/src/utils/history.ts
+++ b/packages/v4/src/utils/history.ts
@@ -1,0 +1,96 @@
+/** Update the URL without navigating, from the parts of it a component owns. */
+
+export interface HistoryOptions {
+  /** The pathname. Defaults to the current one. */
+  path?: string;
+  /** The search params, as an object or a `URLSearchParams`. Defaults to the current ones. */
+  search?: URLSearchParams | Record<string, SearchParamInput>;
+  /** The hash, with or without its `#`. Defaults to the current one. */
+  hash?: string;
+}
+
+/** A value a search param can hold, or a nested structure of them. */
+export type SearchParamInput =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | readonly SearchParamInput[]
+  | { readonly [key: string]: SearchParamInput };
+
+/**
+ * Set one param, recursing into arrays and objects as bracketed names.
+ *
+ * An empty value deletes the param instead of writing it, so a component
+ * clears its own part of the URL by setting it to `''`.
+ */
+function updateUrlSearchParam(
+  params: URLSearchParams,
+  name: string,
+  value: SearchParamInput,
+): URLSearchParams {
+  if (value === '' || value === null || value === undefined) {
+    params.delete(name);
+    return params;
+  }
+
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      updateUrlSearchParam(params, `${name}[${index}]`, item);
+    }
+    return params;
+  }
+
+  if (typeof value === 'object') {
+    for (const [key, item] of Object.entries(value)) {
+      updateUrlSearchParam(params, `${name}[${key}]`, item);
+    }
+    return params;
+  }
+
+  params.set(name, String(value));
+  return params;
+}
+
+/**
+ * Convert an object to `URLSearchParams`, over the current search by default.
+ *
+ * @example
+ * ```js
+ * objectToURLSearchParams({ filters: { color: 'red' } }, '').toString();
+ * // filters%5Bcolor%5D=red
+ * ```
+ */
+export function objectToURLSearchParams(
+  object: Record<string, SearchParamInput>,
+  defaultSearch: string = location.search,
+): URLSearchParams {
+  const params = new URLSearchParams(defaultSearch);
+  for (const [name, value] of Object.entries(object)) {
+    updateUrlSearchParam(params, name, value);
+  }
+  return params;
+}
+
+/** Build the URL from the parts the caller gave, keeping the current ones. */
+function urlFor({ path, search, hash }: HistoryOptions): string {
+  const params = search instanceof URLSearchParams ? search : objectToURLSearchParams(search ?? {});
+  const query = params.toString();
+  const fragment = hash ?? location.hash;
+
+  let url = path ?? location.pathname;
+  if (query) url += `?${query}`;
+  if (fragment) url += fragment.startsWith('#') ? fragment : `#${fragment}`;
+  return url;
+}
+
+/** Push a new history entry for the given URL parts. */
+export function historyPush(options: HistoryOptions, data: unknown = {}, title = ''): void {
+  history.pushState(data, title, urlFor(options));
+}
+
+/** Replace the current history entry with the given URL parts. */
+export function historyReplace(options: HistoryOptions, data: unknown = {}, title = ''): void {
+  history.replaceState(data, title, urlFor(options));
+}

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import * as barrel from './index.js';
 import * as dom from './dom.js';
 import * as easings from './easings.js';
+import * as focus from './focus.js';
 import * as historyModule from './history.js';
 import * as is from './is.js';
 import * as maths from './maths.js';
@@ -20,6 +21,7 @@ describe('the utils barrel', () => {
     const expected = [
       ...Object.keys(dom),
       ...Object.keys(easings),
+      ...Object.keys(focus),
       ...Object.keys(historyModule),
       ...Object.keys(is),
       ...Object.keys(maths),

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as barrel from './index.js';
+import * as is from './is.js';
 import * as maths from './maths.js';
 import * as memoModule from './memo.js';
 import * as selectors from './selectors.js';
@@ -11,6 +12,7 @@ import type { Memo, SmoothTo, SmoothToOptions, SpringOptions } from './index.js'
 describe('the utils barrel', () => {
   it('names every runtime export of every module it fronts', () => {
     const expected = [
+      ...Object.keys(is),
       ...Object.keys(maths),
       ...Object.keys(memoModule),
       ...Object.keys(selectors),

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import * as barrel from './index.js';
 import * as dom from './dom.js';
+import * as easings from './easings.js';
 import * as historyModule from './history.js';
 import * as is from './is.js';
 import * as maths from './maths.js';
@@ -16,6 +17,7 @@ describe('the utils barrel', () => {
   it('names every runtime export of every module it fronts', () => {
     const expected = [
       ...Object.keys(dom),
+      ...Object.keys(easings),
       ...Object.keys(historyModule),
       ...Object.keys(is),
       ...Object.keys(maths),

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -7,6 +7,7 @@ import * as memoModule from './memo.js';
 import * as selectors from './selectors.js';
 import * as smoothToModule from './smoothTo.js';
 import * as strings from './strings.js';
+import * as timing from './timing.js';
 import * as transformModule from './transform.js';
 import type { Memo, SmoothTo, SmoothToOptions, SpringOptions } from './index.js';
 
@@ -20,6 +21,7 @@ describe('the utils barrel', () => {
       ...Object.keys(selectors),
       ...Object.keys(smoothToModule),
       ...Object.keys(strings),
+      ...Object.keys(timing),
       ...Object.keys(transformModule),
     ].sort();
 

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -5,6 +5,7 @@ import * as memoModule from './memo.js';
 import * as selectors from './selectors.js';
 import * as smoothToModule from './smoothTo.js';
 import * as strings from './strings.js';
+import * as transformModule from './transform.js';
 import type { Memo, SmoothTo, SmoothToOptions, SpringOptions } from './index.js';
 
 describe('the utils barrel', () => {
@@ -15,6 +16,7 @@ describe('the utils barrel', () => {
       ...Object.keys(selectors),
       ...Object.keys(smoothToModule),
       ...Object.keys(strings),
+      ...Object.keys(transformModule),
     ].sort();
 
     expect(Object.keys(barrel).sort()).toEqual(expected);

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -12,6 +12,7 @@ import * as smoothToModule from './smoothTo.js';
 import * as strings from './strings.js';
 import * as timing from './timing.js';
 import * as transformModule from './transform.js';
+import * as transitionModule from './transition.js';
 import type { Memo, SmoothTo, SmoothToOptions, SpringOptions } from './index.js';
 
 describe('the utils barrel', () => {
@@ -29,6 +30,7 @@ describe('the utils barrel', () => {
       ...Object.keys(strings),
       ...Object.keys(timing),
       ...Object.keys(transformModule),
+      ...Object.keys(transitionModule),
     ].sort();
 
     expect(Object.keys(barrel).sort()).toEqual(expected);

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as barrel from './index.js';
+import * as dom from './dom.js';
 import * as historyModule from './history.js';
 import * as is from './is.js';
 import * as maths from './maths.js';
@@ -14,6 +15,7 @@ import type { Memo, SmoothTo, SmoothToOptions, SpringOptions } from './index.js'
 describe('the utils barrel', () => {
   it('names every runtime export of every module it fronts', () => {
     const expected = [
+      ...Object.keys(dom),
       ...Object.keys(historyModule),
       ...Object.keys(is),
       ...Object.keys(maths),

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as barrel from './index.js';
+import * as historyModule from './history.js';
 import * as is from './is.js';
 import * as maths from './maths.js';
 import * as memoModule from './memo.js';
@@ -12,6 +13,7 @@ import type { Memo, SmoothTo, SmoothToOptions, SpringOptions } from './index.js'
 describe('the utils barrel', () => {
   it('names every runtime export of every module it fronts', () => {
     const expected = [
+      ...Object.keys(historyModule),
       ...Object.keys(is),
       ...Object.keys(maths),
       ...Object.keys(memoModule),

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -6,6 +6,7 @@ import * as historyModule from './history.js';
 import * as is from './is.js';
 import * as maths from './maths.js';
 import * as memoModule from './memo.js';
+import * as randomModule from './random.js';
 import * as selectors from './selectors.js';
 import * as smoothToModule from './smoothTo.js';
 import * as strings from './strings.js';
@@ -22,6 +23,7 @@ describe('the utils barrel', () => {
       ...Object.keys(is),
       ...Object.keys(maths),
       ...Object.keys(memoModule),
+      ...Object.keys(randomModule),
       ...Object.keys(selectors),
       ...Object.keys(smoothToModule),
       ...Object.keys(strings),

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -22,3 +22,10 @@ export { memo, type Memo } from './memo.js';
 export { selectorFor } from './selectors.js';
 export { smoothTo, type SmoothTo, type SmoothToOptions } from './smoothTo.js';
 export { kebabCase, pascalCase } from './strings.js';
+export {
+  matrix,
+  transform,
+  TRANSFORM_PROPS,
+  type MatrixProps,
+  type TransformProps,
+} from './transform.js';

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -48,6 +48,7 @@ export {
   withTrailingCharacters,
   withTrailingSlash,
 } from './strings.js';
+export { debounce, throttle, wait } from './timing.js';
 export {
   matrix,
   transform,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -28,6 +28,7 @@ export {
   easeOutSine,
   type EasingFunction,
 } from './easings.js';
+export { saveActiveElement, trapFocus, untrapFocus } from './focus.js';
 export {
   historyPush,
   historyReplace,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -22,7 +22,15 @@ export {
 export { memo, type Memo } from './memo.js';
 export { selectorFor } from './selectors.js';
 export { smoothTo, type SmoothTo, type SmoothToOptions } from './smoothTo.js';
-export { kebabCase, pascalCase } from './strings.js';
+export {
+  camelCase,
+  capitalize,
+  kebabCase,
+  lowerCase,
+  pascalCase,
+  snakeCase,
+  upperCase,
+} from './strings.js';
 export {
   matrix,
   transform,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -30,6 +30,16 @@ export {
   pascalCase,
   snakeCase,
   upperCase,
+  withLeadingCharacters,
+  withLeadingSlash,
+  withoutLeadingCharacters,
+  withoutLeadingCharactersRecursive,
+  withoutLeadingSlash,
+  withoutTrailingCharacters,
+  withoutTrailingCharactersRecursive,
+  withoutTrailingSlash,
+  withTrailingCharacters,
+  withTrailingSlash,
 } from './strings.js';
 export {
   matrix,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -84,6 +84,16 @@ export {
 } from './strings.js';
 export { debounce, throttle, wait } from './timing.js';
 export {
+  enterTransition,
+  leaveTransition,
+  setClassesOrStyles,
+  transition,
+  TRANSITION_OPTIONS,
+  type ClassesOrStyles,
+  type TransitionOptions,
+  type TransitionStyles,
+} from './transition.js';
+export {
   matrix,
   transform,
   TRANSFORM_PROPS,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -1,5 +1,6 @@
 /** Public entry point for `@studiometa/js-toolkit-v4/utils`. */
 
+export { isBoolean, isDefined, isFunction, isNull, isNumber, isObject, isString } from './is.js';
 export {
   clamp,
   clamp01,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -1,5 +1,12 @@
 /** Public entry point for `@studiometa/js-toolkit-v4/utils`. */
 
+export {
+  historyPush,
+  historyReplace,
+  objectToURLSearchParams,
+  type HistoryOptions,
+  type SearchParamInput,
+} from './history.js';
 export { isBoolean, isDefined, isFunction, isNull, isNumber, isObject, isString } from './is.js';
 export {
   clamp,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -1,5 +1,6 @@
 /** Public entry point for `@studiometa/js-toolkit-v4/utils`. */
 
+export { createElement, type CreateElementAttributes, type CreateElementChildren } from './dom.js';
 export {
   historyPush,
   historyReplace,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -60,6 +60,7 @@ export {
   type SpringOptions,
 } from './maths.js';
 export { memo, type Memo } from './memo.js';
+export { random, randomInt, randomItem } from './random.js';
 export { selectorFor } from './selectors.js';
 export { smoothTo, type SmoothTo, type SmoothToOptions } from './smoothTo.js';
 export {

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -2,6 +2,33 @@
 
 export { createElement, type CreateElementAttributes, type CreateElementChildren } from './dom.js';
 export {
+  createEaseInOut,
+  createEaseOut,
+  easeInCirc,
+  easeInCubic,
+  easeInExpo,
+  easeInOutCirc,
+  easeInOutCubic,
+  easeInOutExpo,
+  easeInOutQuad,
+  easeInOutQuart,
+  easeInOutQuint,
+  easeInOutSine,
+  easeInQuad,
+  easeInQuart,
+  easeInQuint,
+  easeInSine,
+  easeLinear,
+  easeOutCirc,
+  easeOutCubic,
+  easeOutExpo,
+  easeOutQuad,
+  easeOutQuart,
+  easeOutQuint,
+  easeOutSine,
+  type EasingFunction,
+} from './easings.js';
+export {
   historyPush,
   historyReplace,
   objectToURLSearchParams,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -13,9 +13,11 @@ export {
   clamp,
   clamp01,
   clampDampFactor,
+  createRange,
   damp,
   decayOver,
   DEFAULT_DAMP_FACTOR,
+  fold,
   inertiaDecay,
   inertiaFinalValue,
   inertiaStep,
@@ -24,7 +26,10 @@ export {
   lerp,
   map,
   MAX_SPRING_RATIO,
+  mean,
+  round,
   spring,
+  wrap,
   type SpringOptions,
 } from './maths.js';
 export { memo, type Memo } from './memo.js';

--- a/packages/v4/src/utils/is.spec.ts
+++ b/packages/v4/src/utils/is.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { isBoolean, isDefined, isFunction, isNull, isNumber, isObject, isString } from './is.js';
+
+describe('isNull', () => {
+  it('answers for `null` only', () => {
+    expect(isNull(null)).toBe(true);
+    expect(isNull(undefined)).toBe(false);
+    expect(isNull(0)).toBe(false);
+  });
+});
+
+describe('isDefined', () => {
+  it('excludes `undefined` and nothing else', () => {
+    expect(isDefined(null)).toBe(true);
+    expect(isDefined(0)).toBe(true);
+    expect(isDefined('')).toBe(true);
+    expect(isDefined(undefined)).toBe(false);
+  });
+});
+
+describe('isString', () => {
+  it('answers for strings', () => {
+    expect(isString('')).toBe(true);
+    expect(isString(String('foo'))).toBe(true);
+    expect(isString(1)).toBe(false);
+  });
+});
+
+describe('isNumber', () => {
+  it('excludes `NaN`', () => {
+    expect(isNumber(0)).toBe(true);
+    expect(isNumber(Number.POSITIVE_INFINITY)).toBe(true);
+    expect(isNumber(Number.NaN)).toBe(false);
+    expect(isNumber('1')).toBe(false);
+  });
+});
+
+describe('isBoolean', () => {
+  it('answers for booleans', () => {
+    expect(isBoolean(false)).toBe(true);
+    expect(isBoolean(0)).toBe(false);
+  });
+});
+
+describe('isFunction', () => {
+  it('answers for anything callable', () => {
+    expect(isFunction(() => {})).toBe(true);
+    expect(isFunction(class {})).toBe(true);
+    expect(isFunction({})).toBe(false);
+  });
+});
+
+describe('isObject', () => {
+  it('answers for plain objects only', () => {
+    expect(isObject({})).toBe(true);
+    expect(isObject(Object.create(null))).toBe(true);
+    expect(isObject([])).toBe(false);
+    expect(isObject(null)).toBe(false);
+    expect(isObject(new Date())).toBe(false);
+    expect(isObject(document.createElement('div'))).toBe(false);
+    expect(isObject(() => {})).toBe(false);
+  });
+});

--- a/packages/v4/src/utils/is.ts
+++ b/packages/v4/src/utils/is.ts
@@ -1,0 +1,42 @@
+/** Type guards for the values a component reads from the DOM or its options. */
+
+/** Whether a value is `null`. */
+export function isNull(value: unknown): value is null {
+  return value === null;
+}
+
+/** Whether a value is anything but `undefined`. */
+export function isDefined<T>(value: T | undefined): value is T {
+  return typeof value !== 'undefined';
+}
+
+/** Whether a value is a string. */
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/** Whether a value is a number, `NaN` excluded. */
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value);
+}
+
+/** Whether a value is a boolean. */
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === 'boolean';
+}
+
+/** Whether a value is callable. */
+export function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
+  return typeof value === 'function';
+}
+
+/**
+ * Whether a value is a plain object: an array, a `Date`, a DOM node and `null`
+ * are all excluded.
+ *
+ * The tag is read through `Object.prototype`, so an object with no prototype
+ * answers instead of throwing on a missing `toString`.
+ */
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}

--- a/packages/v4/src/utils/maths.spec.ts
+++ b/packages/v4/src/utils/maths.spec.ts
@@ -11,6 +11,11 @@ import {
   damp,
   MAX_SPRING_RATIO,
   spring,
+  wrap,
+  fold,
+  round,
+  mean,
+  createRange,
 } from './maths.js';
 
 describe('clampDampFactor', () => {
@@ -323,5 +328,101 @@ describe('spring', () => {
       elapsed += INERTIA_FRAME;
     }
     expect(elapsed).toBeGreaterThan(stiff.elapsed);
+  });
+});
+
+describe('wrap', () => {
+  it('keeps an in-range value, and wraps the max onto the min', () => {
+    expect(wrap(5, 0, 10)).toBe(5);
+    expect(wrap(0, 0, 10)).toBe(0);
+    expect(wrap(10, 0, 10)).toBe(0);
+  });
+
+  it('wraps above and below, over any number of cycles', () => {
+    expect(wrap(15, 0, 10)).toBe(5);
+    expect(wrap(25, 0, 10)).toBe(5);
+    expect(wrap(-5, 0, 10)).toBe(5);
+    expect(wrap(1005, 0, 100)).toBe(5);
+  });
+
+  it('supports a negative range and fractional values', () => {
+    expect(wrap(-15, -10, 0)).toBe(-5);
+    expect(wrap(12, -5, 5)).toBe(2);
+    expect(wrap(2.3, 0, 1)).toBeCloseTo(0.3, 10);
+  });
+
+  it('collapses an empty range, and passes a non-finite one through', () => {
+    expect(wrap(5, 0, 0)).toBe(0);
+    expect(wrap(5, 0, Number.POSITIVE_INFINITY)).toBe(5);
+  });
+});
+
+describe('fold', () => {
+  it('keeps an in-range value, bounds included', () => {
+    expect(fold(1, 0, 2)).toBe(1);
+    expect(fold(0, 0, 2)).toBe(0);
+    expect(fold(2, 0, 2)).toBe(2);
+  });
+
+  it('reflects off both bounds, over any number of cycles', () => {
+    expect(fold(3, 0, 2)).toBe(1);
+    expect(fold(4, 0, 2)).toBe(0);
+    expect(fold(-1, 0, 2)).toBe(1);
+    expect(fold(6, 0, 2)).toBe(2);
+    expect(fold(-5, 0, 2)).toBe(1);
+  });
+
+  it('supports a shifted range and fractional values', () => {
+    expect(fold(7, 2, 4)).toBe(3);
+    expect(fold(-15, -10, 0)).toBe(-5);
+    expect(fold(1.5, 0, 1)).toBeCloseTo(0.5, 10);
+  });
+
+  it('returns the min for a range with nothing in it', () => {
+    expect(fold(5, 2, 2)).toBe(2);
+    expect(fold(5, 4, 2)).toBe(4);
+    expect(fold(5, 0, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('round', () => {
+  it('rounds to the given number of decimals', () => {
+    expect(round(1.4)).toBe(1);
+    expect(round(1.5)).toBe(2);
+    expect(round(1.2345, 2)).toBe(1.23);
+    expect(round(-1.005, 2)).toBe(-1);
+  });
+});
+
+describe('mean', () => {
+  it('averages the given numbers', () => {
+    expect(mean([1, 2, 3])).toBe(2);
+    expect(mean([2])).toBe(2);
+    expect(mean([])).toBe(0);
+  });
+});
+
+describe('createRange', () => {
+  it('lists the values one step apart, bounds included', () => {
+    expect(createRange(0, 4, 1)).toEqual([0, 1, 2, 3, 4]);
+    expect(createRange(0, 5, 2)).toEqual([0, 2, 4]);
+    expect(createRange(-2, 2, 2)).toEqual([-2, 0, 2]);
+  });
+
+  it('does not accumulate error on a fractional step', () => {
+    const range = createRange(0, 1, 0.1);
+    expect(range).toHaveLength(11);
+    for (const [index, value] of range.entries()) {
+      expect(value).toBeCloseTo(index / 10, 12);
+    }
+    // Accumulating the step instead ends at 0.9999999999999999.
+    expect(range.at(-1)).toBe(1);
+  });
+
+  it('returns nothing for a range no step describes', () => {
+    expect(createRange(0, 10, 0)).toEqual([]);
+    expect(createRange(0, 10, -1)).toEqual([]);
+    expect(createRange(10, 0, 1)).toEqual([]);
+    expect(createRange(0, Number.POSITIVE_INFINITY, 1)).toEqual([]);
   });
 });

--- a/packages/v4/src/utils/maths.ts
+++ b/packages/v4/src/utils/maths.ts
@@ -44,6 +44,71 @@ export function lerp(min: number, max: number, ratio: number): number {
 }
 
 /**
+ * Wrap a value in a range: it leaves by one bound and comes back by the other.
+ */
+export function wrap(value: number, min: number, max: number): number {
+  const range = max - min;
+
+  if (!Number.isFinite(range)) {
+    return value;
+  }
+
+  return min === max ? min : ((range + ((value - min) % range)) % range) + min;
+}
+
+/**
+ * Fold a value back and forth in a range: it bounces off both bounds.
+ */
+export function fold(value: number, min: number, max: number): number {
+  const range = max - min;
+
+  if (!Number.isFinite(range) || range <= 0) {
+    return min;
+  }
+
+  const wrapped = wrap(value, min, min + range * 2);
+  return wrapped > max ? 2 * max - wrapped : wrapped;
+}
+
+/**
+ * Round a value to the given number of decimals.
+ */
+export function round(value: number, decimals = 0): number {
+  return Number(value.toFixed(decimals));
+}
+
+/**
+ * The arithmetic mean of the given numbers. An empty list averages to `0`.
+ */
+export function mean(numbers: readonly number[]): number {
+  if (numbers.length === 0) {
+    return 0;
+  }
+
+  let sum = 0;
+  for (const value of numbers) {
+    sum += value;
+  }
+  return sum / numbers.length;
+}
+
+/**
+ * The values from `min` up to `max`, one step apart.
+ *
+ * Each value is computed from the index rather than accumulated, so a
+ * fractional step does not drift. A step which is not positive and finite
+ * describes no range and returns an empty array.
+ */
+export function createRange(min: number, max: number, step: number): number[] {
+  if (!Number.isFinite(step) || step <= 0 || !Number.isFinite(max - min) || max < min) {
+    return [];
+  }
+
+  const count = Math.floor((max - min) / step) + 1;
+  return Array.from({ length: count }, (_, index) => min + index * step);
+}
+
+/**
  * Return the fraction retained after `elapsed` milliseconds.
  *
  * Retention is clamped to `[0, 1]`, elapsed time to non-negative values, and non-finite inputs return `0`.

--- a/packages/v4/src/utils/random.spec.ts
+++ b/packages/v4/src/utils/random.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { random, randomInt, randomItem } from './random.js';
+
+/** Make `Math.random()` answer the given values, in order. */
+function stubRandom(...values: number[]): void {
+  let index = 0;
+  vi.spyOn(Math, 'random').mockImplementation(() => values[Math.min(index++, values.length - 1)]);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('random', () => {
+  it('stays between the bounds', () => {
+    stubRandom(0, 0.5, 0.999999);
+    expect(random(10, 20)).toBe(10);
+    expect(random(10, 20)).toBe(15);
+    expect(random(10, 20)).toBeLessThan(20);
+  });
+
+  it('defaults the second bound to zero', () => {
+    stubRandom(0.5);
+    expect(random(10)).toBe(5);
+  });
+});
+
+describe('randomInt', () => {
+  it('includes both bounds, and gives each integer the same chance', () => {
+    // Four integers in `0…3`, so each owns a quarter of the range.
+    stubRandom(0);
+    expect(randomInt(0, 3)).toBe(0);
+    stubRandom(0.2499);
+    expect(randomInt(0, 3)).toBe(0);
+    stubRandom(0.25);
+    expect(randomInt(0, 3)).toBe(1);
+    stubRandom(0.7499);
+    expect(randomInt(0, 3)).toBe(2);
+    stubRandom(0.9999);
+    expect(randomInt(0, 3)).toBe(3);
+  });
+
+  it('accepts its bounds in any order, and a negative range', () => {
+    stubRandom(0.9999);
+    expect(randomInt(3, 0)).toBe(3);
+    stubRandom(0);
+    expect(randomInt(-2, 2)).toBe(-2);
+    stubRandom(0.9999);
+    expect(randomInt(-2, 2)).toBe(2);
+  });
+
+  it('defaults the second bound to zero', () => {
+    stubRandom(0.9999);
+    expect(randomInt(5)).toBe(5);
+  });
+});
+
+describe('randomItem', () => {
+  it('picks an item of an array', () => {
+    stubRandom(0);
+    expect(randomItem(['a', 'b', 'c'])).toBe('a');
+    stubRandom(0.9999);
+    expect(randomItem(['a', 'b', 'c'])).toBe('c');
+  });
+
+  it('picks a character of a string', () => {
+    stubRandom(0.9999);
+    expect(randomItem('abc')).toBe('c');
+  });
+
+  it('answers undefined for an empty array or string', () => {
+    expect(randomItem([])).toBeUndefined();
+    expect(randomItem('')).toBeUndefined();
+  });
+});

--- a/packages/v4/src/utils/random.ts
+++ b/packages/v4/src/utils/random.ts
@@ -1,0 +1,26 @@
+/** Random values, in the ranges a component describes. */
+
+/** A random number between the two bounds, the second defaulting to `0`. */
+export function random(a: number, b = 0): number {
+  return Math.random() * (b - a) + a;
+}
+
+/**
+ * A random integer between the two bounds, both included and the second
+ * defaulting to `0`.
+ *
+ * Every integer in the range is equally likely. Rounding a random float
+ * instead — which is what v3 did — gives the two bounds half a chance each.
+ */
+export function randomInt(a: number, b = 0): number {
+  const min = Math.ceil(Math.min(a, b));
+  const max = Math.floor(Math.max(a, b));
+  return min + Math.floor(Math.random() * (max - min + 1));
+}
+
+/** A random item of an array, or a random character of a string. */
+export function randomItem<T>(items: readonly T[]): T | undefined;
+export function randomItem(items: string): string | undefined;
+export function randomItem<T>(items: readonly T[] | string): T | string | undefined {
+  return items.length > 0 ? items[randomInt(0, items.length - 1)] : undefined;
+}

--- a/packages/v4/src/utils/strings.spec.ts
+++ b/packages/v4/src/utils/strings.spec.ts
@@ -1,10 +1,72 @@
 import { describe, expect, it } from 'vitest';
-import { kebabCase } from './strings.js';
+import {
+  camelCase,
+  capitalize,
+  kebabCase,
+  lowerCase,
+  pascalCase,
+  snakeCase,
+  upperCase,
+} from './strings.js';
+
+describe('lowerCase and upperCase', () => {
+  it('change the case of the whole string', () => {
+    expect(lowerCase('FooBar')).toBe('foobar');
+    expect(upperCase('FooBar')).toBe('FOOBAR');
+  });
+});
+
+describe('capitalize', () => {
+  it('capitalizes the first character and leaves the rest alone', () => {
+    expect(capitalize('btn')).toBe('Btn');
+    expect(capitalize('myRef')).toBe('MyRef');
+    expect(capitalize('my-ref')).toBe('My-ref');
+    expect(capitalize('')).toBe('');
+  });
+});
+
+describe('pascalCase', () => {
+  it('splits words on every boundary', () => {
+    expect(pascalCase('my-ref')).toBe('MyRef');
+    expect(pascalCase('my ref')).toBe('MyRef');
+    expect(pascalCase('my_ref')).toBe('MyRef');
+    expect(pascalCase('myRef')).toBe('MyRef');
+    expect(pascalCase('MYRef')).toBe('MyRef');
+    expect(pascalCase('')).toBe('');
+  });
+});
+
+describe('camelCase', () => {
+  it('lowercases the first word', () => {
+    expect(camelCase('my-ref')).toBe('myRef');
+    expect(camelCase('MyRef')).toBe('myRef');
+    expect(camelCase('my ref name')).toBe('myRefName');
+  });
+});
 
 describe('kebabCase', () => {
-  it('converts PascalCase and camelCase', () => {
+  it('converts the names the framework reads from source', () => {
     expect(kebabCase('SliderDragStart')).toBe('slider-drag-start');
     expect(kebabCase('fetchAfter')).toBe('fetch-after');
     expect(kebabCase('click')).toBe('click');
+    expect(kebabCase('')).toBe('');
+  });
+
+  it('splits on a digit-to-letter boundary', () => {
+    expect(kebabCase('H2Click')).toBe('h2-click');
+    expect(kebabCase('slide2')).toBe('slide2');
+  });
+
+  it('treats anything but a letter or a digit as a separator', () => {
+    expect(kebabCase('foo_bar')).toBe('foo-bar');
+    expect(kebabCase('foo bar')).toBe('foo-bar');
+    expect(kebabCase('--foo--bar--')).toBe('foo-bar');
+  });
+});
+
+describe('snakeCase', () => {
+  it('joins the words with an underscore', () => {
+    expect(snakeCase('SliderDragStart')).toBe('slider_drag_start');
+    expect(snakeCase('foo-bar')).toBe('foo_bar');
   });
 });

--- a/packages/v4/src/utils/strings.spec.ts
+++ b/packages/v4/src/utils/strings.spec.ts
@@ -102,6 +102,15 @@ describe('leading and trailing characters', () => {
     expect(withoutLeadingCharactersRecursive('foo', '/')).toBe('foo');
   });
 
+  it('treats no characters as nothing to do', () => {
+    expect(withLeadingCharacters('foo', '')).toBe('foo');
+    expect(withTrailingCharacters('foo', '')).toBe('foo');
+    expect(withoutLeadingCharacters('foo', '')).toBe('foo');
+    expect(withoutTrailingCharacters('foo', '')).toBe('foo');
+    expect(withoutLeadingCharactersRecursive('foo', '')).toBe('foo');
+    expect(withoutTrailingCharactersRecursive('foo', '')).toBe('foo');
+  });
+
   it('matches the characters literally', () => {
     expect(withoutLeadingCharacters('.foo', '.')).toBe('foo');
     expect(withoutLeadingCharacters('afoo', '.')).toBe('afoo');

--- a/packages/v4/src/utils/strings.spec.ts
+++ b/packages/v4/src/utils/strings.spec.ts
@@ -7,6 +7,16 @@ import {
   pascalCase,
   snakeCase,
   upperCase,
+  withLeadingCharacters,
+  withLeadingSlash,
+  withoutLeadingCharacters,
+  withoutLeadingCharactersRecursive,
+  withoutLeadingSlash,
+  withoutTrailingCharacters,
+  withoutTrailingCharactersRecursive,
+  withoutTrailingSlash,
+  withTrailingCharacters,
+  withTrailingSlash,
 } from './strings.js';
 
 describe('lowerCase and upperCase', () => {
@@ -68,5 +78,50 @@ describe('snakeCase', () => {
   it('joins the words with an underscore', () => {
     expect(snakeCase('SliderDragStart')).toBe('slider_drag_start');
     expect(snakeCase('foo-bar')).toBe('foo_bar');
+  });
+});
+
+describe('leading and trailing characters', () => {
+  it('adds the characters once, however many are already there', () => {
+    expect(withLeadingCharacters('foo', '/')).toBe('/foo');
+    expect(withLeadingCharacters('/foo', '/')).toBe('/foo');
+    expect(withTrailingCharacters('foo', '/')).toBe('foo/');
+    expect(withTrailingCharacters('foo/', '/')).toBe('foo/');
+    expect(withLeadingCharacters('bar', 'foo-')).toBe('foo-bar');
+  });
+
+  it('removes the characters once', () => {
+    expect(withoutLeadingCharacters('//foo', '/')).toBe('/foo');
+    expect(withoutTrailingCharacters('foo//', '/')).toBe('foo/');
+    expect(withoutLeadingCharacters('foo', '/')).toBe('foo');
+  });
+
+  it('removes the characters as often as they repeat', () => {
+    expect(withoutLeadingCharactersRecursive('///foo', '/')).toBe('foo');
+    expect(withoutTrailingCharactersRecursive('foo///', '/')).toBe('foo');
+    expect(withoutLeadingCharactersRecursive('foo', '/')).toBe('foo');
+  });
+
+  it('matches the characters literally', () => {
+    expect(withoutLeadingCharacters('.foo', '.')).toBe('foo');
+    expect(withoutLeadingCharacters('afoo', '.')).toBe('afoo');
+    expect(withoutTrailingCharacters('foo.', '.')).toBe('foo');
+    expect(withoutTrailingCharacters('fooa', '.')).toBe('fooa');
+  });
+});
+
+describe('leading and trailing slashes', () => {
+  it('adds a slash once', () => {
+    expect(withLeadingSlash('foo')).toBe('/foo');
+    expect(withLeadingSlash('/foo')).toBe('/foo');
+    expect(withTrailingSlash('foo')).toBe('foo/');
+    expect(withTrailingSlash('foo/')).toBe('foo/');
+  });
+
+  it('removes a slash once', () => {
+    expect(withoutLeadingSlash('/foo')).toBe('foo');
+    expect(withoutLeadingSlash('foo')).toBe('foo');
+    expect(withoutTrailingSlash('foo/')).toBe('foo');
+    expect(withoutTrailingSlash('foo')).toBe('foo');
   });
 });

--- a/packages/v4/src/utils/strings.ts
+++ b/packages/v4/src/utils/strings.ts
@@ -82,3 +82,60 @@ export const kebabCase = /* @__PURE__ */ memo(function kebabCase(string: string)
 export const snakeCase = /* @__PURE__ */ memo(function snakeCase(string: string): string {
   return delimitedCase(string, '_');
 });
+/** Add the given characters to the start of a string, once. */
+export function withLeadingCharacters(string: string, characters: string): string {
+  return `${characters}${withoutLeadingCharacters(string, characters)}`;
+}
+
+/** Remove the given characters from the start of a string, once. */
+export function withoutLeadingCharacters(string: string, characters: string): string {
+  return string.startsWith(characters) ? string.slice(characters.length) : string;
+}
+
+/** Remove the given characters from the start of a string, as often as they repeat. */
+export function withoutLeadingCharactersRecursive(string: string, characters: string): string {
+  let result = string;
+  while (result.startsWith(characters)) {
+    result = result.slice(characters.length);
+  }
+  return result;
+}
+
+/** Add the given characters to the end of a string, once. */
+export function withTrailingCharacters(string: string, characters: string): string {
+  return `${withoutTrailingCharacters(string, characters)}${characters}`;
+}
+
+/** Remove the given characters from the end of a string, once. */
+export function withoutTrailingCharacters(string: string, characters: string): string {
+  return string.endsWith(characters) ? string.slice(0, -characters.length) : string;
+}
+
+/** Remove the given characters from the end of a string, as often as they repeat. */
+export function withoutTrailingCharactersRecursive(string: string, characters: string): string {
+  let result = string;
+  while (result.endsWith(characters)) {
+    result = result.slice(0, -characters.length);
+  }
+  return result;
+}
+
+/** Add a leading slash to a string, once. */
+export function withLeadingSlash(string: string): string {
+  return withLeadingCharacters(string, '/');
+}
+
+/** Remove the leading slash from a string, once. */
+export function withoutLeadingSlash(string: string): string {
+  return withoutLeadingCharacters(string, '/');
+}
+
+/** Add a trailing slash to a string, once. */
+export function withTrailingSlash(string: string): string {
+  return withTrailingCharacters(string, '/');
+}
+
+/** Remove the trailing slash from a string, once. */
+export function withoutTrailingSlash(string: string): string {
+  return withoutTrailingCharacters(string, '/');
+}

--- a/packages/v4/src/utils/strings.ts
+++ b/packages/v4/src/utils/strings.ts
@@ -87,13 +87,25 @@ export function withLeadingCharacters(string: string, characters: string): strin
   return `${characters}${withoutLeadingCharacters(string, characters)}`;
 }
 
-/** Remove the given characters from the start of a string, once. */
+/**
+ * Remove the given characters from the start of a string, once.
+ *
+ * No characters is nothing to remove: every helper here returns the string
+ * unchanged rather than treating the empty match every string starts and ends
+ * with as a hit.
+ */
 export function withoutLeadingCharacters(string: string, characters: string): string {
+  if (characters.length === 0) {
+    return string;
+  }
   return string.startsWith(characters) ? string.slice(characters.length) : string;
 }
 
 /** Remove the given characters from the start of a string, as often as they repeat. */
 export function withoutLeadingCharactersRecursive(string: string, characters: string): string {
+  if (characters.length === 0) {
+    return string;
+  }
   let result = string;
   while (result.startsWith(characters)) {
     result = result.slice(characters.length);
@@ -108,11 +120,17 @@ export function withTrailingCharacters(string: string, characters: string): stri
 
 /** Remove the given characters from the end of a string, once. */
 export function withoutTrailingCharacters(string: string, characters: string): string {
+  if (characters.length === 0) {
+    return string;
+  }
   return string.endsWith(characters) ? string.slice(0, -characters.length) : string;
 }
 
 /** Remove the given characters from the end of a string, as often as they repeat. */
 export function withoutTrailingCharactersRecursive(string: string, characters: string): string {
+  if (characters.length === 0) {
+    return string;
+  }
   let result = string;
   while (result.endsWith(characters)) {
     result = result.slice(0, -characters.length);

--- a/packages/v4/src/utils/strings.ts
+++ b/packages/v4/src/utils/strings.ts
@@ -3,19 +3,82 @@
  * source, and the `data-` attribute or event type it corresponds to.
  */
 
-const REGEX_KEBAB = /([a-z0-9])([A-Z])/g;
+import { memo } from './memo.js';
+
+const SPLIT_LOWER_UPPER_RE = /([\p{Ll}\d])(\p{Lu})/gu;
+const SPLIT_UPPER_UPPER_RE = /(\p{Lu})([\p{Lu}][\p{Ll}])/gu;
+const STRIP_RE = /[^\p{L}\d]+/giu;
+const SPLIT_REPLACE_VALUE = '$1\0$2';
 
 /**
- * Convert `PascalCase`/`camelCase` to `kebab-case`.
+ * Split a string into words, on case boundaries and on anything which is
+ * neither a letter nor a digit.
+ *
+ * @link https://github.com/blakeembrey/change-case
  */
-export function kebabCase(string: string): string {
-  return string.replace(REGEX_KEBAB, '$1-$2').toLowerCase();
+function split(value: string): string[] {
+  let result = value
+    .trim()
+    .replace(SPLIT_LOWER_UPPER_RE, SPLIT_REPLACE_VALUE)
+    .replace(SPLIT_UPPER_UPPER_RE, SPLIT_REPLACE_VALUE)
+    .replace(STRIP_RE, '\0');
+
+  let start = 0;
+  let end = result.length;
+
+  // Trim the delimiter from around the output.
+  while (result.charAt(start) === '\0') start++;
+  if (start === end) return [];
+  while (result.charAt(end - 1) === '\0') end--;
+
+  return result.slice(start, end).split('\0');
+}
+
+/** Join the words of a string in lowercase, with the given delimiter. */
+function delimitedCase(string: string, delimiter: string): string {
+  return split(string).map(lowerCase).join(delimiter);
+}
+
+/** Convert a string to lowercase. */
+export function lowerCase(string: string): string {
+  return string.toLowerCase();
+}
+
+/** Convert a string to UPPERCASE. */
+export function upperCase(string: string): string {
+  return string.toUpperCase();
 }
 
 /**
- * Capitalize the first letter: a `data-ref="btn"` name becomes the `Btn` of
- * an `onBtnClick` handler.
+ * Capitalize the first character and leave the rest alone: a `data-ref="btn"`
+ * name becomes the `Btn` of an `onBtnClick` handler.
+ *
+ * This is not {@link pascalCase} — it never splits words, so it round-trips a
+ * name the framework read from source.
  */
-export function pascalCase(string: string): string {
-  return string.charAt(0).toUpperCase() + string.slice(1);
+export function capitalize(string: string): string {
+  return upperCase(string.charAt(0)) + string.slice(1);
 }
+
+/** Convert a string to `PascalCase`. */
+export const pascalCase = /* @__PURE__ */ memo(function pascalCase(string: string): string {
+  return split(string)
+    .map((word) => upperCase(word.charAt(0)) + lowerCase(word.slice(1)))
+    .join('');
+});
+
+/** Convert a string to `camelCase`. */
+export const camelCase = /* @__PURE__ */ memo(function camelCase(string: string): string {
+  const result = pascalCase(string);
+  return lowerCase(result.charAt(0)) + result.slice(1);
+});
+
+/** Convert a string to `kebab-case`, the shape of a `data-` attribute. */
+export const kebabCase = /* @__PURE__ */ memo(function kebabCase(string: string): string {
+  return delimitedCase(string, '-');
+});
+
+/** Convert a string to `snake_case`. */
+export const snakeCase = /* @__PURE__ */ memo(function snakeCase(string: string): string {
+  return delimitedCase(string, '_');
+});

--- a/packages/v4/src/utils/timing.spec.ts
+++ b/packages/v4/src/utils/timing.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { debounce, throttle, wait } from './timing.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('debounce', () => {
+  it('runs once, after the calls stop', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced();
+    vi.advanceTimersByTime(99);
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the last call arguments', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced('first');
+    debounced('last');
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledExactlyOnceWith('last');
+  });
+
+  it('defaults to 300ms', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    debounce(fn)();
+
+    vi.advanceTimersByTime(299);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('throttle', () => {
+  it('runs on the leading edge and drops the calls inside the window', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('a');
+    throttled('b');
+    expect(fn).toHaveBeenCalledExactlyOnceWith('a');
+
+    vi.advanceTimersByTime(100);
+    throttled('c');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('c');
+  });
+
+  it('defaults to one frame', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const throttled = throttle(fn);
+
+    throttled();
+    vi.advanceTimersByTime(15);
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('wait', () => {
+  it('resolves after the delay', async () => {
+    const start = performance.now();
+    await wait(20);
+    expect(performance.now() - start).toBeGreaterThanOrEqual(15);
+  });
+
+  it('resolves on the next task by default', async () => {
+    const order: string[] = [];
+    const promise = wait().then(() => order.push('wait'));
+    order.push('sync');
+    await promise;
+    expect(order).toEqual(['sync', 'wait']);
+  });
+});

--- a/packages/v4/src/utils/timing.ts
+++ b/packages/v4/src/utils/timing.ts
@@ -1,0 +1,46 @@
+/** Rate limiting and delays, for the callbacks a component hands to the DOM. */
+
+/**
+ * Delay a function until it stops being called for the given milliseconds.
+ * Only the last call's arguments are used.
+ */
+export function debounce<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delay = 300,
+): (...args: Args) => void {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  return function debounced(...args: Args): void {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}
+
+/**
+ * Run a function at most once per given milliseconds, on the leading edge.
+ * A call inside the window is dropped, not deferred.
+ */
+export function throttle<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delay = 16,
+): (...args: Args) => void {
+  // Not `0`: `performance.now()` starts there, so a first call at page load
+  // would fall inside its own window.
+  let lastCall = Number.NEGATIVE_INFINITY;
+
+  return function throttled(...args: Args): void {
+    const now = performance.now();
+    if (now - lastCall < delay) {
+      return;
+    }
+    lastCall = now;
+    fn(...args);
+  };
+}
+
+/** Resolve after the given milliseconds. */
+export function wait(delay = 0): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+}

--- a/packages/v4/src/utils/transform.spec.ts
+++ b/packages/v4/src/utils/transform.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { matrix, transform, TRANSFORM_PROPS } from './transform.js';
+
+describe('transform', () => {
+  it('formats every property in a stable order', () => {
+    expect(transform({ x: 100, y: 100, z: 100, scale: 0.5, rotate: 45, skew: 10 })).toBe(
+      'translate3d(100px, 100px, 100px) rotate(45deg) scale(0.5) skew(10deg)',
+    );
+  });
+
+  it.each([
+    [{ x: 100 }, 'translate3d(100px, 0px, 0px)'],
+    [{ y: 100 }, 'translate3d(0px, 100px, 0px)'],
+    [{ z: 100 }, 'translate3d(0px, 0px, 100px)'],
+    [{ scale: 0.5 }, 'scale(0.5)'],
+    [{ scaleX: 0.5 }, 'scaleX(0.5)'],
+    [{ scaleY: 0.5 }, 'scaleY(0.5)'],
+    [{ scaleZ: 0.5 }, 'scaleZ(0.5)'],
+    [{ rotate: 45 }, 'rotate(45deg)'],
+    [{ rotateX: 45 }, 'rotateX(45deg)'],
+    [{ rotateY: 45 }, 'rotateY(45deg)'],
+    [{ rotateZ: 45 }, 'rotateZ(45deg)'],
+    [{ skew: 10 }, 'skew(10deg)'],
+    [{ skewX: 10 }, 'skewX(10deg)'],
+    [{ skewY: 10 }, 'skewY(10deg)'],
+  ])('formats %o', (props, expected) => {
+    expect(transform(props)).toBe(expected);
+  });
+
+  it('prefers a shorthand over its per-axis properties', () => {
+    expect(transform({ rotate: 45, rotateX: 10, rotateY: 10, rotateZ: 10 })).toBe('rotate(45deg)');
+    expect(transform({ scale: 2, scaleX: 3, scaleY: 3, scaleZ: 3 })).toBe('scale(2)');
+    expect(transform({ skew: 5, skewX: 1, skewY: 1 })).toBe('skew(5deg)');
+  });
+
+  it('combines per-axis properties', () => {
+    expect(transform({ rotateX: 10, rotateZ: 20, scaleX: 2, skewY: 5 })).toBe(
+      'rotateX(10deg) rotateZ(20deg) scaleX(2) skewY(5deg)',
+    );
+  });
+
+  it('keeps a zero value', () => {
+    expect(transform({ scale: 0 })).toBe('scale(0)');
+    expect(transform({ x: 0 })).toBe('translate3d(0px, 0px, 0px)');
+  });
+
+  it('returns an empty string for no property', () => {
+    expect(transform({})).toBe('');
+  });
+
+  it('lists the properties it formats', () => {
+    expect(TRANSFORM_PROPS).toHaveLength(14);
+    expect(TRANSFORM_PROPS).toContain('rotateZ');
+    expect(Object.isFrozen(TRANSFORM_PROPS)).toBe(true);
+  });
+});
+
+describe('matrix', () => {
+  it('defaults to the identity matrix', () => {
+    expect(matrix()).toBe('matrix(1, 0, 0, 1, 0, 0)');
+    expect(matrix({})).toBe('matrix(1, 0, 0, 1, 0, 0)');
+  });
+
+  it('formats the values in matrix order', () => {
+    expect(matrix({ scaleX: 0.5, scaleY: 0.5 })).toBe('matrix(0.5, 0, 0, 0.5, 0, 0)');
+    expect(matrix({ scaleX: 2, skewY: 1, skewX: 3, scaleY: 4, translateX: 5, translateY: 6 })).toBe(
+      'matrix(2, 1, 3, 4, 5, 6)',
+    );
+  });
+});

--- a/packages/v4/src/utils/transform.ts
+++ b/packages/v4/src/utils/transform.ts
@@ -1,0 +1,113 @@
+/**
+ * CSS transform strings. Both helpers are pure: they format a value and the
+ * caller hands the write to the scheduler.
+ */
+
+export interface TransformProps {
+  x?: number;
+  y?: number;
+  z?: number;
+  rotate?: number;
+  rotateX?: number;
+  rotateY?: number;
+  rotateZ?: number;
+  scale?: number;
+  scaleX?: number;
+  scaleY?: number;
+  scaleZ?: number;
+  skew?: number;
+  skewX?: number;
+  skewY?: number;
+}
+
+/** The properties {@link transform} formats, for callers splitting a style patch. */
+export const TRANSFORM_PROPS = /* @__PURE__ */ Object.freeze([
+  'x',
+  'y',
+  'z',
+  'rotate',
+  'rotateX',
+  'rotateY',
+  'rotateZ',
+  'scale',
+  'scaleX',
+  'scaleY',
+  'scaleZ',
+  'skew',
+  'skewX',
+  'skewY',
+]) as readonly (keyof TransformProps)[];
+
+/**
+ * Format a CSS transform.
+ *
+ * The three axes of a translation are one `translate3d`, and the shorthand of
+ * a rotation, a scale or a skew wins over its per-axis properties.
+ *
+ * @example
+ * ```js
+ * transform({ x: 100, scale: 0.5 });
+ * // translate3d(100px, 0px, 0px) scale(0.5)
+ * ```
+ */
+export function transform(props: TransformProps): string {
+  const parts: string[] = [];
+
+  if (props.x !== undefined || props.y !== undefined || props.z !== undefined) {
+    parts.push(`translate3d(${props.x ?? 0}px, ${props.y ?? 0}px, ${props.z ?? 0}px)`);
+  }
+
+  if (props.rotate !== undefined) {
+    parts.push(`rotate(${props.rotate}deg)`);
+  } else {
+    if (props.rotateX !== undefined) parts.push(`rotateX(${props.rotateX}deg)`);
+    if (props.rotateY !== undefined) parts.push(`rotateY(${props.rotateY}deg)`);
+    if (props.rotateZ !== undefined) parts.push(`rotateZ(${props.rotateZ}deg)`);
+  }
+
+  if (props.scale !== undefined) {
+    parts.push(`scale(${props.scale})`);
+  } else {
+    if (props.scaleX !== undefined) parts.push(`scaleX(${props.scaleX})`);
+    if (props.scaleY !== undefined) parts.push(`scaleY(${props.scaleY})`);
+    if (props.scaleZ !== undefined) parts.push(`scaleZ(${props.scaleZ})`);
+  }
+
+  if (props.skew !== undefined) {
+    parts.push(`skew(${props.skew}deg)`);
+  } else {
+    if (props.skewX !== undefined) parts.push(`skewX(${props.skewX}deg)`);
+    if (props.skewY !== undefined) parts.push(`skewY(${props.skewY}deg)`);
+  }
+
+  return parts.join(' ');
+}
+
+export interface MatrixProps {
+  /** The scale on the x axis. Defaults to `1`. */
+  scaleX?: number;
+  /** The scale on the y axis. Defaults to `1`. */
+  scaleY?: number;
+  /** The skew on the x axis. Defaults to `0`. */
+  skewX?: number;
+  /** The skew on the y axis. Defaults to `0`. */
+  skewY?: number;
+  /** The translation on the x axis. Defaults to `0`. */
+  translateX?: number;
+  /** The translation on the y axis. Defaults to `0`. */
+  translateY?: number;
+}
+
+/**
+ * Format a CSS transform matrix.
+ *
+ * @example
+ * ```js
+ * matrix({ scaleX: 0.5, scaleY: 0.5 });
+ * // matrix(0.5, 0, 0, 0.5, 0, 0)
+ * ```
+ */
+export function matrix(props: MatrixProps = {}): string {
+  const { scaleX = 1, skewY = 0, skewX = 0, scaleY = 1, translateX = 0, translateY = 0 } = props;
+  return `matrix(${scaleX}, ${skewY}, ${skewX}, ${scaleY}, ${translateX}, ${translateY})`;
+}

--- a/packages/v4/src/utils/transition.spec.ts
+++ b/packages/v4/src/utils/transition.spec.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { frames } from '../test-utils.js';
+import {
+  enterTransition,
+  leaveTransition,
+  setClassesOrStyles,
+  transition,
+  type TransitionOptions,
+} from './transition.js';
+
+const created: Element[] = [];
+
+/** An element in the document, so `getComputedStyle()` sees the stylesheet. */
+function createElement(styles = ''): HTMLElement {
+  if (styles) {
+    const style = document.createElement('style');
+    style.textContent = styles;
+    document.head.append(style);
+    created.push(style);
+  }
+  const element = document.createElement('div');
+  document.body.append(element);
+  created.push(element);
+  return element;
+}
+
+afterEach(() => {
+  for (const element of created.splice(0)) element.remove();
+});
+
+describe('setClassesOrStyles', () => {
+  it('adds and removes class names, given as a string or a list', () => {
+    const element = createElement();
+    setClassesOrStyles(element, 'a b');
+    expect(element.className).toBe('a b');
+    setClassesOrStyles(element, ['c'], 'add');
+    expect(element.className).toBe('a b c');
+    setClassesOrStyles(element, 'a b', 'remove');
+    expect(element.className).toBe('c');
+  });
+
+  it('resets an inline style rather than deleting the property', () => {
+    const element = createElement();
+    setClassesOrStyles(element, { opacity: '0' });
+    expect(element.style.opacity).toBe('0');
+    setClassesOrStyles(element, { opacity: '0' }, 'remove');
+    expect(element.style.opacity).toBe('');
+  });
+
+  it('does nothing without a value', () => {
+    const element = createElement();
+    expect(() => setClassesOrStyles(element, undefined)).not.toThrow();
+    expect(element.getAttribute('class')).toBeNull();
+  });
+});
+
+describe('transition', () => {
+  it('applies from, then active and to, and cleans up after itself', async () => {
+    const element = createElement();
+    const promise = transition(element, 'fade');
+    expect(element.className).toBe('fade-from');
+
+    await promise;
+    expect(element.getAttribute('class')).toBe('');
+  });
+
+  it('keeps the to state when asked', async () => {
+    const element = createElement();
+    await transition(element, 'fade', 'keep');
+    expect(element.className).toBe('fade-to');
+  });
+
+  it('accepts explicit class names and inline styles', async () => {
+    const element = createElement();
+    await transition(element, { from: 'is-hidden', active: 'is-moving', to: 'is-shown' }, 'keep');
+    expect(element.className).toBe('is-shown');
+
+    const styled = createElement();
+    await transition(styled, { from: { opacity: '0' }, to: { opacity: '1' } }, 'keep');
+    expect(styled.style.opacity).toBe('1');
+  });
+
+  it('waits for a real transition to end', async () => {
+    const element = createElement('.slide-active { transition: opacity 60ms linear }');
+    let done = false;
+    const promise = transition(
+      element,
+      { from: { opacity: '0' }, active: 'slide-active', to: { opacity: '1' } },
+      'keep',
+    ).then(() => {
+      done = true;
+    });
+
+    await frames(3);
+    expect(done).toBe(false);
+
+    await promise;
+    expect(done).toBe(true);
+    expect(element.classList.contains('slide-active')).toBe(false);
+  });
+
+  it('resolves a second transition started while the first runs', async () => {
+    const element = createElement('.slide-active { transition: opacity 60ms linear }');
+    const first = transition(element, { active: 'slide-active', to: { opacity: '1' } }, 'keep');
+    const second = transition(element, { active: 'slide-active', to: { opacity: '0' } }, 'keep');
+
+    await expect(Promise.all([first, second])).resolves.toBeDefined();
+    expect(element.style.opacity).toBe('0');
+  });
+});
+
+describe('enterTransition and leaveTransition', () => {
+  const options: TransitionOptions = {
+    enterFrom: 'enter-from',
+    enterActive: 'enter-active',
+    enterTo: 'enter-to',
+    enterKeep: true,
+    leaveFrom: 'leave-from',
+    leaveActive: 'leave-active',
+    leaveTo: 'leave-to',
+    leaveKeep: true,
+  };
+
+  it('clears the other direction end state before running', async () => {
+    const element = createElement();
+
+    await leaveTransition(element, options);
+    expect(element.className).toBe('leave-to');
+
+    await enterTransition(element, options);
+    expect(element.className).toBe('enter-to');
+
+    await leaveTransition(element, options);
+    expect(element.className).toBe('leave-to');
+  });
+
+  it('leaves nothing behind when the end state is not kept', async () => {
+    const element = createElement();
+    await enterTransition(element, { ...options, enterKeep: false });
+    expect(element.getAttribute('class')).toBe('');
+  });
+});

--- a/packages/v4/src/utils/transition.ts
+++ b/packages/v4/src/utils/transition.ts
@@ -1,5 +1,5 @@
-import { nextFrame } from '../../src/index.js';
-import type { OptionDefinition } from '../../src/index.js';
+import type { OptionDefinition } from '../Base.js';
+import { nextFrame } from '../scheduler.js';
 
 /**
  * CSS transition helpers for class names or inline styles. Apply `from`, then
@@ -14,21 +14,13 @@ export interface TransitionStyles {
   to?: ClassesOrStyles;
 }
 
-interface TransitionState {
-  isTransitioning: boolean;
-  onEnd: (() => void) | null;
+/** The run in progress on an element, which a new one interrupts. */
+interface TransitionRun {
+  aborted: boolean;
+  abort: () => void;
 }
 
-const states = new WeakMap<HTMLElement, TransitionState>();
-
-function stateFor(el: HTMLElement): TransitionState {
-  let state = states.get(el);
-  if (!state) {
-    state = { isTransitioning: false, onEnd: null };
-    states.set(el, state);
-  }
-  return state;
-}
+const runs = new WeakMap<HTMLElement, TransitionRun>();
 
 function toClassList(value: string | string[]): string[] {
   return (Array.isArray(value) ? value : value.split(' ')).filter(Boolean);
@@ -57,21 +49,12 @@ function hasTransition(el: HTMLElement): boolean {
   return Boolean(transitionDuration) && transitionDuration !== '0s';
 }
 
-function end(el: HTMLElement, classesOrStyles: TransitionStyles, mode: 'keep' | 'remove'): void {
-  const state = stateFor(el);
-  if (state.onEnd) {
-    el.removeEventListener('transitionend', state.onEnd);
-  }
-  if (mode === 'remove') {
-    setClassesOrStyles(el, classesOrStyles.to, 'remove');
-  }
-  setClassesOrStyles(el, classesOrStyles.active, 'remove');
-  state.isTransitioning = false;
-  state.onEnd = null;
-}
-
 /**
  * Run a CSS transition on an element.
+ *
+ * A transition started while another one runs on the same element interrupts
+ * it: the interrupted one removes what it applied and resolves, so a caller
+ * awaiting it is never left waiting for an end which will not come.
  *
  * @param mode Whether the `to` state is kept or removed at the end.
  */
@@ -89,31 +72,59 @@ export async function transition(
         }
       : { from: '', active: '', to: '', ...nameOrStyles };
 
-  const state = stateFor(el);
-  if (state.isTransitioning) {
-    end(el, classesOrStyles, 'remove');
-  }
+  runs.get(el)?.abort();
 
-  state.isTransitioning = true;
-  setClassesOrStyles(el, classesOrStyles.from);
-  await nextFrame();
-  setClassesOrStyles(el, classesOrStyles.active);
-
-  await new Promise<void>((resolve) => {
-    if (hasTransition(el)) {
-      state.onEnd = () => resolve();
-      el.addEventListener('transitionend', state.onEnd);
-    }
-    setClassesOrStyles(el, classesOrStyles.from, 'remove');
-    setClassesOrStyles(el, classesOrStyles.to);
-    nextFrame().then(() => {
-      if (!state.onEnd) {
-        resolve();
-      }
-    });
+  let onEnd: (() => void) | null = null;
+  let settle: () => void;
+  const ended = new Promise<void>((resolve) => {
+    settle = resolve;
   });
 
-  end(el, classesOrStyles, mode);
+  /** Drop the listener, the `active` state and, unless kept, the `to` state. */
+  function end(endMode: 'keep' | 'remove'): void {
+    if (runs.get(el) === run) {
+      runs.delete(el);
+    }
+    if (onEnd) {
+      el.removeEventListener('transitionend', onEnd);
+      onEnd = null;
+    }
+    if (endMode === 'remove') {
+      setClassesOrStyles(el, classesOrStyles.to, 'remove');
+    }
+    setClassesOrStyles(el, classesOrStyles.active, 'remove');
+  }
+
+  const run: TransitionRun = {
+    aborted: false,
+    abort() {
+      run.aborted = true;
+      end('remove');
+      settle();
+    },
+  };
+  runs.set(el, run);
+
+  setClassesOrStyles(el, classesOrStyles.from);
+  await nextFrame();
+  if (run.aborted) return;
+
+  setClassesOrStyles(el, classesOrStyles.active);
+
+  if (hasTransition(el)) {
+    onEnd = () => settle();
+    el.addEventListener('transitionend', onEnd);
+  }
+  setClassesOrStyles(el, classesOrStyles.from, 'remove');
+  setClassesOrStyles(el, classesOrStyles.to);
+  if (!onEnd) {
+    nextFrame().then(() => settle());
+  }
+
+  await ended;
+  if (run.aborted) return;
+
+  end(mode);
 }
 
 /** Shared transition option definitions. */

--- a/packages/v4/test/package-node-consumer.js
+++ b/packages/v4/test/package-node-consumer.js
@@ -15,6 +15,11 @@ import createMemoryStorageProviderDefault, {
   createMemoryStorageProvider,
 } from '@studiometa/js-toolkit-v4/createMemoryStorageProvider';
 import clampDefault, { clamp } from '@studiometa/js-toolkit-v4/utils/clamp';
+import * as utils from '@studiometa/js-toolkit-v4/utils';
+import kebabCaseDefault, { kebabCase } from '@studiometa/js-toolkit-v4/utils/kebabCase';
+import transformDefault, { transform } from '@studiometa/js-toolkit-v4/utils/transform';
+import easeOutQuadDefault, { easeOutQuad } from '@studiometa/js-toolkit-v4/utils/easeOutQuad';
+import randomIntDefault, { randomInt } from '@studiometa/js-toolkit-v4/utils/randomInt';
 
 assert.equal(Base, toolkit.Base);
 assert.equal(BaseDefault, Base);
@@ -58,5 +63,25 @@ storage.set('theme', 'dark');
 assert.deepEqual(seen, ['light']);
 assert.equal(clampDefault, clamp);
 assert.equal(clamp(12, 0, 10), 10);
+
+// The ported utilities, through their own subpath and through the barrel.
+assert.equal(kebabCaseDefault, kebabCase);
+assert.equal(kebabCase, utils.kebabCase);
+assert.equal(kebabCase('SliderDragStart'), 'slider-drag-start');
+assert.equal(utils.capitalize('btn'), 'Btn');
+assert.equal(utils.pascalCase('my-ref'), 'MyRef');
+assert.equal(utils.withoutTrailingSlash('/foo/'), '/foo');
+assert.equal(transformDefault, transform);
+assert.equal(transform({ x: 10 }), 'translate3d(10px, 0px, 0px)');
+assert.equal(utils.matrix(), 'matrix(1, 0, 0, 1, 0, 0)');
+assert.equal(easeOutQuadDefault, easeOutQuad);
+assert.equal(easeOutQuad(1), 1);
+assert.equal(randomIntDefault, randomInt);
+assert.equal(randomInt(0, 0), 0);
+assert.equal(utils.isObject({}), true);
+assert.equal(utils.round(1.2345, 2), 1.23);
+assert.deepEqual(utils.createRange(0, 2, 1), [0, 1, 2]);
+assert.equal(typeof utils.debounce(() => {}), 'function');
+await utils.wait(1);
 
 console.log('Node packed consumer: root and public subpaths passed.');


### PR DESCRIPTION
Ports the utilities named in the brief from v3 into v4, one commit each, plus the two promotions DESIGN §9 planned out of `migration/utils/`.

## What lands

| module | symbols |
| --- | --- |
| `utils/transform.ts` | `transform`, `matrix`, `TRANSFORM_PROPS` |
| `utils/is.ts` | `isNull`, `isDefined`, `isString`, `isNumber`, `isBoolean`, `isFunction`, `isObject` |
| `utils/strings.ts` | `lowerCase`, `upperCase`, `capitalize`, `camelCase`, `pascalCase`, `kebabCase`, `snakeCase`, and the leading/trailing character and slash helpers |
| `utils/history.ts` | `historyPush`, `historyReplace`, `objectToURLSearchParams` |
| `utils/timing.ts` | `debounce`, `throttle`, `wait` |
| `utils/dom.ts` | `createElement` |
| `utils/maths.ts` | `wrap`, `fold`, `round`, `mean`, `createRange` |
| `utils/easings.ts` | `easeLinear`, the seven ease-in curves with their out and in-out forms, `createEaseOut`, `createEaseInOut` |
| `utils/random.ts` | `random`, `randomInt`, `randomItem` |
| `utils/transition.ts` | `transition`, `enterTransition`, `leaveTransition`, `setClassesOrStyles`, `TRANSITION_OPTIONS` — promoted from `migration/utils/` |
| `utils/focus.ts` | `trapFocus`, `untrapFocus`, `saveActiveElement` — promoted from `migration/utils/` |

## Breaking

`pascalCase()` now splits words: `my-ref` becomes `MyRef`, where it used to become `My-ref`. What it did before is `capitalize()`, which is what `Base` calls to build `onBtnClick` and `optionFooChanged`.

## Deliberate changes

- **`transform()` is pure.** v3 took elements and wrote `style.transform`. This layer does no DOM write (DESIGN §9), so it formats a string and the caller hands it to the scheduler — the shape `matrix()` already had.
- **`transition()` no longer hangs on an interrupted run.** A transition started while another one ran on the same element removed the first one's `transitionend` listener without resolving its promise. The interrupted run is now aborted explicitly: it removes what it applied, then resolves.
- **`randomInt()` is uniform.** v3 rounded a random float, which gave both bounds half the chance of every other integer — and `randomItem()` is built on it, so the first and last item of every list were picked half as often.
- **`createRange()` computes each value from its index** instead of accumulating the step, and returns `[]` for a step which is not positive and finite, where v3 looped forever on `0`.
- **`throttle()` reads `performance.now()`** and starts from `-Infinity`, so a first call at page load is not inside its own window.
- **The trimming helpers match literally.** v3 built a `RegExp` out of the characters argument, so `.` matched any character.
- **The focusable selector excludes a form control with a negative tabindex**, which it only excluded for links and media.
- **`saveActiveElement()` uses a shared runtime slot** — there is one focus on the page, so two evaluated copies of the package must save and restore through the same one.

## Not ported

`isDev` (the diagnostic protocol replaced it), `isArray`, `isEmpty`, `isEmptyString`, `startsWith`, `endsWith`.

## Checks

`npm run lint`, `npm run lint:types`, `npm run test:v4` (956 tests) and `npm run check:package` all pass. Every commit updates the utils barrel spec and regenerates the subpath stubs, so each one is green on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9