### PR TITLE
docs(v3): give the benchmark take-turns rule its real reason

### DIFF
--- a/packages/js-toolkit/src/__benchmarks__/mount-at-scale.bench.ts
+++ b/packages/js-toolkit/src/__benchmarks__/mount-at-scale.bench.ts
@@ -8,7 +8,7 @@
  *    title to report a per-component cost.
  * 2. **Between versions, now.** Both run on the same runner, in the same
  *    browser, minutes apart, which is as close to a controlled comparison as
- *    two frameworks that cannot share a document will get.
+ *    two mounting paths sharing one main thread will get.
  *
  * Each version is driven through its **own native path** — v3's document
  * mutation observer feeding `SmartQueue`, v4's observer feeding its
@@ -18,10 +18,14 @@
  * thread — observed from the components, so neither framework's own settle
  * API gets to define away work it defers.
  *
- * **The versions take turns**, v3 first, because they collide on
- * `el.__base__`; see `registerScenario()`. They are therefore in separate
- * groups, and the ratio is read from the report rather than from vitest's
- * per-group summary.
+ * **The versions take turns**, v3 first, and the v4 groups run with v3's
+ * registry emptied. Not because the two cannot coexist — since v4 keys its
+ * instance map with a symbol they share a document safely, which
+ * `packages/v4/src/coexistence.spec.ts` proves — but because a live v3
+ * registry rescans the whole document on every mutation, on the thread the v4
+ * groups are timing. That cost is measured in `releaseDocumentFromV3()`. The
+ * two are therefore in separate groups, and the ratio is read from the report
+ * rather than from vitest's per-group summary.
  *
  * Wall clock alone cannot answer the question `SmartQueue` was written for.
  * `mount-at-scale.profile.ts` reports the blocking profile — total blocking

