### PR TITLE
Settle whether @component() needs to copy the inherited config

### DIFF
--- a/packages/v4/src/decorators.spec.ts
+++ b/packages/v4/src/decorators.spec.ts
@@ -1,17 +1,20 @@
 import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import {
   Base,
+  type BaseConfig,
   type ChildrenCollection,
   type ComponentImporter,
   type DelegatedEvent,
   type GlobalEvent,
   type RefEvent,
+  resolveConfig,
 } from './Base.js';
+import { isBaseConstructor } from './component-brand.js';
 import { createContext, signal, type Signal } from './context.js';
 import { children, component, inject, on, provide, read, write } from './decorators.js';
 import { registerComponents } from './registry.js';
 import { defaultScheduler } from './scheduler.js';
-import { getInstance, resetDom, settle } from './test-utils.js';
+import { getInstance, resetDom, settle, TodoItem } from './test-utils.js';
 
 const DecoContext = createContext<Signal<number>>('deco-context');
 
@@ -288,6 +291,105 @@ describe('@component', () => {
     const root = render();
     await settle();
     expect(getInstance(root, 'DecoParent').$isMounted).toBe(true);
+  });
+
+  /**
+   * The decorator writes `{ ...value.config, ...config }`, so a class with no
+   * own `config` copies its parent's keys down before adding its own. None of
+   * those copied keys reach the merged config on their own: `resolveConfig()`
+   * walks the chain and merges the same values from the parent's own config.
+   */
+  it('copies no value into the merged config that resolveConfig does not merge', () => {
+    class CopyParent extends Base {
+      static config: BaseConfig = {
+        name: 'CopyParent',
+        refs: ['handle'],
+        options: { one: String },
+        components: { TodoItem },
+        mountStrategy: 'visible',
+      };
+    }
+
+    const added: BaseConfig = { name: 'CopyChild', refs: ['extra'], options: { two: String } };
+
+    /** The own config the decorator writes today. */
+    class WithCopy extends CopyParent {
+      static config: BaseConfig = { ...CopyParent.config, ...added };
+    }
+
+    /** The own config it would write without the copy. */
+    class WithoutCopy extends CopyParent {
+      static config: BaseConfig = added;
+    }
+
+    expect(resolveConfig(WithCopy)).toEqual(resolveConfig(WithoutCopy));
+    expect(resolveConfig(WithCopy)).toMatchObject({
+      name: 'CopyChild',
+      refs: ['handle', 'extra'],
+      mountStrategy: 'visible',
+    });
+  });
+
+  /**
+   * What the copy is for. `isBaseConstructor()` reads `config.name` straight
+   * off the class — it cannot call `resolveConfig()`, which lives in `Base` and
+   * imports the brand. A class with no own `config` passes because it reads its
+   * parent's; a decorated one only passes because the decorator carried the
+   * inherited name into the config it wrote. Untyped sources reach this by
+   * extending a component and adding config without renaming, the case #823
+   * made register under the inherited name.
+   */
+  it('keeps a class whose config omits a name recognisable as a component', () => {
+    @component({ name: 'BrandParent' })
+    class BrandParent extends Base {}
+
+    // Registering under the inherited name collides with the parent, which is
+    // the loud first-wins path and not what this spec is about.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // @ts-expect-error `name` is missing, as it is in untyped sources.
+    @component({ options: { extra: Boolean } })
+    class BrandChild extends BrandParent {}
+    warn.mockRestore();
+
+    expect(BrandChild.config.name).toBe('BrandParent');
+    // Consumed by `config.components` entries, `@on(Class, type)` and the lazy
+    // import resolution: all three reject a class the brand check refuses.
+    expect(isBaseConstructor(BrandChild)).toBe(true);
+    expect(() => on(BrandChild, 'ping')).not.toThrow();
+  });
+
+  it('writes an own config and leaves the parent object untouched', () => {
+    @component({ name: 'OwnParent', refs: ['a'] })
+    class OwnParent extends Base {}
+    const parentConfig = OwnParent.config;
+
+    @component({ name: 'OwnChild', refs: ['b'] })
+    class OwnChild extends OwnParent {}
+
+    expect(Object.hasOwn(OwnChild, 'config')).toBe(true);
+    expect(OwnChild.config).not.toBe(parentConfig);
+    expect(parentConfig).toEqual({ name: 'OwnParent', refs: ['a'] });
+
+    // An undecorated subclass reads the parent object by identity. Nothing
+    // mutates a `config` in place, so the sharing is safe.
+    class OwnGrandChild extends OwnChild {}
+    expect(OwnGrandChild.config).toBe(OwnChild.config);
+    expect(resolveConfig(OwnGrandChild).name).toBe('OwnChild');
+  });
+
+  /**
+   * Declaring both is a mistake, but pin which one wins: static field
+   * initializers run after class decorators, so the field replaces everything
+   * the decorator wrote — `fromDecorator` never reaches the merged config.
+   */
+  it('is overwritten by a static config field on the same class', () => {
+    @component({ name: 'FieldWins', options: { fromDecorator: Boolean } })
+    class FieldWins extends Base {
+      static config: BaseConfig = { name: 'FieldWinsStatic' };
+    }
+
+    expect(FieldWins.config).toEqual({ name: 'FieldWinsStatic' });
+    expect(resolveConfig(FieldWins).options).toEqual({});
   });
 });
 

