### PR TITLE
[Bugfix] Drain the v3 task queues by index instead of Array#shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix mounting a large page costing several seconds: `Queue.run()` and `SmartQueue.run()` drained their task list with `Array#shift`, which moves every remaining entry, so draining N tasks cost O(N²) — and `SmartQueue`, which `$mount()` queues about six closures per component into, hands over its whole queue. Both now walk the list by index and trim it once per turn. Draining 60 000 tasks goes from 583 ms to 3.6 ms, and a page of 5 000 flat components settles in 294 ms instead of 5 548 ms
+
 ### Removed
 
 - Type-only symbols no longer get a dedicated subpath: the 89 entries such as `@studiometa/js-toolkit/BaseConfig` and `@studiometa/js-toolkit/utils/AnimateOptions` are gone. A subpath exists to stop one runtime import from pulling a whole barrel's graph, and a type import is erased before anything runs, so it never had that cost. Import types from `@studiometa/js-toolkit` or `@studiometa/js-toolkit/utils` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
-- Fix mounting a large page costing several seconds: `Queue.run()` and `SmartQueue.run()` drained their task list with `Array#shift`, which moves every remaining entry, so draining N tasks cost O(N²) — and `SmartQueue`, which `$mount()` queues about six closures per component into, hands over its whole queue. Both now walk the list by index and trim it once per turn. Draining 60 000 tasks goes from 583 ms to 3.6 ms, and a page of 5 000 flat components settles in 294 ms instead of 5 548 ms
+- Fix `Queue` and `SmartQueue` draining in quadratic time, which cost a page of 5 000 components several seconds of mounting: 5 548 ms becomes 294 ms ([#833](https://github.com/studiometa/js-toolkit/pull/833))
 
 ### Removed
 

--- a/packages/js-toolkit/src/__benchmarks__/mount-at-scale.bench.ts
+++ b/packages/js-toolkit/src/__benchmarks__/mount-at-scale.bench.ts
@@ -138,9 +138,9 @@ function swapBench(version: Version, scenario: ScenarioName, size: number): void
  */
 function destroyBench(version: Version, size: number): void {
   // Fewer iterations than a swap group: the whole pool is mounted at once, so
-  // the count sets how heavy the starting page is, and v3 cannot afford a
-  // heavy one — its queue drains with `Array#shift`, which V8 turns quadratic
-  // past ~16 000 entries.
+  // the count sets how heavy the starting page is, and neither version should
+  // be charged for setting up a document several times the size the group is
+  // named after.
   const base = samplesFor(size);
   const options = { ...base, iterations: Math.min(base.iterations, 5) };
   let pool: HTMLElement[] = [];

--- a/packages/js-toolkit/src/utils/Queue.spec.ts
+++ b/packages/js-toolkit/src/utils/Queue.spec.ts
@@ -37,4 +37,67 @@ describe('The `Queue` class', () => {
     await p;
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should run one batch of `concurrency` tasks per flush', async () => {
+    const queue = new Queue(2, nextTick);
+    const spy = vi.fn();
+
+    for (let index = 0; index < 5; index += 1) {
+      queue.add(spy);
+    }
+
+    await nextTick();
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(queue.tasks).toHaveLength(3);
+    await nextTick();
+    expect(spy).toHaveBeenCalledTimes(4);
+    await nextTick();
+    expect(spy).toHaveBeenCalledTimes(5);
+    expect(queue.tasks).toHaveLength(0);
+  });
+
+  it('should empty the array it is given', () => {
+    const queue = new Queue(10);
+    const spy = vi.fn();
+    const tasks = [spy, spy, spy];
+
+    queue.run(tasks);
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(tasks).toHaveLength(0);
+  });
+
+  it('should pick up tasks pushed while it is running', () => {
+    const queue = new Queue(10);
+    const order: string[] = [];
+    const tasks = [
+      () => {
+        order.push('first');
+        tasks.push(() => order.push('nested'));
+      },
+      () => order.push('second'),
+    ];
+
+    queue.run(tasks);
+    expect(order).toEqual(['first', 'second', 'nested']);
+    expect(tasks).toHaveLength(0);
+  });
+
+  it('should drop a throwing task and keep the ones after it', () => {
+    const queue = new Queue(10);
+    const spy = vi.fn();
+    const tasks = [
+      spy,
+      () => {
+        throw new Error('nope');
+      },
+      spy,
+    ];
+
+    expect(() => queue.run(tasks)).toThrow('nope');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(tasks).toHaveLength(1);
+
+    queue.run(tasks);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/js-toolkit/src/utils/Queue.ts
+++ b/packages/js-toolkit/src/utils/Queue.ts
@@ -72,13 +72,28 @@ export class Queue {
   }
 
   /**
-   * Run the queue.
+   * Run the given tasks in order, then drop the ones that ran from the array.
+   *
+   * The array is walked by index and trimmed once, rather than drained with
+   * `Array#shift`: V8 moves every remaining entry on each shift, so a queue
+   * handed over whole — which is what `SmartQueue` does — costs O(n²) to
+   * drain. `tasks.length` is read on every turn, so work queued by a running
+   * task is picked up by the same drain.
+   *
+   * The trim is in a `finally`: a task that throws takes itself and everything
+   * before it out of the queue, and leaves the rest of the queue alone.
    */
   run(tasks: Array<(...args: unknown[]) => unknown>) {
-    let task;
-    // eslint-disable-next-line no-cond-assign
-    while ((task = tasks.shift())) {
-      task();
+    let index = 0;
+
+    try {
+      while (index < tasks.length) {
+        const task = tasks[index];
+        index += 1;
+        task();
+      }
+    } finally {
+      tasks.splice(0, index);
     }
   }
 }

--- a/packages/js-toolkit/src/utils/SmartQueue.spec.ts
+++ b/packages/js-toolkit/src/utils/SmartQueue.spec.ts
@@ -25,4 +25,80 @@ describe('The `SmartQueue` class', () => {
     await nextTick();
     expect(spy).toHaveBeenCalledTimes(4);
   });
+
+  it('should leave the tasks it could not afford in the queue', async () => {
+    const queue = new SmartQueue();
+    const spy = vi.fn(task);
+
+    for (let index = 0; index < 4; index += 1) {
+      queue.add(() => spy(15));
+    }
+
+    await nextTick();
+    expect(queue.tasks).toHaveLength(1);
+    await nextTick();
+    expect(queue.tasks).toHaveLength(0);
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+
+  /**
+   * The drain is what makes a page of thousands of components affordable: one
+   * `$mount()` queues about six tasks, so the queue is tens of thousands deep
+   * before the first turn runs. A drain costing more per task as the queue
+   * grows turns that into a multi-second page, so this pins the whole queue
+   * being emptied in a single turn.
+   */
+  it('should drain a deep queue in a single turn', () => {
+    const queue = new SmartQueue();
+    let ran = 0;
+
+    for (let index = 0; index < 30_000; index += 1) {
+      queue.tasks.push(() => {
+        ran += 1;
+      });
+    }
+
+    queue.run(queue.tasks);
+    expect(ran).toBe(30_000);
+    expect(queue.tasks).toHaveLength(0);
+  });
+
+  it('should pick up tasks queued while it is running', () => {
+    const queue = new SmartQueue();
+    const order: string[] = [];
+
+    queue.tasks.push(() => {
+      order.push('first');
+      queue.tasks.push(() => order.push('nested'));
+    });
+    queue.tasks.push(() => order.push('second'));
+
+    queue.run(queue.tasks);
+    expect(order).toEqual(['first', 'second', 'nested']);
+    expect(queue.tasks).toHaveLength(0);
+  });
+
+  it('should drop a throwing task and keep the ones after it', () => {
+    const queue = new SmartQueue();
+    const spy = vi.fn();
+
+    queue.tasks.push(spy);
+    queue.tasks.push(() => {
+      throw new Error('nope');
+    });
+    queue.tasks.push(spy);
+
+    expect(() => queue.run(queue.tasks)).toThrow('nope');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(queue.tasks).toHaveLength(1);
+
+    queue.run(queue.tasks);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should resolve the promise of each added task', async () => {
+    const queue = new SmartQueue();
+    const values = await Promise.all([queue.add(() => 1), queue.add(() => 2)]);
+    expect(values).toEqual([1, 2]);
+  });
 });

--- a/packages/js-toolkit/src/utils/SmartQueue.ts
+++ b/packages/js-toolkit/src/utils/SmartQueue.ts
@@ -41,16 +41,28 @@ export class SmartQueue extends Queue {
   }
 
   /**
-   * Run the queue.
+   * Run as many tasks as the budget allows, then drop the ones that ran.
+   *
+   * `flush()` hands over the live queue, so this walks it by index and trims
+   * it once instead of draining it with `Array#shift`, whose per-entry cost
+   * makes a deep queue quadratic. Reading `tasks.length` on every turn keeps
+   * work queued by a running task eligible for the same drain, and whatever
+   * the budget leaves behind is what `flush()` reschedules.
    */
   run(tasks: Array<(...args: unknown[]) => unknown>) {
-    let task;
     const start = performance.now();
     let now = start;
-    // eslint-disable-next-line no-cond-assign
-    while (now - start < LONG_TASK_DURATION && (task = tasks.shift())) {
-      task();
-      now = performance.now();
+    let index = 0;
+
+    try {
+      while (now - start < LONG_TASK_DURATION && index < tasks.length) {
+        const task = tasks[index];
+        index += 1;
+        task();
+        now = performance.now();
+      }
+    } finally {
+      tasks.splice(0, index);
     }
   }
 }

--- a/packages/js-toolkit/vitest.bench.config.ts
+++ b/packages/js-toolkit/vitest.bench.config.ts
@@ -20,10 +20,9 @@ import { decorators } from '../v4/vite-plugin-decorators.js';
  * - `vitest run` runs `*.profile.ts`, which reports the blocking profile a
  *   throughput number cannot show.
  *
- * `V3_BENCH_SIZES` sets the at-scale sizes. The default stops at 1 000
- * because v3 does not survive 5 000: its queue drains with `Array#shift`,
- * which V8 turns quadratic past ~16 000 entries, and one swap then takes over
- * five seconds. That number belongs in a report, not in every run.
+ * `V3_BENCH_SIZES` sets the at-scale sizes. The default stops at 1 000 to keep
+ * a run bounded: 5 000 costs both versions minutes of samples, so it belongs
+ * in a report rather than in every run.
  */
 const sizes = (process.env.V3_BENCH_SIZES ?? '100,1000')
   .split(',')


### PR DESCRIPTION
### 🔗 Linked issue

_None — found while profiling v3 against v4 at page scale._

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`Queue.run()` and `SmartQueue.run()` both consumed their list with `Array#shift`. V8 moves every remaining entry on a shift, so the cost of taking one task grows with the depth of the queue, and draining N tasks costs O(N²).

`Queue.flush()` hides it: it splices `concurrency` (10) tasks off before running them, so the base class only ever shifts through a ten-element array. `SmartQueue.flush()` hands `run()` **the whole queue** — and that is the queue the framework mounts through. `addToQueue()` puts about six closures in it per `$mount()`, so a page of a few thousand components is tens of thousands of entries deep, well past the ~16 000 where V8 stops keeping `shift` cheap.

Both drains now walk the array by index and remove the consumed prefix with a single `splice`:

```ts
let index = 0;
try {
  while (now - start < LONG_TASK_DURATION && index < tasks.length) {
    const task = tasks[index];
    index += 1;
    task();
    now = performance.now();
  }
} finally {
  tasks.splice(0, index);
}
```

#### Why in `run()` and not in `flush()`

`SmartQueue.flush()` passing the live queue is not the defect — it is the feature. Mounting queues more work while it drains, and handing `run()` the live array is what lets the same turn pick that work up. A `flush()` that spliced a fixed batch off first would have to push the leftovers back on, and would stop draining the work a running task queues. So the array stays live, and only the way it is consumed changes: `tasks.length` is read on every turn, exactly as the `shift` loop did.

Both classes are changed even though only `SmartQueue` is hit today, because `run()` is public and `new Queue(Infinity)` reaches the base class down the same path.

#### Behaviour that is unchanged

Each of these is pinned by a test in `Queue.spec.ts` / `SmartQueue.spec.ts`, and each was also diffed against the pre-fix build in a harness before the tests were written — the six observations are byte-identical:

| | before | after |
| --- | --- | --- |
| work queued during a drain | picked up by the same drain | same |
| `SmartQueue`'s 40 ms budget | bounds one turn, remainder rescheduled | same |
| `Queue`'s `concurrency` batching | one batch of `concurrency` per flush | same |
| `add()` | resolves per task, in order | same |
| a task that throws | it and everything before it leave the queue, the rest stay, the error escapes `run()` | same |

The `finally` is what keeps the last row true: `shift` removed a task before running it, so the trim has to happen even on the way out.

### 📊 Evidence

Every number below was measured on an otherwise idle machine (8 cores, load < 1.0), before and after, in the same session.

#### 1. The drain on its own

Node 24.19 (V8), the queue filled directly and `run()` driven by hand until empty, so the number is the drain and nothing else. Median of 5.

| tasks | before | after | speed-up | `run()` turns before → after |
| --- | --- | --- | --- | --- |
| 1 000 | 0.5 ms | 0.3 ms | 1.7× | 1 → 1 |
| 5 000 | 0.9 ms | 0.8 ms | 1.1× | 1 → 1 |
| 10 000 | 1.5 ms | 1.0 ms | 1.5× | 1 → 1 |
| 20 000 | 48.7 ms | 1.3 ms | 37× | 2 → 1 |
| 30 000 | 115.5 ms | 1.8 ms | 64× | 3 → 1 |
| 60 000 | 583.1 ms | 3.6 ms | 162× | 15 → 1 |

The curve, not the multiple, is the point: below the V8 threshold the two are the same code, and above it the old cost per task climbs with the queue (0.15 ms → 9.72 ms per thousand tasks) while the new one is flat (0.10 ms → 0.06 ms per thousand).

`Queue(concurrency 10)`, adding and draining N tasks, is unmoved — it never had a deep array to shift through.

#### 2. Mounting a page — blocking profile

`src/__benchmarks__/mount-at-scale.profile.ts`, Chromium, median of 5 swaps. This is the file that reports settle time and total blocking time; `mount-at-scale.bench.ts` reports wall clock only, and is in §3.

| scenario | size | version | settle before → after | TBT before → after | longest task before → after |
| --- | --- | --- | --- | --- | --- |
| flat | 1 000 | v3 | 62.70 → 52.30 ms | 0 → 0 | 0 → 0 |
| flat | 1 000 | v4 | 27.00 → 22.20 ms | 0 → 0 | 0 → 0 |
| realistic | 1 000 | v3 | 224 → 230 ms | 0 → 0 | 0 → 0 |
| realistic | 1 000 | v4 | 113 → 119 ms | 0 → 0 | 0 → 0 |
| flat | 5 000 | v3 | **5 548 → 294 ms** | 35 → 56 ms | 85 → 101 ms |
| flat | 5 000 | v4 | 111 → 110 ms | 0 → 0 | 0 → 0 |
| nested | 5 000 | v3 | **6 625 → 343 ms** | 31 → 36 ms | 81 → 86 ms |
| nested | 5 000 | v4 | 103 → 101 ms | 0 → 0 | 0 → 0 |
| realistic | 5 000 | v3 | **6 390 → 1 022 ms** | 75 → 93 ms | 125 → 143 ms |
| realistic | 5 000 | v4 | 585 → 527 ms | 23 → 18 ms | 73 → 68 ms |

At 1 000 nothing moves, and it should not: six thousand queued closures never reach the threshold. At 5 000 v3 settles 19× sooner on a flat page and 6× sooner on a realistic one.

**Total blocking time does not improve, and at 5 000 it gets slightly worse.** That is honest and it is not the drain: see the second defect below.

#### 3. Mounting a page — wall clock

`src/__benchmarks__/mount-at-scale.bench.ts`, the swap groups, 7 iterations, mean. The `destroy` groups are excluded from both runs — they mount six pools at once in `setup`, which the pre-fix build cannot sample in reasonable time, so including them would have compared different amounts of work.

A swap is a destroy plus a mount plus settling, so it reads higher than the profile's settle time.

| scenario | size | v3 before | v3 after | v3 speed-up | v4 before | v4 after |
| --- | --- | --- | --- | --- | --- | --- |
| control | 1 000 | 0.79 ms | 0.27 ms | — | 3.37 ms | 4.27 ms |
| flat | 1 000 | 66.46 ms | 75.84 ms | — | 22.93 ms | 21.44 ms |
| nested | 1 000 | 76.91 ms | 78.80 ms | — | 21.66 ms | 21.97 ms |
| realistic | 1 000 | 205 ms | 200 ms | — | 129 ms | 113 ms |
| control | 5 000 | 17.10 ms | 16.74 ms | — | 24.99 ms | 22.31 ms |
| flat | 5 000 | **6 617 ms** | **319 ms** | **20.7×** | 113 ms | 107 ms |
| nested | 5 000 | 6 601 ms | 344 ms | 19.2× | 121 ms | 108 ms |
| realistic | 5 000 | 6 357 ms | 1 140 ms | 5.6× | 586 ms | 570 ms |

No speed-up is claimed at 1 000: those cells move by less than their own relative margin of error (`±37%` on v3 flat before, `±23%` after), which is exactly what should happen to a queue that never gets deep enough to cross the threshold. v4 is unchanged throughout, as it must be — nothing in this pull request touches it, and it is the control on the two runs being comparable.

The wall-clock ratio at 5 000 flat is **58× before, 3.0× after**, which is the profile's 50× → 2.7× measured a different way.

#### 4. The v3-against-v4 ratio

Read from the profile above, both versions measured minutes apart in the same browser.

| scenario | size | ratio before | ratio after |
| --- | --- | --- | --- |
| flat | 1 000 | 2.3× | 2.4× |
| realistic | 1 000 | 2.0× | 1.9× |
| flat | **5 000** | **50×** | **2.7×** |
| nested | 5 000 | 64× | 3.4× |
| realistic | 5 000 | 10.9× | 1.9× |

**The number for release notes is 2.7×, not 50×.** Most of what the 5 000-component gap measured was this bug, not a design difference between the two versions. What is left — roughly 2× to 3× — is the difference the mounting designs actually make, and it matches what the 1 000-component sizes said all along.

### 🐞 A second defect, reported and not fixed

`SmartQueue`'s budget bounds **how many tasks run in a turn, never how long one task runs**. It is checked between tasks, so a single queued closure runs to completion whatever it costs.

`mountComponents()` in `src/Base/utils.ts` queues exactly such a closure: one task that walks the registry and calls `new ctor(el).$mount()` for every matching element in the document. On a page of 5 000 components that is one uninterruptible task, and it is the long task the profile reports. This is why fixing the drain does not lower TBT: the same long tasks now sit inside a 294 ms window instead of a 5 548 ms one, which is why the numbers even tick up.

Splitting that scan is a change to `mountComponents()`, not to the drain, so it is out of scope here.

Related, also untouched: a task that throws leaves `isScheduled` at `true`, because `flush()` sets it to `false` after `run()` returns. The queue is then wedged — nothing reschedules it, and every later `add()` returns a promise that never settles. Measured on both builds:

```
before { later: 'pending', isScheduled: true, left: 1 }
after  { later: 'pending', isScheduled: true, left: 1 }
```

The fix preserves that exactly rather than quietly changing it, since `Base` treats a queued hook throwing as a caller error and one turn of the queue is the wrong place to decide otherwise.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9
