### PR TITLE
refactor(v4)!: make deepmerge variadic

### DIFF
--- a/packages/v4/migration/Track/AbstractTrack.ts
+++ b/packages/v4/migration/Track/AbstractTrack.ts
@@ -8,7 +8,7 @@ import {
   type ScheduledTask,
   type Unsubscribe,
 } from '../../src/index.js';
-import { deepmerge, deepmergeAll } from '../../src/utils/deepmerge.js';
+import { deepmerge } from '../../src/utils/deepmerge.js';
 import { TrackContext } from './TrackContext.js';
 import { TRACK_PSEUDO_EVENTS, TrackEvent } from './TrackEvent.js';
 import { warn } from './utils.js';
@@ -143,7 +143,7 @@ export class AbstractTrack<T extends BaseProps = BaseProps> extends Base<Abstrac
    * then the event's own data.
    */
   send(data: Record<string, unknown>, event?: Event): void {
-    this.dispatch(deepmergeAll([this.context, this.payload ?? {}, data ?? {}]), event);
+    this.dispatch(deepmerge(this.context, this.payload ?? {}, data ?? {}), event);
   }
 
   /**

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -340,10 +340,6 @@
       "types": "./dist/subpaths/utils/deepmerge.d.ts",
       "import": "./dist/subpaths/utils/deepmerge.js"
     },
-    "./utils/deepmergeAll": {
-      "types": "./dist/subpaths/utils/deepmergeAll.d.ts",
-      "import": "./dist/subpaths/utils/deepmergeAll.js"
-    },
     "./utils/createElement": {
       "types": "./dist/subpaths/utils/createElement.d.ts",
       "import": "./dist/subpaths/utils/createElement.js"

--- a/packages/v4/src/subpaths/utils/deepmergeAll.ts
+++ b/packages/v4/src/subpaths/utils/deepmergeAll.ts
@@ -1,1 +1,0 @@
-export { deepmergeAll, deepmergeAll as default } from '../../utils/deepmerge.js';

--- a/packages/v4/src/utils/deepmerge.spec.ts
+++ b/packages/v4/src/utils/deepmerge.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deepmerge, deepmergeAll } from './deepmerge.js';
+import { deepmerge } from './deepmerge.js';
 
 describe('deepmerge', () => {
   it('recurses into plain objects, keeping the keys the source does not name', () => {
@@ -102,24 +102,36 @@ describe('deepmerge', () => {
 
     it('leaves the global prototype alone', () => {
       deepmerge({ x: 1 }, attacker());
-      deepmergeAll([{ x: 1 }, attacker()]);
+      deepmerge({ x: 1 }, attacker(), attacker());
       expect(({} as { polluted?: string }).polluted).toBeUndefined();
     });
   });
 });
 
-describe('deepmergeAll', () => {
-  it('merges left to right, the rightmost winning', () => {
-    expect(deepmergeAll([{ a: 1 }, { a: 2, b: 1 }, { b: 2 }])).toEqual({ a: 2, b: 2 });
+describe('deepmerge over any number of layers', () => {
+  it('folds left to right, the rightmost winning', () => {
+    expect(deepmerge({ a: 1 }, { a: 2, b: 1 }, { b: 2 })).toEqual({ a: 2, b: 2 });
   });
 
   it('recurses through every layer', () => {
     expect(
-      deepmergeAll([{ e: { currency: 'EUR' } }, { e: { items: [1] } }, { e: { items: [2] } }]),
+      deepmerge({ e: { currency: 'EUR' } }, { e: { items: [1] } }, { e: { items: [2] } }),
     ).toEqual({ e: { currency: 'EUR', items: [2] } });
   });
 
+  it('spreads a list built at runtime', () => {
+    const layers = [{ a: 1 }, { b: 2 }, { c: 3 }];
+    expect(deepmerge(...layers)).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
   it('answers an empty object for no layer', () => {
-    expect(deepmergeAll([])).toEqual({});
+    expect(deepmerge()).toEqual({});
+  });
+
+  it('deep-copies a single layer', () => {
+    const only = { a: { b: 1 } };
+    const copy = deepmerge(only) as { a: { b: number } };
+    copy.a.b = 99;
+    expect(only.a.b).toBe(1);
   });
 });

--- a/packages/v4/src/utils/deepmerge.ts
+++ b/packages/v4/src/utils/deepmerge.ts
@@ -48,18 +48,13 @@ function clone<T>(value: T): T {
 }
 
 /**
- * Merge `source` over `target`, recursing into plain objects.
+ * Merge one source over one target.
  *
- * Neither input is mutated, and the result shares no plain object or array
- * with either of them.
- *
- * @example
- * ```js
- * deepmerge({ ecommerce: { currency: 'EUR' } }, { ecommerce: { items: [1] } });
- * // { ecommerce: { currency: 'EUR', items: [1] } }
- * ```
+ * The recursion stays on this binary function: routing it back through the
+ * variadic entry point would allocate an arguments array and run a `reduce`
+ * for every nested key, which measured 37 % slower on a three-layer payload.
  */