--- a/packages/js-toolkit/src/__benchmarks__/mount-at-scale.fixtures.ts
+++ b/packages/js-toolkit/src/__benchmarks__/mount-at-scale.fixtures.ts
@@ -400,13 +400,12 @@ const scenarioComponents = {
 /**
  * Register the components one scenario needs, for one version only.
  *
- * **The two versions have to take the document in turns.** Both publish their
- * instances on `el.__base__`, so two live registries do not merely add noise
- * to each other's measurements: v4's teardown walks a removed subtree, finds
- * v3's entries in that map and calls `$destroy()` on them — which throws
- * outright once v3 has left its `'terminated'` marker there. Measuring both
- * natively in one document is therefore not an option, and pretending
- * otherwise would have produced numbers rather than an error only by luck.
+ * **The two versions take the document in turns.** Not because they collide:
+ * v4 keys its per-element instance map with a symbol rather than the
+ * `'__base__'` string v3 uses, so neither reads the other's entries, and
+ * `packages/v4/src/coexistence.spec.ts` covers the case that used to throw —
+ * v4's teardown finding the `'terminated'` marker v3 leaves behind. They take
+ * turns to keep the measurement clean, which `releaseDocumentFromV3()` prices.
  *
  * Only the components a scenario needs are registered, so v3's per-mutation
  * document scan stays one or two selectors wide rather than the whole
@@ -421,7 +420,28 @@ export async function registerScenario(version: Version, scenario: ScenarioName)
 }
 
 /**
- * Hand the document over from v3 to v4.
+ * Hand the document over from v3 to v4, so the v4 groups measure v4 alone.
+ *
+ * **This is measurement isolation, not a crash workaround.** v3's registry
+ * callback runs on every childList mutation: it rescans the whole document
+ * once per registered name, then walks every live instance checking
+ * `isConnected`. Left live across the v4 groups — six v3 names registered by
+ * then — it charges them for a scan that grows with the page v4 just mounted.
+ *
+ * Priced by running this file sixteen times in each state, released against
+ * live, alternating so drift hits both. Medians across rounds, at 1 000
+ * components:
+ *
+ * | group             | released | v3 live |  delta | rounds slower |
+ * | :--               |      --: |     --: |    --: |           --: |
+ * | `swap` control    |  2.30 ms | 3.10 ms |   +35% |         16/16 |
+ * | `destroy` flat    |  4.30 ms | 6.10 ms |   +42% |         16/16 |
+ * | `swap` realistic  | 104.2 ms | 112.4 ms |   +8% |         12/16 |
+ *
+ * All ten v4 benchmarks came out slower with v3 live, and the two cheap
+ * groups in every single round. The same-condition contrast — one half of the
+ * released rounds against the other — stays within ±13%, so the two headline
+ * figures are well outside the noise the benchmark makes on its own.
  *
  * v3 must go first: v4 installs its mutation processor on the first
  * registration and offers no way to remove it, while v3's registry is a plain
@@ -429,6 +449,11 @@ export async function registerScenario(version: Version, scenario: ScenarioName)
  * observer attached but with nothing to scan for and no instances to
  * terminate, which is as close to absent as v3 can be made without reloading
  * the page.
+ *
+ * Safety no longer depends on any of this: v4 keys its instance map with
+ * `Symbol.for('@studiometa/js-toolkit-v4/instances')`, so the two versions
+ * share a document without touching each other's entries. See
+ * `packages/v4/src/coexistence.spec.ts`.
  */
 export function releaseDocumentFromV3(): void {
   globalThis.__JS_TOOLKIT_REGISTRY__?.clear();

--- a/packages/js-toolkit/src/__benchmarks__/mount-at-scale.profile.ts
+++ b/packages/js-toolkit/src/__benchmarks__/mount-at-scale.profile.ts
@@ -197,8 +197,9 @@ function report(): string {
   return lines.join('\n');
 }
 
-// v3 has to go first: the two versions collide on `el.__base__`, and only v3's
-// registry can be emptied afterwards. See `registerScenario()`.
+// v3 has to go first: only v3's registry can be emptied afterwards, and a live
+// one would rescan the document on every mutation the v4 profiles make. See
+// `releaseDocumentFromV3()`.
 describe.sequential('mount-at-scale blocking profile', () => {
   for (const version of ['v3', 'v4'] as const) {
     for (const size of SIZES) {

--- a/packages/js-toolkit/src/__benchmarks__/v3-vs-v4.bench.ts
+++ b/packages/js-toolkit/src/__benchmarks__/v3-vs-v4.bench.ts
@@ -11,12 +11,14 @@
  * friends mutate a module-level map, and everything in this file shares
  * one realm, so a global set here would follow every benchmark below it.
  *
- * Neither version is *registered* here, which is what lets the two share
- * a document at all: v3 and v4 both publish their instances on
- * `el.__base__`, and a live v4 registry finds v3's entries there and
- * calls `$destroy()` on them. Mounting is done by hand on both sides.
- * `mount-at-scale.bench.ts` measures the registered paths, and has to
- * give each version the document in turn.
+ * Neither version is *registered* here: mounting is done by hand on both
+ * sides, so no registry scan runs inside a measurement. The two can share
+ * a document safely — v4 keys its instance map with a symbol rather than
+ * the `'__base__'` string v3 uses, which
+ * `packages/v4/src/coexistence.spec.ts` proves — but a live registry
+ * would still charge these benchmarks for work they do not measure.
+ * `mount-at-scale.bench.ts` measures the registered paths, and gives each
+ * version the document in turn for that same reason.
  */
 import { bench, describe } from 'vitest';
 import { Base as BaseV3, type BaseConfig } from '@studiometa/js-toolkit';


### PR DESCRIPTION
## What

`mount-at-scale.bench.ts` hands the document to one version at a time, via `releaseDocumentFromV3()`. The comments justified that with a crash: both versions keyed their per-element instance map with `__base__`, so v4's teardown walked a removed subtree, found v3's `'terminated'` marker and called `$destroy()` on a string. They concluded coexistence was "not an option".

Since #831 that is out of date. v4 keys its map with `Symbol.for('@studiometa/js-toolkit-v4/instances')`, and `packages/v4/src/coexistence.spec.ts` proves both versions share a document safely — terminated v3 instances included.

So the question was whether the workaround still earns its place. A second reason had been offered but never measured: v3's registry callback rescans the whole document once per registered name on every childList mutation, then walks every live instance checking `isConnected` — all on the thread the v4 groups are timing.

## Measured

Two conditions, chosen so that B is exactly what deleting the workaround would produce:

- **A — released** (current code): `releaseDocumentFromV3()` before each v4 group.
- **B — v3 live**: the call skipped, so the six names the v3 groups registered (`V3Flat`, `V3Depth1..4`, `V3Realistic`) stay in v3's registry across the v4 groups. Asserted live at run time, not assumed.

Sixteen rounds of each, strictly alternating so machine drift hits both, and reduced with the published metric — tinybench's median per round, median across rounds.

At 1 000 components:

| group | released | v3 live | delta | rounds slower |
| :-- | --: | --: | --: | --: |
| `swap` control | 2.30 ms | 3.10 ms | **+35%** | 16/16 |
| `destroy` flat | 4.30 ms | 6.10 ms | **+42%** | 16/16 |
| `swap` nested | 18.00 ms | 19.50 ms | +8% | 12/16 |
| `swap` realistic | 104.2 ms | 112.4 ms | +8% | 12/16 |
| `swap` flat | 18.30 ms | 18.75 ms | +2% | 9/16 |

The noise floor first: contrasting one half of the released rounds against the other — like against like — stays within ±13% on every group. The two headline figures are well outside that, and each was slower in every single one of the sixteen rounds. All ten v4 benchmarks came out slower with v3 live, which under a fair-coin null is p = 2⁻¹⁰ on the sign alone.

The size of the effect tracks the mechanism: the added cost is roughly a fixed per-mutation scan proportional to the element count in the document, so it is invisible against a 104 ms realistic swap and worth a third of a 2.30 ms control swap. The `destroy` groups pay most because they start from a pool of six pages at once.

## Decision

**Keep `releaseDocumentFromV3()`.** The crash no longer justifies it; measurement isolation does, by 35-42% on the cheap groups.

The comments now say that, in `mount-at-scale.bench.ts`, `mount-at-scale.fixtures.ts` (`registerScenario()` and `releaseDocumentFromV3()`, which carries the table), `mount-at-scale.profile.ts` and `v3-vs-v4.bench.ts` — the last two repeated the same stale `__base__` claim. Each now points at `packages/v4/src/coexistence.spec.ts` so the next reader can see the crash is handled rather than merely unmentioned.

## Numbers

This is a comments-only diff — not one executable line changed, so no published figure moves. The instrumentation used for the measurement (an env-gated `define` and a liveness assertion) was reverted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9
