### PR TITLE
docs: bring the unreleased changelog entries to the released style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,17 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Removed
 
-- Type-only symbols no longer get a dedicated subpath: the 89 entries such as `@studiometa/js-toolkit/BaseConfig` and `@studiometa/js-toolkit/utils/AnimateOptions` are gone. A subpath exists to stop one runtime import from pulling a whole barrel's graph, and a type import is erased before anything runs, so it never had that cost. Import types from `@studiometa/js-toolkit` or `@studiometa/js-toolkit/utils` instead
+- Drop the dedicated subpaths of the 89 type-only symbols, such as `@studiometa/js-toolkit/BaseConfig`. Import types from `@studiometa/js-toolkit` or `@studiometa/js-toolkit/utils` instead ([#777](https://github.com/studiometa/js-toolkit/pull/777))
 
 ### Changed
 
-- The published package is now assembled in `packages/js-toolkit/` instead of a repository-level `dist/`, and its modules sit in that folder's own `dist/`. Every entry of the `exports` map resolves through three conditions — `typescript` for the TypeScript source, `types` for the declaration and `import` for the module — so the subpaths a consumer imports are unchanged
-- The build uses tsdown (rolldown) instead of esbuild plus a separate `tsgo --build` pass, in every package
-- Formatting moves from Prettier to `oxfmt`, which covers the whole tree instead of a hand-written glob; the demo keeps Prettier for its Twig templates
-- The toolchain moves to the released `typescript@7` (`tsc`) instead of `@typescript/native-preview` (`tsgo`), and `oxlint` to 1.77.0
-- The test runner moves to Vitest 4.1.10, and each package owns its runner config. Vitest 5 waits on one thing: it replaces the top-level `bench()` with `context.bench`, which the benchmark suite has to be rewritten for
-- v3's benchmarks run in a real Chromium instead of Node with happy-dom, so they measure the same environment v4's do. Regressions are tracked by `.github/actions/bench-diff` — the base and the head commit measured on one runner — instead of CodSpeed, which is removed. `src/__benchmarks__/mount-at-scale.bench.ts` and `mount-at-scale.profile.ts` add the v3-against-v4 mounting comparison, including a total-blocking-time profile
-- The subpath stubs are committed instead of being regenerated before every build, test and lint run. `npm run subpaths` rewrites them and the `exports` map together; the contract test fails until the result is committed
+- Assemble the published package in `packages/js-toolkit/` instead of a repository-level `dist/`. The subpaths a consumer imports are unchanged ([#777](https://github.com/studiometa/js-toolkit/pull/777))
+- Build with tsdown (rolldown) instead of esbuild plus a separate `tsgo --build` pass, in every package ([#777](https://github.com/studiometa/js-toolkit/pull/777))
+- Format with `oxfmt` instead of Prettier, across the whole tree; the demo keeps Prettier for its Twig templates ([#777](https://github.com/studiometa/js-toolkit/pull/777))
+- Move the toolchain to the released `typescript@7` (`tsc`) instead of `@typescript/native-preview` (`tsgo`), and `oxlint` to 1.77.0 ([#777](https://github.com/studiometa/js-toolkit/pull/777))
+- Move the test runner to Vitest 4.1.10, with each package owning its runner config ([#777](https://github.com/studiometa/js-toolkit/pull/777))
+- Run v3's benchmarks in a real Chromium instead of Node with happy-dom, add the v3-against-v4 mounting comparison, and track regressions with `.github/actions/bench-diff` instead of CodSpeed, which is removed ([#830](https://github.com/studiometa/js-toolkit/pull/830))
+- Commit the subpath stubs instead of regenerating them before every build, test and lint run. `npm run subpaths` rewrites them and the `exports` map together ([#777](https://github.com/studiometa/js-toolkit/pull/777))
 
 ## [v3.9.0](https://github.com/studiometa/js-toolkit/compare/3.8.2..3.9.0) (2026-08-10)
 


### PR DESCRIPTION
Every entry under a released heading is one line ending in its pull request:

```markdown
- Add `npm run measure` reporting the module graph of every published entry point … ([#757](https://github.com/studiometa/js-toolkit/pull/757))
```

Every entry under `[Unreleased]` was a paragraph with no reference. After #833 landed a short linked entry, the section read two ways at once.

All eight now match. The detail they carried is in the pull requests — #777 for the build and toolchain moves, #830 for the benchmark migration — which is where a reader who wants the mechanism looks anyway, and where it stays correct as the code moves.

**One line was dropped rather than shortened:** the note that Vitest 5 is blocked on `bench()` becoming `context.bench`. That is a plan, not a change, and a changelog is the wrong place for it. It is in #777 if anyone needs it.

Nothing but `CHANGELOG.md` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9