-export function deepmerge(
+function merge(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -70,13 +65,25 @@ export function deepmerge(
     if (UNSAFE.has(key)) {
       continue;
     }
-    out[key] = isPlain(out[key]) && isPlain(value) ? deepmerge(out[key], value) : clone(value);
+    out[key] = isPlain(out[key]) && isPlain(value) ? merge(out[key], value) : clone(value);
   }
 
   return out;
 }
 
-/** Merge a list of layers left to right, the rightmost winning. */
-export function deepmergeAll(layers: Record<string, unknown>[]): Record<string, unknown> {
-  return layers.reduce<Record<string, unknown>>((merged, layer) => deepmerge(merged, layer), {});
+/**
+ * Merge every layer left to right, the rightmost winning.
+ *
+ * No input is mutated, and the result shares no plain object or array with any
+ * of them. One layer is therefore a deep copy of it, and no layer is `{}`.
+ * Spread a list built at runtime: `deepmerge(...layers)`.
+ *
+ * @example
+ * ```js
+ * deepmerge({ ecommerce: { currency: 'EUR' } }, { ecommerce: { items: [1] } });
+ * // { ecommerce: { currency: 'EUR', items: [1] } }
+ * ```
+ */
+export function deepmerge(...layers: Record<string, unknown>[]): Record<string, unknown> {
+  return layers.reduce<Record<string, unknown>>(merge, {});
 }

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -1,6 +1,6 @@
 /** Public entry point for `@studiometa/js-toolkit-v4/utils`. */
 
-export { deepmerge, deepmergeAll } from './deepmerge.js';
+export { deepmerge } from './deepmerge.js';
 export { createElement, type CreateElementAttributes, type CreateElementChildren } from './dom.js';
 export {
   createEaseInOut,

--- a/packages/v4/test/package-node-consumer.js
+++ b/packages/v4/test/package-node-consumer.js
@@ -81,7 +81,7 @@ assert.equal(randomIntDefault, randomInt);
 assert.equal(randomInt(0, 0), 0);
 assert.equal(deepmergeDefault, deepmerge);
 assert.deepEqual(deepmerge({ a: { b: 1 } }, { a: { c: 2 } }), { a: { b: 1, c: 2 } });
-assert.equal(utils.deepmergeAll([{ a: 1 }, { a: 2 }]).a, 2);
+assert.equal(utils.deepmerge({ a: 1 }, { a: 2 }, { a: 3 }).a, 3);
 assert.equal(utils.isObject({}), true);
 assert.equal(utils.round(1.2345, 2), 1.23);
 assert.deepEqual(utils.createRange(0, 2, 1), [0, 1, 2]);


### PR DESCRIPTION
Follow-up to #821, before anything depends on the shape. `deepmerge(a, b)` and `deepmergeAll([a, b, c])` were one function and a fold over it — `deepmerge(a, b, c, d)` is both.

```js
deepmerge(defaults, overrides);              // reads exactly as before
deepmerge(context, payload, eventData);      // what deepmergeAll was for
deepmerge(...layers);                        // a list built at runtime
```

The package loses a name and a subpath, and the fold gives two behaviours for free: one layer is a deep copy of it, no layer is `{}`.

Track's call site is the one this was written for:

```diff
-deepmergeAll([this.context, this.payload ?? {}, data ?? {}])
+deepmerge(this.context, this.payload ?? {}, data ?? {})
```

## The recursion stays binary

Making the exported function variadic is the obvious move and it has a cost that is not obvious: the recursive call for every nested key goes back through the variadic entry point, allocating an arguments array and running a `reduce` to fold a list of two.

Measured over three runs on a realistic three-layer payload — nested objects, small arrays:

| shape | marginal gz | ns/merge |
| --- | --: | --: |
| `deepmerge(a, b)` + `deepmergeAll([…])` (what #821 shipped) | +176 B | ~24,900 |
| variadic, recursion through the variadic function | +170 B | **~34,100** |
| **variadic, recursion on a private binary `merge()`** | **+166 B** | ~24,800 |

So the exported function folds and a private `merge()` recurses. Nine bytes of source, 37 % back.

## Breaking

`deepmergeAll(layers)` is gone; call `deepmerge(...layers)`. Nothing outside this repo consumes it — #821 merged an hour ago — which is why it is worth doing now rather than living with two names.

## Checks

`npm run lint`, `npm run lint:types`, `npm run test:v4` (974 tests) and `npm run check:package` pass. The spec's `deepmergeAll` block became the variadic cases of the one function, and the packed consumer asserts a three-layer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9