--- a/packages/v4/src/decorators.ts
+++ b/packages/v4/src/decorators.ts
@@ -173,6 +173,14 @@ export function component(config: BaseConfig) {
     value: T,
     context: ClassDecoratorContext<T>,
   ): void {
+    // Copying the inherited config adds nothing to the merged one —
+    // `resolveConfig()` walks the prototype chain — but `isBaseConstructor()`
+    // reads `config.name` straight off the class, and cannot call
+    // `resolveConfig()` because `Base` imports the brand. A config written
+    // without a name, as an untyped subclass adding config to its parent's
+    // does, would leave the class registered under the name it inherited yet
+    // rejected by every brand check: `config.components` entries,
+    // `@on(Class, type)` and lazy import resolution.
     value.config = { ...value.config, ...config };
     context.addInitializer(function initialize(this: T) {
       registerComponent(this);


### PR DESCRIPTION
#823 left a note on `@component()`: `value.config = { ...value.config, ...config }` copies a parent's config onto the child as its own, and `resolveConfig()` already merges `config` along the prototype chain, so the copy looked redundant. Three other PRs were touching `decorators.ts` at the time. They have merged, so here is the answer.

**It is not redundant. The code stays, with a comment saying why.**

## The evidence

Four specs in `decorators.spec.ts`, written against the current code, then re-run against `value.config = config` (the copy removed). Only one of them changes.

**The copy adds no value to the merged config.** A subclass whose own config carries the inherited keys and one whose own config carries only the declared keys resolve to the same `refs` union, the same `options`, the same `components`, and the same inherited `mountStrategy`. `resolveConfig()` collects only `Object.hasOwn(current, 'config')` levels and merges them, which is exactly the work the copy duplicates. This spec passes either way.

**The copy is what keeps the class recognisable.** `isBaseConstructor()` reads `config.name` straight off the class. It cannot call `resolveConfig()` — that lives in `Base`, which imports the brand. A class with no own `config` passes the check because it reads its parent's through the prototype chain. A decorated one only passes because the decorator carried the inherited name into the config it wrote.

## What would have broken

The case is a config written without a `name`. `BaseConfig` requires one, so TypeScript catches it; untyped sources reach it by extending a component and adding config without renaming — the exact case #823 made register under the inherited name:

```js
@component({ name: 'Parent', options: { one: String } })
class Parent extends Base {}

@component({ options: { two: String } })  // no rename
class Child extends Parent {}
```

Without the copy, `Child.config` is `{ options: { two: String } }`. `resolveConfig()` still resolves the name to `Parent`, so the class registers and mounts and collides loudly — but `isBaseConstructor(Child)` is now `false`, and the three places that ask reject it:

- `registerFamily()` — a `config.components` entry warns `component.invalid-family-declaration` and is dropped
- `@on(Child, 'event')` — throws `TypeError`
- `resolveComponentClass()` — a lazily imported module "did not resolve to a component class"

A class that registers and mounts, but that no parent can declare and no handler can target. The copy is one shallow spread standing between the decorator and that split.

## One defect found, not fixed here

Declaring both `@component({...})` and `static config = {...}` on the same class silently drops everything the decorator declared: static field initializers run *after* class decorators, so the field replaces the decorator's write wholesale. The last spec pins which one wins so the loss is at least known. Fixing it means moving the write into `context.addInitializer()`, which runs after the static fields — a change to when a class's config exists, not a cleanup, so it is not folded in here.

`npm run lint`, `npm run lint:types`, `npm run test:v4` (1078 passing) and `npm run check:package` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9
