### PR TITLE
feat(v4): port getOffsetSizes, scrollTo and noop

### DIFF
--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -344,6 +344,10 @@
       "types": "./dist/subpaths/utils/createElement.d.ts",
       "import": "./dist/subpaths/utils/createElement.js"
     },
+    "./utils/getOffsetSizes": {
+      "types": "./dist/subpaths/utils/getOffsetSizes.d.ts",
+      "import": "./dist/subpaths/utils/getOffsetSizes.js"
+    },
     "./utils/createEaseInOut": {
       "types": "./dist/subpaths/utils/createEaseInOut.d.ts",
       "import": "./dist/subpaths/utils/createEaseInOut.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -592,6 +592,14 @@
       "types": "./dist/subpaths/utils/randomItem.d.ts",
       "import": "./dist/subpaths/utils/randomItem.js"
     },
+    "./utils/SCROLL_AXES": {
+      "types": "./dist/subpaths/utils/SCROLL_AXES.d.ts",
+      "import": "./dist/subpaths/utils/SCROLL_AXES.js"
+    },
+    "./utils/scrollTo": {
+      "types": "./dist/subpaths/utils/scrollTo.d.ts",
+      "import": "./dist/subpaths/utils/scrollTo.js"
+    },
     "./utils/selectorFor": {
       "types": "./dist/subpaths/utils/selectorFor.d.ts",
       "import": "./dist/subpaths/utils/selectorFor.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -580,6 +580,14 @@
       "types": "./dist/subpaths/utils/memo.d.ts",
       "import": "./dist/subpaths/utils/memo.js"
     },
