### PR TITLE
feat(v4): port the resource loading helpers

### DIFF
--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -496,6 +496,18 @@
       "types": "./dist/subpaths/utils/isString.d.ts",
       "import": "./dist/subpaths/utils/isString.js"
     },
+    "./utils/loadImage": {
+      "types": "./dist/subpaths/utils/loadImage.d.ts",
+      "import": "./dist/subpaths/utils/loadImage.js"
+    },
+    "./utils/loadLink": {
+      "types": "./dist/subpaths/utils/loadLink.d.ts",
+      "import": "./dist/subpaths/utils/loadLink.js"
+    },
+    "./utils/loadScript": {
+      "types": "./dist/subpaths/utils/loadScript.d.ts",
+      "import": "./dist/subpaths/utils/loadScript.js"
+    },
     "./utils/clamp": {
       "types": "./dist/subpaths/utils/clamp.d.ts",
       "import": "./dist/subpaths/utils/clamp.js"

--- a/packages/v4/src/subpaths/utils/loadImage.ts
+++ b/packages/v4/src/subpaths/utils/loadImage.ts
@@ -1,0 +1,1 @@
+export { loadImage, loadImage as default } from '../../utils/load.js';

--- a/packages/v4/src/subpaths/utils/loadLink.ts
+++ b/packages/v4/src/subpaths/utils/loadLink.ts
@@ -1,0 +1,1 @@
+export { loadLink, loadLink as default } from '../../utils/load.js';

--- a/packages/v4/src/subpaths/utils/loadScript.ts
+++ b/packages/v4/src/subpaths/utils/loadScript.ts
@@ -1,0 +1,1 @@
+export { loadScript, loadScript as default } from '../../utils/load.js';

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -6,6 +6,7 @@ import * as easings from './easings.js';
 import * as focus from './focus.js';
 import * as historyModule from './history.js';
 import * as is from './is.js';
+import * as load from './load.js';
 import * as maths from './maths.js';
 import * as memoModule from './memo.js';
 import * as noopModule from './noop.js';
@@ -28,6 +29,7 @@ describe('the utils barrel', () => {
       ...Object.keys(focus),
       ...Object.keys(historyModule),
       ...Object.keys(is),
+      ...Object.keys(load),
       ...Object.keys(maths),
       ...Object.keys(memoModule),
       ...Object.keys(noopModule),

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -44,6 +44,7 @@ export {
   type SearchParamInput,
 } from './history.js';
 export { isBoolean, isDefined, isFunction, isNull, isNumber, isObject, isString } from './is.js';
+export { loadImage, loadLink, loadScript } from './load.js';
 export {
   clamp,
   clamp01,

--- a/packages/v4/src/utils/load.spec.ts
+++ b/packages/v4/src/utils/load.spec.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadImage, loadLink, loadScript } from './load.js';
+
+/** A 1×1 transparent GIF, so nothing here needs the network. */
+const PIXEL = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+/** Well-formed as a URL, not decodable as an image. */
+const BROKEN_IMAGE = 'data:image/gif;base64,bm90LWEtZ2lm';
+
+const decodeDescriptor = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'decode');
+
+/** Replace `decode()` for one test, and put the real one back after it. */
+function mockDecode(implementation: undefined | (() => Promise<void>)): void {
+  Object.defineProperty(HTMLImageElement.prototype, 'decode', {
+    configurable: true,
+    writable: true,
+    value: implementation,
+  });
+}
+
+let counter = 0;
+
+/** A unique URL per call, so the deduplication maps never leak between tests. */
+function uniqueScript(body = ''): string {
+  counter += 1;
+  return `data:text/javascript,${encodeURIComponent(`globalThis.__load = ${counter};${body}`)}`;
+}
+
+function uniqueStylesheet(): string {
+  counter += 1;
+  return `data:text/css,${encodeURIComponent(`.load-${counter} { color: red }`)}`;
+}
+
+afterEach(() => {
+  if (decodeDescriptor) {
+    Object.defineProperty(HTMLImageElement.prototype, 'decode', decodeDescriptor);
+  }
+  for (const element of document.head.querySelectorAll('script[src^="data:"], link')) {
+    element.remove();
+  }
+});
+
+describe('loadImage', () => {
+  it('resolves with the loaded element', async () => {
+    const image = await loadImage(PIXEL);
+
+    expect(image).toBeInstanceOf(HTMLImageElement);
+    expect(image.src).toBe(PIXEL);
+    expect(image.naturalWidth).toBe(1);
+    expect(image.naturalHeight).toBe(1);
+  });
+
+  it('never touches the document', async () => {
+    const image = await loadImage(PIXEL);
+
+    expect(image.isConnected).toBe(false);
+    expect(document.querySelector('img')).toBe(null);
+  });
+
+  it('rejects with an Error naming the source', async () => {
+    const promise = loadImage(BROKEN_IMAGE);
+
+    await expect(promise).rejects.toBeInstanceOf(Error);
+    await expect(promise).rejects.toThrowError(`Failed to load "${BROKEN_IMAGE}".`);
+    await expect(promise).rejects.toHaveProperty('cause', expect.any(Event));
+  });
+
+  it('waits for decode() to resolve before it resolves', async () => {
+    let decoded = false;
+    const decode = decodeDescriptor?.value as () => Promise<void>;
+
+    mockDecode(async function mockedDecode(this: HTMLImageElement) {
+      await decode.call(this);
+      decoded = true;
+    });
+
+    await loadImage(PIXEL);
+
+    expect(decoded).toBe(true);
+  });
+
+  it('falls back to the events when decode() rejects on an image that loads', async () => {
+    // What some cross-origin images do in Safari: `decode()` rejects with an
+    // `EncodingError` while the load itself works.
+    mockDecode(() => Promise.reject(new DOMException('mocked', 'EncodingError')));
+
+    const image = await loadImage(PIXEL);
+
+    expect(image.naturalWidth).toBe(1);
+  });
+
+  it('still rejects on a real failure when decode() rejects', async () => {
+    mockDecode(() => Promise.reject(new DOMException('mocked', 'EncodingError')));
+
+    await expect(loadImage(BROKEN_IMAGE)).rejects.toThrowError(`Failed to load "${BROKEN_IMAGE}".`);
+  });
+
+  it('falls back to the events when decode() is unavailable', async () => {
+    mockDecode(undefined);
+
+    const image = await loadImage(PIXEL);
+
+    expect(image.naturalWidth).toBe(1);
+    await expect(loadImage(BROKEN_IMAGE)).rejects.toThrowError('Failed to load');
+  });
+});
+
+describe('loadScript', () => {
+  it('appends the script to the head and resolves with it', async () => {
+    const src = uniqueScript();
+    const script = await loadScript(src);
+
+    expect(script).toBeInstanceOf(HTMLScriptElement);
+    expect(script.parentElement).toBe(document.head);
+    expect(script.src).toBe(src);
+  });
+
+  it('sets the given attributes', async () => {
+    const script = await loadScript(uniqueScript(), { type: 'module', 'data-foo': 'bar' });
+
+    expect(script.type).toBe('module');
+    expect(script.dataset.foo).toBe('bar');
+  });
+
+  it('deduplicates by resolved URL: one element, one execution', async () => {
+    const src = uniqueScript('globalThis.__loadRuns = (globalThis.__loadRuns ?? 0) + 1;');
+
+    const first = loadScript(src);
+    const second = loadScript(src);
+
+    expect(second).toBe(first);
+    await Promise.all([first, second]);
+
+    expect(
+      [...document.head.querySelectorAll('script')].filter((el) => el.src === src),
+    ).toHaveLength(1);
+    expect((globalThis as Record<string, unknown>).__loadRuns).toBe(1);
+
+    // A third call after the load still hands back the settled promise.
+    expect(loadScript(src)).toBe(first);
+  });
+
+  it('rejects with an Error naming the source, and allows a retry', async () => {
+    const src = '/__does-not-exist__/load.spec.js';
+    const first = loadScript(src);
+
+    await expect(first).rejects.toThrowError(`Failed to load "${src}".`);
+    expect(document.head.querySelector(`script[src="${src}"]`)).toBe(null);
+
+    // The failure is forgotten, so this is a new attempt rather than the
+    // rejection the first call stored.
+    const retried = loadScript(src);
+    expect(retried).not.toBe(first);
+    await expect(retried).rejects.toThrowError(`Failed to load "${src}".`);
+  });
+});
+
+describe('loadLink', () => {
+  it('appends the link to the head and resolves with it', async () => {
+    const href = uniqueStylesheet();
+    const link = await loadLink(href, { rel: 'stylesheet' });
+
+    expect(link).toBeInstanceOf(HTMLLinkElement);
+    expect(link.parentElement).toBe(document.head);
+    expect(link.rel).toBe('stylesheet');
+    expect(link.href).toBe(href);
+  });
+
+  it('deduplicates one rel on one href', async () => {
+    const href = uniqueStylesheet();
+
+    const first = loadLink(href, { rel: 'stylesheet' });
+    expect(loadLink(href, { rel: 'stylesheet' })).toBe(first);
+
+    await first;
+    expect(
+      [...document.head.querySelectorAll('link')].filter((el) => el.href === href),
+    ).toHaveLength(1);
+  });
+
+  it('keys on the rel too, so two intents on one href both happen', async () => {
+    const href = uniqueStylesheet();
+
+    const stylesheet = loadLink(href, { rel: 'stylesheet' });
+    const prefetch = loadLink(href, { rel: 'prefetch' });
+
+    expect(prefetch).not.toBe(stylesheet);
+
+    // A prefetch of a `data:` URL may settle either way, or not at all.
+    prefetch.catch(() => {});
+    await stylesheet;
+
+    const links = [...document.head.querySelectorAll('link')].filter((el) => el.href === href);
+    expect(links).toHaveLength(2);
+    expect(links.map((link) => link.rel).sort()).toEqual(['prefetch', 'stylesheet']);
+  });
+
+  it('sets the given attributes', async () => {
+    const href = uniqueStylesheet();
+    const link = await loadLink(href, { rel: 'stylesheet', media: 'print', title: 'themed' });
+
+    expect(link.media).toBe('print');
+    expect(link.title).toBe('themed');
+  });
+
+  it('resolves at once on a rel the browser ignores, instead of hanging', async () => {
+    const href = uniqueStylesheet();
+    const relList = document.createElement('link').relList;
+
+    expect(relList.supports('studiometa-nonsense')).toBe(false);
+
+    let settled = false;
+    const promise = loadLink(href, { rel: 'studiometa-nonsense' }).then((link) => {
+      settled = true;
+      return link;
+    });
+
+    // One microtask is all it may take: no event is coming.
+    const link = await promise;
+
+    expect(settled).toBe(true);
+    expect(link.rel).toBe('studiometa-nonsense');
+    expect(link.parentElement).toBe(document.head);
+  });
+
+  it('rejects with an Error naming the href', async () => {
+    const href = '/__does-not-exist__/load.spec.css';
+
+    await expect(loadLink(href, { rel: 'stylesheet' })).rejects.toThrowError(
+      `Failed to load "${href}".`,
+    );
+  });
+});

--- a/packages/v4/src/utils/load.ts
+++ b/packages/v4/src/utils/load.ts
@@ -1,0 +1,194 @@
+/** Loading a resource, as a promise that settles when the browser is done with it. */
+
+import { getSharedRuntimeSlot } from '../shared-runtime.js';
+
+/**
+ * The pending loads for the elements that go in `<head>`, keyed by the URL the
+ * browser will actually request — and by the `rel` too, for a link.
+ *
+ * Two evaluated copies of the package share them: appending an embed twice
+ * executes a third-party script twice, which the deduplication exists to
+ * prevent, so a module-level map would not be enough.
+ */
+const state = /* @__PURE__ */ getSharedRuntimeSlot('load', 1, () => ({
+  scripts: new Map<string, Promise<HTMLScriptElement>>(),
+  links: new Map<string, Promise<HTMLLinkElement>>(),
+}));
+
+/** What the browser will request, which is what two calls share or do not. */
+function resolveUrl(src: string): string {
+  return new URL(src, location.href).href;
+}
+
+/**
+ * A real `Error`, so a reporter has a message and `catch` blocks can read one.
+ * The load and error events carry no reason, hence the source in the message
+ * and the event as the cause.
+ */
+function loadingFailed(src: string, event: Event): Error {
+  return new Error(`Failed to load "${src}".`, { cause: event });
+}
+
+function setAttributes(element: Element, attributes: Record<string, string>): void {
+  for (const [name, value] of Object.entries(attributes)) {
+    element.setAttribute(name, value);
+  }
+}
+
+/**
+ * Forget a failed load, so a later call can try again — a network blip must not
+ * make a URL unloadable for the life of the page. Guarded by identity: only the
+ * entry this load owns is dropped.
+ */
+function forget<T>(map: Map<string, Promise<T>>, key: string, owner: Promise<T>): void {
+  if (map.get(key) === owner) {
+    map.delete(key);
+  }
+}
+
+/**
+ * Will the browser act on this `rel`? A `<link>` it ignores fires no event at
+ * all, so this is the difference between a promise and a leak.
+ */
+function relIsSupported(rel: string): boolean {
+  const { relList } = document.createElement('link');
+  // `supports()` throws on an empty token, and a `rel` may hold several.
+  return rel.split(/\s+/).some((token) => token !== '' && relList.supports(token));
+}
+
+/**
+ * Load an image, resolved once its bitmap is decoded.
+ *
+ * The element is detached and stays that way: this preloads a URL, it does not
+ * put an image on the page. Awaiting `decode()` rather than the load event is
+ * the point — assigning the URL to a visible `<img>` afterwards paints in the
+ * same frame instead of janking the one after it. The element comes back for
+ * its `naturalWidth`/`naturalHeight`.
+ *
+ * Nothing is deduplicated here: the HTTP cache already does it, and a detached
+ * element costs nothing to build.
+ */
+export async function loadImage(src: string): Promise<HTMLImageElement> {
+  const image = new Image();
+
+  const settled = new Promise<void>((resolve, reject) => {
+    image.addEventListener('load', () => resolve(), { once: true });
+    image.addEventListener('error', (event) => reject(loadingFailed(src, event)), { once: true });
+  });
+
+  image.src = src;
+
+  if (typeof image.decode === 'function') {
+    try {
+      await image.decode();
+      return image;
+    } catch {
+      // A rejection is not proof of failure: some cross-origin images reject
+      // with an `EncodingError` and load perfectly. The events are the
+      // authority on whether the load worked, so fall through to them.
+    }
+  }
+
+  await settled;
+  return image;
+}
+
+/**
+ * Load a script, appended to `<head>`.
+ *
+ * There is no target option: a detached `<script>` never runs. Calls are
+ * deduplicated by resolved URL, so asking twice for one embed returns the very
+ * same promise and executes the third-party code once. A failed load is
+ * forgotten, so it can be retried.
+ */
+export function loadScript(
+  src: string,
+  attributes: Record<string, string> = {},
+): Promise<HTMLScriptElement> {
+  const url = resolveUrl(src);
+  const pending = state.scripts.get(url);
+
+  if (pending) {
+    return pending;
+  }
+
+  const promise = new Promise<HTMLScriptElement>((resolve, reject) => {
+    const script = document.createElement('script');
+    setAttributes(script, attributes);
+    script.addEventListener('load', () => resolve(script), { once: true });
+    script.addEventListener(
+      'error',
+      (event) => {
+        forget(state.scripts, url, promise);
+        script.remove();
+        reject(loadingFailed(src, event));
+      },
+      { once: true },
+    );
+    script.src = src;
+    document.head.append(script);
+  });
+
+  state.scripts.set(url, promise);
+
+  return promise;
+}
+
+/**
+ * Load a `<link>`, appended to `<head>`.
+ *
+ * `rel` is required because a `<link>` without one is inert and would never
+ * settle. It is also part of the deduplication key, next to the resolved URL:
+ * prefetching a URL and loading it as a stylesheet are two intents on one
+ * href, and both must happen.
+ *
+ * **A `rel` the browser ignores resolves at once.** `relList.supports()`
+ * answers whether the browser will act on it — Safari ignores `prefetch`
+ * entirely — and a hint is best-effort, so an ignored one is a resolved
+ * promise over an inert element rather than a promise waiting forever for an
+ * event that will never fire. The element is appended either way.
+ */
+export function loadLink(
+  href: string,
+  attributes: { rel: string } & Record<string, string>,
+): Promise<HTMLLinkElement> {
+  const { rel } = attributes;
+  // A NUL cannot appear in a URL, so no `rel` can forge another one's key.
+  const key = `${rel}\u0000${resolveUrl(href)}`;
+  const pending = state.links.get(key);
+
+  if (pending) {
+    return pending;
+  }
+
+  const supported = relIsSupported(rel);
+
+  const promise = new Promise<HTMLLinkElement>((resolve, reject) => {
+    const link = document.createElement('link');
+    setAttributes(link, attributes);
+
+    if (supported) {
+      link.addEventListener('load', () => resolve(link), { once: true });
+      link.addEventListener(
+        'error',
+        (event) => {
+          forget(state.links, key, promise);
+          link.remove();
+          reject(loadingFailed(href, event));
+        },
+        { once: true },
+      );
+    }
+
+    link.href = href;
+    document.head.append(link);
+
+    if (!supported) {
+      resolve(link);
+    }
+  });
+
+  state.links.set(key, promise);
+
+  return promise;
+}


### PR DESCRIPTION
Ports v3's resource-loading helpers to v4, redesigned. One module, `packages/v4/src/utils/load.ts`, three functions:

```ts
loadImage(src: string): Promise<HTMLImageElement>
loadScript(src: string, attributes?: Record<string, string>): Promise<HTMLScriptElement>
loadLink(href: string, attributes: { rel: string } & Record<string, string>): Promise<HTMLLinkElement>
```

## The six v3 defects this fixes

1. **A rejection that carried no message.** v3 rejected with a plain `{ event, element }` object, so `catch (error) { error.message }` was `undefined` and error reporters dropped the failure entirely. Every rejection is now ``new Error(`Failed to load "${src}".`, { cause: event })`` — a real `Error`, naming the source, with the event kept as the cause.
2. **An image was ready before it was ready.** v3 resolved on the `load` event, which fires before the bitmap is decoded, so assigning the URL to a visible `<img>` decoded on the main thread and janked the next frame. `loadImage` awaits **`decode()`** instead.
3. **`loadScript` executed a third-party embed once per call.** Nothing deduplicated: two components asking for the same maps/analytics/player SDK appended two `<script>` elements and ran it twice. `loadScript` and `loadLink` now deduplicate on the resolved URL (`new URL(src, location.href).href`) and hand back the very same promise. The maps live in a **shared runtime slot** (`getSharedRuntimeSlot('load', …)`, the pattern `storage/providers.ts` and `utils/focus.ts` use), so two evaluated copies of the package cannot double-execute an embed either.
4. **`loadLink` could never settle.** `loadLink(src)` set only `href`; a `<link>` with no `rel` is inert and fires no event, so the promise hung forever. `rel` is now required by the type.
5. **A `<link>` in a browser that ignores its `rel` leaked the same way.** Safari ignores `prefetch` entirely — no load event, ever. `loadLink` asks `relList.supports(rel)` first (see below).
6. **`loadImage` had a pointless `appendTo`, `loadScript` a dangerous one.** v3's one generic took `{ appendTo }` for all six element types: an image never needs the document, and a script or a link put anywhere but `<head>` is either inert or a bug. The option is gone; `loadImage` never touches the document, `loadScript`/`loadLink` always append to `<head>`.

## `decode()`, measured in real Chromium

`decode()` **cannot be trusted alone as a failure signal**, which the specs prove rather than assume. Removing the events fallback makes three specs fail, including the plain "a broken image rejects" one: for `data:image/gif;base64,bm90LWEtZ2lm`, Chromium's `decode()` rejects with a raw `EncodingError` `DOMException`, which would have escaped as the caller's error — the same shape Safari produces on cross-origin images that **load perfectly**. The two are indistinguishable from the rejection.

So the load/error events are the authority and `decode()` is only ever the fast path:

```js
image.src = src;

if (typeof image.decode === 'function') {
  try {
    await image.decode();
    return image;
  } catch {
    // Not proof of failure. Fall through to the events.
  }
}

await settled; // resolves on `load`, rejects with the Error on `error`
return image;
```

A rejected `decode()` on an image that did load falls through to an already-resolved `settled`; a rejected `decode()` on a genuine failure falls through to the real `Error`. The same path covers a browser with no `decode()` at all. Three specs cover the three cases, plus one that wraps the real `decode()` to assert the promise does not resolve before it does.

## An unsupported `rel` resolves at once

`document.createElement('link').relList.supports(rel)` answers whether the browser will act on a `rel`. When it will not, the element is still appended and the promise **resolves immediately** with it — a hint is best-effort, and waiting for an event that is never coming is a leak, not caution. This is the owner's leaning, and it is documented in the JSDoc. The spec asserts it; with the check removed, that spec fails on a 15-second timeout, which is exactly the leak.

Multi-token `rel` values are supported (`supports()` throws on an empty token, so tokens are split and any supported one counts).

## The four `@studiometa/ui` `loadImage` call sites

All four `await loadImage(src)` then assign the URL, and use nothing from the return value. They translate with **no change but the import**, and each one silently gains the decode:

| File | v3 | v4 |
| --- | --- | --- |
| `Figure/AbstractFigure.ts:86` | `try { await loadImage(src) } catch { … }` | identical — and `this.src = src` now paints without a decode on the main thread |
| `Figure/AbstractFigureDynamic.ts:67` | `try { await loadImage(original) } catch { … }` | identical |
| `FigureVideo/FigureVideo.ts:70` | `loadImage(poster).then(() => …).catch(() => …)` | identical |
| `FigureVideo/FigureVideoTwicpics.ts:124` | `loadImage(twicPoster).then(() => …).catch(() => …)` | identical |

The one behaviour change they see: their `catch` blocks now receive an `Error` with a message instead of `{ event, element }`. All four discard the argument and log their own message, so nothing breaks — and anything that did read `error.message` starts working.

`Prefetch/AbstractPrefetch.ts` is the other consumer this unblocks: it hand-rolls `document.createElement('link')`, `rel = 'prefetch'`, a static `Set` of prefetched URLs and a `load` listener. That is `loadLink(url.href, { rel: 'prefetch' })` — with the dedup shared across evaluated copies rather than per class, and no hang in Safari.

## Deliberately dropped

`loadIframe`, `loadEmbed`, `loadTrack` and the generic `loadElement` are **not ported**. Zero consumers across `@studiometa/ui`, and an `<iframe>` you want in the page you write in markup rather than build in JavaScript. The generic is what forced every helper to share one wrong set of rules in the first place.

## One judgement call worth flagging

**A failed load is forgotten**, so a later call retries instead of replaying a stored rejection — a network blip must not make a URL unloadable for the life of the page. The failed element is removed from `<head>` too. The eviction happens inside the error listener, before `reject()`, so no `.catch()` is attached internally and an unhandled rejection still surfaces to the console. Spec: `rejects with an Error naming the source, and allows a retry`.

## Verification

`npm run lint`, `npm run lint:types`, `npm run test:v4` (**991 tests, 73 files, all passing**) and `packages/v4 → npm run check:package` are green on each of the two commits. The 17 new specs run in real Chromium under vitest browser mode and touch **no network**: data URIs for the successes, a same-origin 404 for the failures.

Three mutations were run against the implementation to confirm the specs bite: dropping the `decode()` fallback fails 3, dropping `rel` from the dedup key fails 1, and always waiting for a load event fails 1 on a timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9