+    "./utils/noop": {
+      "types": "./dist/subpaths/utils/noop.d.ts",
+      "import": "./dist/subpaths/utils/noop.js"
+    },
+    "./utils/noopValue": {
+      "types": "./dist/subpaths/utils/noopValue.d.ts",
+      "import": "./dist/subpaths/utils/noopValue.js"
+    },
     "./utils/random": {
       "types": "./dist/subpaths/utils/random.d.ts",
       "import": "./dist/subpaths/utils/random.js"

--- a/packages/v4/src/subpaths/utils/SCROLL_AXES.ts
+++ b/packages/v4/src/subpaths/utils/SCROLL_AXES.ts
@@ -1,0 +1,1 @@
+export { SCROLL_AXES, SCROLL_AXES as default } from '../../utils/scrollTo.js';

--- a/packages/v4/src/subpaths/utils/getOffsetSizes.ts
+++ b/packages/v4/src/subpaths/utils/getOffsetSizes.ts
@@ -1,0 +1,1 @@
+export { getOffsetSizes, getOffsetSizes as default } from '../../utils/dom.js';

--- a/packages/v4/src/subpaths/utils/noop.ts
+++ b/packages/v4/src/subpaths/utils/noop.ts
@@ -1,0 +1,1 @@
+export { noop, noop as default } from '../../utils/noop.js';

--- a/packages/v4/src/subpaths/utils/noopValue.ts
+++ b/packages/v4/src/subpaths/utils/noopValue.ts
@@ -1,0 +1,1 @@
+export { noopValue, noopValue as default } from '../../utils/noop.js';

--- a/packages/v4/src/subpaths/utils/scrollTo.ts
+++ b/packages/v4/src/subpaths/utils/scrollTo.ts
@@ -1,0 +1,1 @@
+export { scrollTo, scrollTo as default } from '../../utils/scrollTo.js';

--- a/packages/v4/src/utils/dom.spec.ts
+++ b/packages/v4/src/utils/dom.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { createElement } from './dom.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createElement, getOffsetSizes } from './dom.js';
 
 describe('createElement', () => {
   it('creates a div by default', () => {
@@ -44,5 +44,91 @@ describe('createElement', () => {
     expect(createElement('div', '<script>alert(1)</script>').innerHTML).toBe(
       '&lt;script&gt;alert(1)&lt;/script&gt;',
     );
+  });
+});
+
+describe('getOffsetSizes', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.removeAttribute('style');
+    window.scrollTo(0, 0);
+  });
+
+  /** Compare against the platform, which is right whenever no transform runs. */
+  function expectToMatchBoundingClientRect(element: HTMLElement) {
+    const { x, y, width, height, top, right, bottom, left } = element.getBoundingClientRect();
+    const sizes = getOffsetSizes(element);
+
+    for (const [key, value] of Object.entries({ x, y, width, height, top, right, bottom, left })) {
+      expect(sizes[key as keyof typeof sizes], key).toBeCloseTo(value, 5);
+    }
+  }
+
+  it('answers a detached element with zeroes', () => {
+    expect(getOffsetSizes(createElement())).toEqual({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+  });
+
+  it('matches getBoundingClientRect on a plain element', () => {
+    const element = createElement('div');
+    element.style.cssText = 'width: 100px; height: 50px; margin: 20px 0 0 30px;';
+    document.body.append(element);
+
+    expectToMatchBoundingClientRect(element);
+  });
+
+  it('matches getBoundingClientRect through positioned and bordered ancestors', () => {
+    const element = createElement('div');
+    element.style.cssText =
+      'width: 100px; height: 50px; position: absolute; top: 15px; left: 25px;';
+    const parent = createElement('div', [element]);
+    parent.style.cssText =
+      'position: relative; top: 40px; left: 10px; border: 7px solid; padding: 11px;';
+    document.body.append(parent);
+
+    expectToMatchBoundingClientRect(element);
+  });
+
+  it('accounts for the page scroll', () => {
+    const element = createElement('div');
+    element.style.cssText = 'width: 100px; height: 50px; margin-top: 3000px;';
+    document.body.append(element, createElement('div', ' '));
+    document.body.style.height = '5000px';
+    window.scrollTo(0, 800);
+
+    expect(window.scrollY).toBeGreaterThan(0);
+    expectToMatchBoundingClientRect(element);
+  });
+
+  it('accounts for the scroll of an ancestor with an overflow', () => {
+    const element = createElement('div');
+    element.style.cssText = 'width: 50px; height: 50px; margin: 400px 0 0 300px;';
+    const scroller = createElement('div', [element]);
+    scroller.style.cssText = 'width: 200px; height: 200px; overflow: auto; border: 4px solid;';
+    document.body.append(scroller);
+    scroller.scrollTo(120, 250);
+
+    expect(scroller.scrollTop).toBe(250);
+    expectToMatchBoundingClientRect(element);
+  });
+
+  it('ignores the transforms getBoundingClientRect applies', () => {
+    const element = createElement('div');
+    element.style.cssText = 'width: 100px; height: 50px; margin: 20px 0 0 30px;';
+    document.body.append(element);
+
+    const untransformed = getOffsetSizes(element);
+    element.style.transform = 'translateX(10px) rotate(45deg) scale(0.5)';
+
+    expect(getOffsetSizes(element)).toEqual(untransformed);
+    expect(element.getBoundingClientRect().left).not.toBeCloseTo(untransformed.left, 5);
   });
 });

--- a/packages/v4/src/utils/dom.ts
+++ b/packages/v4/src/utils/dom.ts
@@ -5,6 +5,8 @@ interface AnyHTMLElementTagNameMap extends HTMLElementTagNameMap {
   [key: string]: HTMLElement;
 }
 
+/** Element creation and element measurement, both element-level DOM helpers. */
+
 /** What an element can be given as content: markup-free text, nodes, or both. */
 export type CreateElementChildren = string | Node | Array<string | Node>;
 
@@ -66,4 +68,50 @@ export function createElement<T extends keyof AnyHTMLElementTagNameMap = 'div'>(
   }
 
   return element as AnyHTMLElementTagNameMap[T];
+}
+
+/** A `DOMRect`-shaped box, in the same viewport coordinates. */
+export interface OffsetSizes {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+/**
+ * Measure an element's box as layout placed it, with every transform on it and
+ * on its ancestors ignored — what `getBoundingClientRect()` would answer if
+ * nothing were transformed. Coordinates are the viewport's, as that method's.
+ *
+ * A pure read: the caller owns the phase it happens in.
+ */
+export function getOffsetSizes(element: HTMLElement): OffsetSizes {
+  let x = element.offsetLeft;
+  let y = element.offsetTop;
+  let offsetParent = element.offsetParent;
+
+  for (let node = element.parentElement; node; node = node.parentElement) {
+    // Every scrolling ancestor shifts the box, the document included: reading
+    // the chain covers the page scroll in standards and in quirks mode alike.
+    x -= node.scrollLeft;
+    y -= node.scrollTop;
+
+    if (node === offsetParent) {
+      // The offsets are relative to the offset parent's padding edge, and its
+      // own offsets place its border edge, so its border sits between the two.
+      const styles = getComputedStyle(node);
+      x += node.offsetLeft + Number.parseFloat(styles.borderLeftWidth);
+      y += node.offsetTop + Number.parseFloat(styles.borderTopWidth);
+      offsetParent = node.offsetParent;
+    }
+  }
+
+  const width = element.offsetWidth;
+  const height = element.offsetHeight;
+
+  return { x, y, width, height, top: y, right: x + width, bottom: y + height, left: x };
 }

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -8,6 +8,7 @@ import * as historyModule from './history.js';
 import * as is from './is.js';
 import * as maths from './maths.js';
 import * as memoModule from './memo.js';
+import * as noopModule from './noop.js';
 import * as randomModule from './random.js';
 import * as scrollToModule from './scrollTo.js';
 import * as selectors from './selectors.js';
@@ -29,6 +30,7 @@ describe('the utils barrel', () => {
       ...Object.keys(is),
       ...Object.keys(maths),
       ...Object.keys(memoModule),
+      ...Object.keys(noopModule),
       ...Object.keys(randomModule),
       ...Object.keys(scrollToModule),
       ...Object.keys(selectors),

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -9,6 +9,7 @@ import * as is from './is.js';
 import * as maths from './maths.js';
 import * as memoModule from './memo.js';
 import * as randomModule from './random.js';
+import * as scrollToModule from './scrollTo.js';
 import * as selectors from './selectors.js';
 import * as smoothToModule from './smoothTo.js';
 import * as strings from './strings.js';
@@ -29,6 +30,7 @@ describe('the utils barrel', () => {
       ...Object.keys(maths),
       ...Object.keys(memoModule),
       ...Object.keys(randomModule),
+      ...Object.keys(scrollToModule),
       ...Object.keys(selectors),
       ...Object.keys(smoothToModule),
       ...Object.keys(strings),

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -69,6 +69,14 @@ export {
 } from './maths.js';
 export { memo, type Memo } from './memo.js';
 export { random, randomInt, randomItem } from './random.js';
+export {
+  SCROLL_AXES,
+  scrollTo,
+  type ScrollAxis,
+  type ScrollPosition,
+  type ScrollToOptions,
+  type ScrollToTarget,
+} from './scrollTo.js';
 export { selectorFor } from './selectors.js';
 export { smoothTo, type SmoothTo, type SmoothToOptions } from './smoothTo.js';
 export {

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -68,6 +68,7 @@ export {
   type SpringOptions,
 } from './maths.js';
 export { memo, type Memo } from './memo.js';
+export { noop, noopValue } from './noop.js';
 export { random, randomInt, randomItem } from './random.js';
 export {
   SCROLL_AXES,

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -1,7 +1,13 @@
 /** Public entry point for `@studiometa/js-toolkit-v4/utils`. */
 
 export { deepmerge } from './deepmerge.js';
-export { createElement, type CreateElementAttributes, type CreateElementChildren } from './dom.js';
+export {
+  createElement,
+  getOffsetSizes,
+  type CreateElementAttributes,
+  type CreateElementChildren,
+  type OffsetSizes,
+} from './dom.js';
 export {
   createEaseInOut,
   createEaseOut,

--- a/packages/v4/src/utils/noop.spec.ts
+++ b/packages/v4/src/utils/noop.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { noop, noopValue } from './noop.js';
+
+describe('noop', () => {
+  it('returns undefined', () => {
+    expect(noop()).toBeUndefined();
+  });
+
+  it('takes the arguments of the callback it stands in for', () => {
+    const handler: (event: Event, index: number) => void = noop;
+    expect(handler(new Event('click'), 0)).toBeUndefined();
+  });
+});
+
+describe('noopValue', () => {
+  it('returns the very value it is given', () => {
+    const object = { a: 1 };
+    expect(noopValue(object)).toBe(object);
+    expect(noopValue('a')).toBe('a');
+    expect(noopValue(undefined)).toBeUndefined();
+  });
+
+  it('keeps the type of the value', () => {
+    const value: number = noopValue(1);
+    expect(value).toBe(1);
+  });
+});

--- a/packages/v4/src/utils/noop.ts
+++ b/packages/v4/src/utils/noop.ts
@@ -1,0 +1,9 @@
+/** Placeholders for an optional callback, so a caller never branches on one. */
+
+/** Do nothing, whatever it is called with. */
+export function noop(): void {}
+
+/** Return the value unaltered: the identity of a transform chain. */
+export function noopValue<T>(value: T): T {
+  return value;
+}

--- a/packages/v4/src/utils/scrollTo.spec.ts
+++ b/packages/v4/src/utils/scrollTo.spec.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cdp } from 'vitest/browser';
+import type {} from '@vitest/browser-playwright';
+import { createElement } from './dom.js';
+import { scrollTo, SCROLL_AXES } from './scrollTo.js';
+
+/** A page taller and wider than the viewport, with a target inside it. */
+function givenAScrollablePage(): HTMLElement {
+  const target = createElement('div');
+  target.style.cssText = 'width: 100px; height: 100px; margin: 2000px 0 0 1500px;';
+  target.id = 'target';
+  document.body.append(target);
+  document.body.style.cssText = 'margin: 0; width: 4000px; height: 5000px;';
+  return target;
+}
+
+/** A scrolling element with a border, and a target inside its content. */
+function givenAScrollingElement(): { root: HTMLElement; target: HTMLElement } {
+  const target = createElement('div');
+  target.style.cssText = 'width: 50px; height: 50px; margin: 600px 0 0 700px;';
+  const content = createElement('div', [target]);
+  // Room past the target, so a scroll to it is not cut short by the extents.
+  content.style.cssText = 'width: 3000px; height: 3000px;';
+  const root = createElement('div', [content]);
+  root.style.cssText = 'width: 200px; height: 200px; overflow: auto; border: 5px solid;';
+  document.body.append(root);
+  return { root, target };
+}
+
+afterEach(async () => {
+  document.body.innerHTML = '';
+  document.body.removeAttribute('style');
+  window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
+  await cdp().send('Emulation.setEmulatedMedia', { features: [] });
+});
+
+describe('scrollTo', () => {
+  it('scrolls the window to a distance, on the y axis by default', () => {
+    givenAScrollablePage();
+
+    expect(scrollTo(800, { behavior: 'instant' })).toEqual({ left: 0, top: 800 });
+    expect(window.scrollY).toBe(800);
+    expect(window.scrollX).toBe(0);
+  });
+
+  it('scrolls on the axis it is given', () => {
+    givenAScrollablePage();
+
+    expect(scrollTo(800, { axis: SCROLL_AXES.x, behavior: 'instant' })).toEqual({
+      left: 800,
+      top: 0,
+    });
+    expect(scrollTo(300, { axis: SCROLL_AXES.both, behavior: 'instant' })).toEqual({
+      left: 300,
+      top: 300,
+    });
+    expect(window.scrollX).toBe(300);
+    expect(window.scrollY).toBe(300);
+  });
+
+  it('lets a position object name its own axes, whatever the axis option', () => {
+    givenAScrollablePage();
+    scrollTo({ left: 400, top: 400 }, { axis: SCROLL_AXES.both, behavior: 'instant' });
+
+    // v3 dropped this `left` on the default y axis, which made an explicit
+    // request silently do nothing.
+    expect(scrollTo({ left: 900 }, { behavior: 'instant' })).toEqual({ left: 900, top: 400 });
+    expect(window.scrollX).toBe(900);
+    expect(window.scrollY).toBe(400);
+  });
+
+  it('scrolls to an element and to a selector alike', () => {
+    const target = givenAScrollablePage();
+    const expected = target.getBoundingClientRect().top;
+
+    expect(scrollTo(target, { behavior: 'instant' })).toEqual({ left: 0, top: expected });
+    window.scrollTo({ top: 0, behavior: 'instant' });
+    expect(scrollTo('#target', { behavior: 'instant' })).toEqual({ left: 0, top: expected });
+    expect(window.scrollY).toBe(expected);
+  });
+
+  it('stops short of the element by its scroll-margin', () => {
+    const target = givenAScrollablePage();
+    const withoutMargin = scrollTo(target, { behavior: 'instant' }).top;
+
+    window.scrollTo({ top: 0, behavior: 'instant' });
+    target.style.scrollMarginTop = '40px';
+
+    expect(scrollTo(target, { behavior: 'instant' }).top).toBe(withoutMargin - 40);
+  });
+
+  it('stops short of the target by the offset', () => {
+    givenAScrollablePage();
+
+    expect(scrollTo(1000, { offset: 100, behavior: 'instant' })).toEqual({ left: 0, top: 900 });
+    expect(scrollTo({ left: 1000, top: 1000 }, { offset: 100, behavior: 'instant' })).toEqual({
+      left: 900,
+      top: 900,
+    });
+  });
+
+  it('clamps to the scrollable range at both ends', () => {
+    givenAScrollablePage();
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+
+    expect(scrollTo(99999, { behavior: 'instant' })).toEqual({ left: 0, top: max });
+    // v3 clamped the far end only, so an offset past the start scrolled nowhere.
+    expect(scrollTo(50, { offset: 200, behavior: 'instant' })).toEqual({ left: 0, top: 0 });
+  });
+
+  it('is a no-op on a selector that matches nothing', () => {
+    givenAScrollablePage();
+    scrollTo(500, { behavior: 'instant' });
+
+    expect(scrollTo('#nothing-here')).toEqual({ left: 0, top: 500 });
+    expect(window.scrollY).toBe(500);
+  });
+
+  it('scrolls a root element, in its own content coordinates', () => {
+    const { root, target } = givenAScrollingElement();
+
+    // v3 read `scrollTop` as the left position and offset the target by the
+    // window scroll, so neither axis landed on an element inside a scroller.
+    expect(
+      scrollTo(target, { rootElement: root, axis: SCROLL_AXES.both, behavior: 'instant' }),
+    ).toEqual({ left: 700, top: 600 });
+    expect(root.scrollLeft).toBe(700);
+    expect(root.scrollTop).toBe(600);
+  });
+
+  it('clamps a root element to its own scrollable range', () => {
+    const { root } = givenAScrollingElement();
+    const max = root.scrollHeight - root.clientHeight;
+
+    expect(scrollTo(99999, { rootElement: root, behavior: 'instant' }).top).toBe(max);
+    expect(root.scrollTop).toBe(max);
+  });
+
+  it('asks for a smooth scroll by default', () => {
+    givenAScrollablePage();
+    const spy = vi.spyOn(window, 'scrollTo');
+
+    scrollTo(100);
+
+    expect(spy).toHaveBeenCalledWith({ left: 0, top: 100, behavior: 'smooth' });
+    spy.mockRestore();
+  });
+
+  it('asks for an instant scroll for a reader who turned motion down', async () => {
+    givenAScrollablePage();
+    await cdp().send('Emulation.setEmulatedMedia', {
+      features: [{ name: 'prefers-reduced-motion', value: 'reduce' }],
+    });
+    const spy = vi.spyOn(window, 'scrollTo');
+
+    scrollTo(100);
+
+    expect(spy).toHaveBeenCalledWith({ left: 0, top: 100, behavior: 'instant' });
+    spy.mockRestore();
+  });
+
+  it('reads the motion preference at every call, not once at load', async () => {
+    givenAScrollablePage();
+    const spy = vi.spyOn(window, 'scrollTo');
+
+    scrollTo(100);
+    await cdp().send('Emulation.setEmulatedMedia', {
+      features: [{ name: 'prefers-reduced-motion', value: 'reduce' }],
+    });
+    scrollTo(200);
+
+    expect(spy.mock.calls.map(([options]) => options)).toEqual([
+      { left: 0, top: 100, behavior: 'smooth' },
+      { left: 0, top: 200, behavior: 'instant' },
+    ]);
+    spy.mockRestore();
+  });
+
+  it('lets the caller override the behavior', () => {
+    givenAScrollablePage();
+    const spy = vi.spyOn(window, 'scrollTo');
+
+    scrollTo(100, { behavior: 'auto' });
+
+    expect(spy).toHaveBeenCalledWith({ left: 0, top: 100, behavior: 'auto' });
+    spy.mockRestore();
+  });
+});

--- a/packages/v4/src/utils/scrollTo.ts
+++ b/packages/v4/src/utils/scrollTo.ts
@@ -1,0 +1,157 @@
+import { usePrefersReducedMotion } from '../services/media.js';
+import { isNumber, isString } from './is.js';
+import { clamp } from './maths.js';
+
+/** Where a scroller stands on both axes, in pixels from the start. */
+export interface ScrollPosition {
+  left: number;
+  top: number;
+}
+
+/** What a scroll can be aimed at. */
+export type ScrollToTarget = string | Element | number | Partial<ScrollPosition>;
+
+/** The axes a scroll is allowed to move. */
+export const SCROLL_AXES = /* @__PURE__ */ Object.freeze({
+  x: 'x',
+  y: 'y',
+  both: 'both',
+} as const);
+
+export type ScrollAxis = (typeof SCROLL_AXES)[keyof typeof SCROLL_AXES];
+
+export interface ScrollToOptions {
+  /** What scrolls. Defaults to the window. */
+  rootElement?: Element | Window;
+  /** Which axes a target that names none may move. Defaults to `'y'`. */
+  axis?: ScrollAxis;
+  /** Pixels to stop short of the target. Defaults to `0`. */
+  offset?: number;
+  /** Defaults to `'smooth'`, or to `'instant'` when the reader asked for less motion. */
+  behavior?: ScrollBehavior;
+}
+
+function currentPositionOf(root: Element | Window): ScrollPosition {
+  return root instanceof Window
+    ? { left: root.scrollX, top: root.scrollY }
+    : { left: root.scrollLeft, top: root.scrollTop };
+}
+
+function maxPositionOf(root: Element | Window): ScrollPosition {
+  // The window scrolls the document, so its extents come from the scroller.
+  const scroller = root instanceof Window ? (document.scrollingElement ?? document.body) : root;
+  const [width, height] =
+    root instanceof Window
+      ? [root.innerWidth, root.innerHeight]
+      : [root.clientWidth, root.clientHeight];
+
+  return {
+    // Classic scrollbars and fractional zoom can make the difference negative.
+    left: Math.max(0, scroller.scrollWidth - width),
+    top: Math.max(0, scroller.scrollHeight - height),
+  };
+}
+
+function pixels(value: string): number {
+  return Number.parseFloat(value) || 0;
+}
+
+/**
+ * Where an element sits inside the root's scrolled content.
+ *
+ * `scroll-margin` is how a document asks to be stopped short of an element,
+ * and it is honored here as `scrollIntoView()` honors it.
+ */
+function positionOfElement(
+  element: Element,
+  root: Element | Window,
+  current: ScrollPosition,
+): ScrollPosition {
+  const rect = element.getBoundingClientRect();
+  const styles = getComputedStyle(element);
+  let left = rect.left + current.left - pixels(styles.scrollMarginLeft);
+  let top = rect.top + current.top - pixels(styles.scrollMarginTop);
+
+  if (!(root instanceof Window)) {
+    // A viewport coordinate is not a content coordinate for a scrolling
+    // element: subtract where its padding box starts, borders included.
+    const rootRect = root.getBoundingClientRect();
+    const rootStyles = getComputedStyle(root);
+    left -= rootRect.left + pixels(rootStyles.borderLeftWidth);
+    top -= rootRect.top + pixels(rootStyles.borderTopWidth);
+  }
+
+  return { left, top };
+}
+
+/** The axes the target asks for, `undefined` on an axis it leaves alone. */
+function requestedPosition(
+  target: ScrollToTarget,
+  root: Element | Window,
+  current: ScrollPosition,
+  axis: ScrollAxis,
+): Partial<ScrollPosition> | null {
+  // A position object names its own axes, so `axis` has nothing left to pick.
+  if (!isString(target) && !isNumber(target) && !(target instanceof Element)) {
+    return { left: target.left, top: target.top };
+  }
+
+  let position: ScrollPosition;
+
+  if (isNumber(target)) {
+    position = { left: target, top: target };
+  } else {
+    const element = isString(target) ? document.querySelector(target) : target;
+    if (!element) {
+      return null;
+    }
+    position = positionOfElement(element, root, current);
+  }
+
+  if (axis === SCROLL_AXES.x) {
+    return { left: position.left };
+  }
+  if (axis === SCROLL_AXES.y) {
+    return { top: position.top };
+  }
+  return position;
+}
+
+/**
+ * Scroll to an element, a selector, a distance or a position, and get the
+ * destination back. A target the document does not contain is a no-op.
+ *
+ * The browser owns the animation — this asks for it and returns. Smooth
+ * scrolling is the default and becomes instant for a reader who asked for less
+ * motion, which is read live rather than captured at load.
+ *
+ * @example
+ * ```js
+ * scrollTo('#section', { offset: 80 });
+ * scrollTo({ left: 0 }, { rootElement: carousel });
+ * ```
+ */
+export function scrollTo(target: ScrollToTarget, options: ScrollToOptions = {}): ScrollPosition {
+  const { rootElement = window, axis = SCROLL_AXES.y, offset = 0, behavior } = options;
+
+  const current = currentPositionOf(rootElement);
+  const requested = requestedPosition(target, rootElement, current, axis);
+
+  if (!requested) {
+    return current;
+  }
+
+  const max = maxPositionOf(rootElement);
+  const destination: ScrollPosition = {
+    left: requested.left === undefined ? current.left : clamp(requested.left - offset, 0, max.left),
+    top: requested.top === undefined ? current.top : clamp(requested.top - offset, 0, max.top),
+  };
+
+  rootElement.scrollTo({
+    ...destination,
+    // Reading the media query does not start the service.
+    behavior: behavior ?? (usePrefersReducedMotion().props().matches ? 'instant' : 'smooth'),
+  });
+
+  return destination;
+}


### PR DESCRIPTION
Ports three v3 utilities into v4, one commit each. All three are pure or read-only helpers; none owns a loop or schedules anything.

## What landed

| symbol | module | v3 source |
| --- | --- | --- |
| `getOffsetSizes`, `OffsetSizes` | `utils/dom.ts` | `utils/css/getOffsetSizes.ts` |
| `scrollTo`, `SCROLL_AXES`, `ScrollAxis`, `ScrollPosition`, `ScrollToOptions`, `ScrollToTarget` | `utils/scrollTo.ts` | `utils/scrollTo.ts` |
| `noop`, `noopValue` | `utils/noop.ts` | `utils/noop.ts` |

`getOffsetSizes` joins `dom.ts` rather than opening a CSS-geometry module: measuring an element and creating one are both element-level DOM helpers, and a module holding a single function would be a folder, not a layer.

## `scrollTo`: the animation goes to the browser

v3 ran a `tween()` on its own `requestAnimationFrame` loop, lerping the scroll position frame by frame with `behavior: 'instant'`. DESIGN §8 forbids this layer owning a loop, and rebuilding it on `useRaf()` + `toggle()` would only move the ownership around — re-implementing an easing the platform already ships so that the result looks like `behavior: 'smooth'`. **v4 computes the destination and hands it to `scrollTo({ behavior })`.**

What that buys beyond dropping the loop:

- The browser's smooth scroll is interruptible by the reader's own wheel and touch, which is exactly what v3's `wheel`/`touchmove` cancellation was hand-rolling.
- It composes with `scroll-snap`, which a frame-by-frame lerp fights.

**It respects `prefers-reduced-motion`.** The behavior defaults to `'smooth'` and becomes `'instant'` under `usePrefersReducedMotion()`, read per call rather than captured at load, because the preference changes while the page is open. This is not left to the user agent: whether a UA downgrades a *programmatic* smooth scroll is unspecified, so the utility asks explicitly. The spec asserts both states and the crossing between them through CDP media emulation, so the preference travels the real event path.

**It returns the destination synchronously instead of a promise.** Once the browser owns the animation it owns the completion too, and that is a scroll-service concern — `useScroll().isScrolling` already reports it, with a `scrollend` fallback for browsers that lack the event. A promise here would either hang whenever the browser declines to move as asked (unreachable target, snapping elsewhere) or need an arbitrary timeout, which is scheduling this layer must not own. Measured: the only real consumer in `@studiometa/ui`, `AnchorScrollTo`, discards v3's promise.

## Defects fixed rather than ported

Each has a regression test running in a real Chromium.

**`getOffsetSizes`** — the spec now compares every field against `getBoundingClientRect()` on an untransformed element, which is the assertion the v3 spec wanted and jsdom could not give it (its three cases all assert `0`, and one of them compares `sizes[key]` to itself).

- v3 subtracted `window.scrollX`/`scrollY` and nothing else, so an element inside a scrolled `overflow: auto` ancestor was reported at the position it had before that ancestor was scrolled. Reading `scrollLeft`/`scrollTop` off the whole ancestor chain covers intermediate scrollers and the page scroll in one pass — the document's scroll is the scrolling element's, in standards and in quirks mode alike.
- `offsetTop`/`offsetLeft` are measured from the offset parent's padding edge while the offset parent's own are measured to its border edge, so summing them straight up the chain loses one border width per positioned ancestor. Measured at **7px of error** through a single `border: 7px solid` parent; removing the compensation term fails the spec.

**`scrollTo`**

- Scrolling a root element read `scrollTop` as the left position and `scrollLeft` as the top (`getCurrentScrollPosition`, v3 lines 40–41), and placed the target with the *window* scroll, so an element inside an overflow container was never reached on either axis. It is now placed in the root's content coordinates, its border box included.
- Positions were clamped at the far end only, so `scrollTo(50, { offset: 200 })` asked for `-150` and went nowhere. Both ends are clamped now, and the extents use `clientWidth`/`clientHeight` rather than `offsetWidth`/`offsetHeight`, which count the border the scroll never reaches.
- `axis` silently dropped an explicit `{ left }` on the default `y` axis, except for one special case (`!isDefined(target.left)`) that made the rule unguessable. A position object now names its own axes, and `axis` picks them only for the targets that name none.

## Other API changes versus v3

- `scrollTo.axis` symbols become the frozen `SCROLL_AXES` object with a derived `ScrollAxis` type. A `Symbol` cannot be written in an attribute or a JSON config, which a data-attribute framework needs.
- `rootElement` and element targets widen from `HTMLElement` to `Element`, so SVG and any scroll container qualify.
- `scroll-margin` is read with `parseFloat` rather than `parseInt`, so a sub-pixel margin is no longer truncated.
- `noop` gains an explicit `void` return type, and the `@return {void}` tags go — the signature says it.

## Verification

`npm run lint`, `npm run lint:types`, `npm run test:v4` and `packages/v4 → npm run check:package` are green on **each** of the three commits. The v4 suite is **74 files / 998 tests passing**, 18 of them new. `npm run subpaths` regenerated five stubs (`getOffsetSizes`, `scrollTo`, `SCROLL_AXES`, `noop`, `noopValue`) and the `exports` map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9
