### PR TITLE
refactor(v4): reduce cyclomatic complexity at the top of the distribution

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,6 +12,12 @@
       {
         "allowDestructuring": true
       }
+    ],
+    "complexity": [
+      "error",
+      {
+        "max": 20
+      }
     ]
   },
   "overrides": [
@@ -53,8 +59,9 @@
       }
     },
     {
-      "files": ["**/*.spec.ts", "**/*.bench.ts", "**/__benchmarks__/**"],
+      "files": ["**/*.spec.ts", "**/*.bench.ts", "**/__benchmarks__/**", "packages/v4/test/**"],
       "rules": {
+        "complexity": "off",
         "js-toolkit/no-internal-barrel-import": "off",
         "js-toolkit/require-config": "off",
         "js-toolkit/require-config-name-pascal-case": "off",

--- a/packages/js-toolkit/src/utils/css/animate.ts
+++ b/packages/js-toolkit/src/utils/css/animate.ts
@@ -150,6 +150,9 @@ const TRANSLATE_DEFS: ReadonlyArray<readonly [string, number, string]> = [
  * Compile a pair of keyframes into a pre-computed segment.
  * All constant work (deltas, property filtering) is done here once.
  */
+// Deliberately flat: this runs once per segment so that rendering does not
+// branch, and splitting it would move the branches back onto the hot path.
+// oxlint-disable-next-line complexity
 function compileSegment(from: NormalizedKeyframe, to: NormalizedKeyframe): CompiledSegment {
   const transformStarts: number[] = [];
   const transformDeltas: number[] = [];

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -693,6 +693,22 @@ const handlerPlan = /* @__PURE__ */ memo((ctor: BaseConstructor): HandlerPlan =>
   return { childNames, refs, componentName: config.name, entries };
 });
 
+/** One handler waiting on a descendant, resolved at event time. */
+type DelegatedEntry =
+  | { kind: 'child'; name: string; invoke: (payload: DelegatedEvent) => void }
+  // `name` here is the **declared** ref, suffix included: it is compared
+  // against the `data-ref` attribute and handed to `queryRefs()`.
+  | { kind: 'ref'; name: string; invoke: (payload: RefEvent) => void };
+
+type DelegatedEntries = Map<string, DelegatedEntry[]>;
+
+function addDelegated(delegated: DelegatedEntries, type: string, entry: DelegatedEntry): void {
+  if (!delegated.has(type)) {
+    delegated.set(type, []);
+  }
+  delegated.get(type)?.push(entry);
+}
+
 /**
  * `mounted()` may return one cleanup, several, nothing — or a promise of
  * those. The shape nests, so a subclass composes with what it extends
@@ -1279,45 +1295,44 @@ export class Base<T extends BaseProps = BaseProps> {
 
   /** Bind root, delegated child/ref and global handlers for the current mount cycle. Delegated handlers resolve dynamic descendants at event time. */
   #bindHandlers(): void {
-    const self = this as unknown as Record<string, (payload: unknown) => void>;
     // Resolve class-level handler metadata once.
     const plan = handlerPlan(this.constructor as BaseConstructor);
-    const { childNames, refs, componentName } = plan;
+    const delegated: DelegatedEntries = new Map();
+    // Decorated handlers win: the plan lists the same method names, and the
+    // set returned here is what tells the second pass to skip them.
+    const decorated = this.#bindDecoratedHandlers(plan, delegated);
+    this.#bindPlannedHandlers(plan, delegated, decorated);
+    this.#installDelegatedListeners(plan.componentName, delegated);
+  }
 
-    type Entry =
-      | { kind: 'child'; name: string; invoke: (payload: DelegatedEvent) => void }
-      // `name` here is the **declared** ref, suffix included: it is compared
-      // against the `data-ref` attribute and handed to `queryRefs()`.
-      | { kind: 'ref'; name: string; invoke: (payload: RefEvent) => void };
-    const delegated = new Map<string, Entry[]>();
-    const addDelegated = (type: string, entry: Entry) => {
-      if (!delegated.has(type)) {
-        delegated.set(type, []);
-      }
-      delegated.get(type)?.push(entry);
-    };
-    const bindOwn = (type: string, invoke: (event: Event) => void) => {
-      const listener: EventListener = (event) => invoke(event);
-      this.$el.addEventListener(type, listener);
-      this.#listeners.push([type, listener, this.$el, false]);
-    };
-    /** Bind a global handler in bubble phase for the current mount cycle. Capture is only for delegated non-bubbling events. */
-    const bindGlobal = (
-      target: Window | Document,
-      type: string,
-      invoke: (payload: GlobalEvent) => void,
-    ) => {
-      const listener: EventListener = (event) => invoke({ event, target });
-      target.addEventListener(type, listener);
-      this.#listeners.push([type, listener, target, false]);
-    };
+  #bindOwn(type: string, invoke: (event: Event) => void): void {
+    const listener: EventListener = (event) => invoke(event);
+    this.$el.addEventListener(type, listener);
+    this.#listeners.push([type, listener, this.$el, false]);
+  }
 
-    // Decorated handlers already contain resolved targets and event types.
+  /** Bind a global handler in bubble phase for the current mount cycle. Capture is only for delegated non-bubbling events. */
+  #bindGlobal(
+    target: Window | Document,
+    type: string,
+    invoke: (payload: GlobalEvent) => void,
+  ): void {
+    const listener: EventListener = (event) => invoke({ event, target });
+    target.addEventListener(type, listener);
+    this.#listeners.push([type, listener, target, false]);
+  }
+
+  /**
+   * Bind the decorated handlers, which already carry resolved targets and
+   * event types, and return the functions they bound.
+   */
+  #bindDecoratedHandlers(plan: HandlerPlan, delegated: DelegatedEntries): Set<unknown> {
+    const { childNames, refs } = plan;
     const registrations = this[HANDLER_REGISTRATIONS] ?? [];
     const decorated: Set<unknown> = new Set(registrations.map(({ handler }) => handler));
     for (const { target, child, type, handler } of registrations) {
       if (target) {
-        bindGlobal(target, type, (payload) => handler.call(this, payload));
+        this.#bindGlobal(target, type, (payload) => handler.call(this, payload));
       } else if (child) {
         // Decorators use the declared ref name, including `[]`.
         const declaredChild = childNames.includes(child);
@@ -1325,17 +1340,25 @@ export class Base<T extends BaseProps = BaseProps> {
         if (!declaredChild && !ref) {
           warnRefSuffixMismatch(this, child, refs);
         }
-        addDelegated(type, {
+        addDelegated(delegated, type, {
           kind: ref ? 'ref' : 'child',
           name: child,
           invoke: (payload: DelegatedEvent | RefEvent) => handler.call(this, payload),
-        } as Entry);
+        } as DelegatedEntry);
       } else {
-        bindOwn(type, (event) => handler.call(this, event));
+        this.#bindOwn(type, (event) => handler.call(this, event));
       }
     }
+    return decorated;
+  }
 
-    // Bind undecorated magic handlers from the cached class plan.
+  /** Bind the undecorated magic handlers from the cached class plan. */
+  #bindPlannedHandlers(
+    plan: HandlerPlan,
+    delegated: DelegatedEntries,
+    decorated: Set<unknown>,
+  ): void {
+    const self = this as unknown as Record<string, (payload: unknown) => void>;
     for (const entry of plan.entries) {
       const { method, type } = entry;
       // Read through the instance, deliberately: a class field can shadow a
@@ -1346,44 +1369,28 @@ export class Base<T extends BaseProps = BaseProps> {
         continue;
       }
       if (entry.kind === 'global') {
-        bindGlobal(entry.target, type, (payload) => self[method](payload));
+        this.#bindGlobal(entry.target, type, (payload) => self[method](payload));
       } else if (entry.kind === 'own') {
-        bindOwn(type, (event) => self[method](event));
+        this.#bindOwn(type, (event) => self[method](event));
       } else {
-        addDelegated(type, {
+        addDelegated(delegated, type, {
           kind: entry.kind,
           name: entry.name,
           invoke: (payload: DelegatedEvent | RefEvent) => self[method](payload),
-        } as Entry);
+        } as DelegatedEntry);
       }
     }
+  }
 
+  /** Install one root listener per delegated event type. */
+  #installDelegatedListeners(componentName: string, delegated: DelegatedEntries): void {
     for (const [type, entries] of delegated) {
       const listener: EventListener = (event) => {
         let el = event.target instanceof Element ? event.target : null;
         while (el && el !== this.$el) {
           let invoked = false;
           for (const entry of entries) {
-            if (entry.kind === 'child') {
-              const child = el[INSTANCES]?.get(entry.name);
-              if (child?.$isMounted) {
-                entry.invoke({
-                  event,
-                  target: child,
-                  // The detail verbatim — what a plain listener reads.
-                  payload: (event as CustomEvent).detail,
-                });
-                invoked = true;
-              }
-            } else if (isRefOf(el, this.$el, componentName, entry.name)) {
-              const target = el;
-              entry.invoke({
-                event,
-                target,
-                // The index within the ref list as `$refs` sees it, so the two
-                // spellings share one numbering.
-                index: queryRefs(this.$el, componentName, entry.name).indexOf(target),
-              });
+            if (this.#invokeDelegated(entry, el, event, componentName)) {
               invoked = true;
             }
           }
@@ -1400,5 +1407,42 @@ export class Base<T extends BaseProps = BaseProps> {
       this.$el.addEventListener(type, listener, capture);
       this.#listeners.push([type, listener, this.$el, capture]);
     }
+  }
+
+  /**
+   * Fire one delegated entry when `el` is what it waits on: a mounted child
+   * instance, or an owned ref. Returns whether it fired, which is how the
+   * walk knows it reached the nearest matching element.
+   */
+  #invokeDelegated(
+    entry: DelegatedEntry,
+    el: Element,
+    event: Event,
+    componentName: string,
+  ): boolean {
+    if (entry.kind === 'child') {
+      const child = el[INSTANCES]?.get(entry.name);
+      if (!child?.$isMounted) {
+        return false;
+      }
+      entry.invoke({
+        event,
+        target: child,
+        // The detail verbatim — what a plain listener reads.
+        payload: (event as CustomEvent).detail,
+      });
+      return true;
+    }
+    if (!isRefOf(el, this.$el, componentName, entry.name)) {
+      return false;
+    }
+    entry.invoke({
+      event,
+      target: el,
+      // The index within the ref list as `$refs` sees it, so the two
+      // spellings share one numbering.
+      index: queryRefs(this.$el, componentName, entry.name).indexOf(el),
+    });
+    return true;
   }
 }

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -707,6 +707,9 @@ function reportLifecycleFailure(instance: Base, message: string, error: unknown)
   });
 }
 
+/** What `#guard()` returns instead of a value when the guarded call threw. */
+const GUARD_FAILED = Symbol('guard-failed');
+
 export class Base<T extends BaseProps = BaseProps> {
   /** A class-owned brand inherited by subclasses and shared by bundled copies. */
   static readonly [BASE_BRAND] = true;
@@ -834,11 +837,7 @@ export class Base<T extends BaseProps = BaseProps> {
     if (!this.#isActiveMountCycle(cycle)) {
       return this;
     }
-    try {
-      this.#collectCleanup(this.mounted(), cycle);
-    } catch (error) {
-      reportLifecycleFailure(this, '`mounted()` failed.', error);
-    }
+    this.#guard('`mounted()` failed.', () => this.#collectCleanup(this.mounted(), cycle));
     if (!this.#isActiveMountCycle(cycle)) {
       return this;
     }
@@ -874,18 +873,10 @@ export class Base<T extends BaseProps = BaseProps> {
     const callbacks = this.#destroyCallbacks;
     this.#destroyCallbacks = [];
     for (const callback of callbacks) {
-      try {
-        callback();
-      } catch (error) {
-        reportLifecycleFailure(this, 'A mount cleanup failed.', error);
-      }
+      this.#guard('A mount cleanup failed.', callback);
     }
     this.#clearOptionEffects();
-    try {
-      this.destroyed();
-    } catch (error) {
-      reportLifecycleFailure(this, '`destroyed()` failed.', error);
-    }
+    this.#guard('`destroyed()` failed.', () => this.destroyed());
     // The element may already be detached, so a bubbling event would reach
     // nobody: announce from the document instead.
     const detail: LifecycleEventDetail = { instance: this };
@@ -909,17 +900,9 @@ export class Base<T extends BaseProps = BaseProps> {
     const callbacks = this.#terminateCallbacks;
     this.#terminateCallbacks = [];
     for (const callback of callbacks) {
-      try {
-        callback();
-      } catch (error) {
-        reportLifecycleFailure(this, 'A termination cleanup failed.', error);
-      }
+      this.#guard('A termination cleanup failed.', callback);
     }
-    try {
-      this.terminated();
-    } catch (error) {
-      reportLifecycleFailure(this, '`terminated()` failed.', error);
-    }
+    this.#guard('`terminated()` failed.', () => this.terminated());
     this.$el[INSTANCES]?.delete(this.$config.name);
     return this;
   }
@@ -1147,6 +1130,21 @@ export class Base<T extends BaseProps = BaseProps> {
     return this.#isMounted && this.#mountCycle === cycle;
   }
 
+  /**
+   * Run a hook or a cleanup owned by the component. A throw there must not
+   * abandon the framework bookkeeping which follows it, so it is reported and
+   * swallowed; the sentinel lets the few callers which care tell a failure
+   * from a value the call returned.
+   */
+  #guard<T>(message: string, run: () => T): T | typeof GUARD_FAILED {
+    try {
+      return run();
+    } catch (error) {
+      reportLifecycleFailure(this, message, error);
+      return GUARD_FAILED;
+    }
+  }
+
   #initializeOptionEffects(cycle: number): void {
     for (const [name, reader] of optionReaders.get(this) ?? []) {
       if (!this.#isActiveMountCycle(cycle)) {
@@ -1203,11 +1201,7 @@ export class Base<T extends BaseProps = BaseProps> {
     const previousCleanup = this.#optionCleanups.get(name);
     this.#optionCleanups.delete(name);
     if (previousCleanup) {
-      try {
-        previousCleanup();
-      } catch (error) {
-        reportLifecycleFailure(this, `Option "${name}" cleanup failed.`, error);
-      }
+      this.#guard(`Option "${name}" cleanup failed.`, previousCleanup);
     }
     if (!this.#isMounted) {
       return;
@@ -1220,8 +1214,7 @@ export class Base<T extends BaseProps = BaseProps> {
     }
 
     const cycle = this.#mountCycle;
-    let cleanup: OptionChangedReturn;
-    try {
+    const cleanup = this.#guard(`\`${method}()\` failed.`, () => {
       const rawValue = reader.rawValue();
       const change: OptionChange = {
         name,
@@ -1231,20 +1224,16 @@ export class Base<T extends BaseProps = BaseProps> {
         previousRawValue,
         initial,
       };
-      cleanup = (handler as (change: OptionChange) => OptionChangedReturn).call(this, change);
-    } catch (error) {
-      reportLifecycleFailure(this, `\`${method}()\` failed.`, error);
+      return (handler as (change: OptionChange) => OptionChangedReturn).call(this, change);
+    });
+    if (cleanup === GUARD_FAILED) {
       return;
     }
     if (typeof cleanup === 'function') {
       if (this.#isMounted && this.#mountCycle === cycle) {
         this.#optionCleanups.set(name, cleanup);
       } else {
-        try {
-          cleanup();
-        } catch (error) {
-          reportLifecycleFailure(this, `Option "${name}" cleanup failed.`, error);
-        }
+        this.#guard(`Option "${name}" cleanup failed.`, cleanup);
       }
     }
   }
@@ -1253,11 +1242,7 @@ export class Base<T extends BaseProps = BaseProps> {
     const cleanups = this.#optionCleanups;
     this.#optionCleanups = new Map();
     for (const [name, cleanup] of cleanups) {
-      try {
-        cleanup();
-      } catch (error) {
-        reportLifecycleFailure(this, `Option "${name}" cleanup failed.`, error);
-      }
+      this.#guard(`Option "${name}" cleanup failed.`, cleanup);
     }
   }
 
@@ -1273,11 +1258,7 @@ export class Base<T extends BaseProps = BaseProps> {
       } else {
         // The originating mount cycle ended while an async result was pending:
         // run the cleanup right away instead of leaking.
-        try {
-          result();
-        } catch (error) {
-          reportLifecycleFailure(this, 'A late mount cleanup failed.', error);
-        }
+        this.#guard('A late mount cleanup failed.', result);
       }
       return;
     }

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -466,6 +466,42 @@ function warnLiteralDefault(
   );
 }
 
+/** Turn the attribute in force into a value. `null` means the attribute is absent. */
+type OptionTypeRule = (raw: string | null, defaultValue: () => unknown) => unknown;
+
+/** An absent attribute reads the declared default, or the type's empty value. */
+function absentValue(defaultValue: () => unknown, empty: unknown): unknown {
+  const value = defaultValue();
+  return value === undefined ? empty : value;
+}
+
+/**
+ * `buildDefault()` already answers `[]` or `{}` when nothing was declared, so
+ * a structured type needs no empty value of its own. Unparsable JSON is not a
+ * failure either: the option falls back to that same default.
+ */
+function readJSON(raw: string | null, defaultValue: () => unknown): unknown {
+  if (raw === null) {
+    return absentValue(defaultValue, undefined);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return defaultValue();
+  }
+}
+
+/** What each supported option type makes of its attribute. */
+const OPTION_TYPE_RULES = new Map<unknown, OptionTypeRule>([
+  // Presence is the value, so — unlike every other type — a declared `null`
+  // default still reads as `false`.
+  [Boolean, (raw, defaultValue) => (raw === null ? (defaultValue() ?? false) : raw !== 'false')],
+  [Number, (raw, defaultValue) => (raw === null ? absentValue(defaultValue, 0) : Number(raw))],
+  [String, (raw, defaultValue) => (raw === null ? absentValue(defaultValue, '') : raw)],
+  [Array, readJSON],
+  [Object, readJSON],
+]);
+
 function buildOptions(instance: Base): Record<string, unknown> {
   const options: Record<string, unknown> = {};
   const readers = new Map<string, OptionReader>();
@@ -509,29 +545,12 @@ function buildOptions(instance: Base): Record<string, unknown> {
       return undefined;
     };
 
-    const read = (raw: string | null): unknown => {
-      if (type === Boolean) {
-        return raw === null ? (defaultValue() ?? false) : raw !== 'false';
-      }
-      if (raw === null) {
-        const value = defaultValue();
-        if (value !== undefined) return value;
-        if (type === Number) return 0;
-        if (type === String) return '';
-        return undefined;
-      }
-      if (type === Number) {
-        return Number(raw);
-      }
-      if (type === Array || type === Object) {
-        try {
-          return JSON.parse(raw);
-        } catch {
-          return defaultValue();
-        }
-      }
-      return raw;
-    };
+    // An unrecognised type has no rule of its own: it keeps the declared
+    // default when the attribute is absent, and the raw string otherwise.
+    const rule =
+      OPTION_TYPE_RULES.get(type) ??
+      ((raw, fallback) => (raw === null ? absentValue(fallback, undefined) : raw));
+    const read = (raw: string | null): unknown => rule(raw, defaultValue);
 
     // Every option is responsive, and it is **derived on read**: the getter
     // consults the viewport as well as the element, and stores nothing. This

--- a/packages/v4/src/context.ts
+++ b/packages/v4/src/context.ts
@@ -1,4 +1,4 @@
-import { reportDiagnostic } from './diagnostics.js';
+import { isolateCallbackFailure } from './diagnostics.js';
 import { getSharedRuntimeSlot } from './shared-runtime.js';
 
 const CONTEXT_REQUEST = 'js-toolkit:context:request';
@@ -50,11 +50,9 @@ export function signal<T>(initialValue: T): Signal<T> {
           if (!subscriber.isActive) {
             continue;
           }
-          try {
-            subscriber.callback(delivered);
-          } catch (error) {
-            reportDiagnostic('callback.signal-failed', 'A signal subscriber failed.', error);
-          }
+          isolateCallbackFailure('callback.signal-failed', 'A signal subscriber failed.', () =>
+            subscriber.callback(delivered),
+          );
           if (current !== delivered) {
             break;
           }
@@ -80,15 +78,11 @@ export function signal<T>(initialValue: T): Signal<T> {
       const subscriber: Subscriber<T> = { callback, isActive: true };
       subscribers.add(subscriber);
       if (immediate) {
-        try {
-          callback(current);
-        } catch (error) {
-          reportDiagnostic(
-            'callback.signal-failed',
-            'An immediate signal subscriber failed.',
-            error,
-          );
-        }
+        isolateCallbackFailure(
+          'callback.signal-failed',
+          'An immediate signal subscriber failed.',
+          () => callback(current),
+        );
       }
       return () => {
         subscriber.isActive = false;

--- a/packages/v4/src/decorators.ts
+++ b/packages/v4/src/decorators.ts
@@ -195,25 +195,41 @@ function mergeOwnConfigs(base: BaseConfig, extra: BaseConfig): BaseConfig {
  * are the only ones worth a warning.
  */
 function conflictingKeys(base: BaseConfig, extra: BaseConfig): string[] {
+  return [
+    ...conflictingScalars(base, extra),
+    ...conflictingEntries('options', base, extra),
+    ...conflictingEntries('components', base, extra),
+  ];
+}
+
+/** Top-level keys both declare with different values; the collections are compared per entry. */
+function conflictingScalars(base: BaseConfig, extra: BaseConfig): string[] {
   const conflicts: string[] = [];
   const scalars = base as unknown as Record<string, unknown>;
   for (const [key, value] of Object.entries(extra)) {
-    if (key !== 'refs' && key !== 'options' && key !== 'components' && scalars[key] !== undefined) {
-      if (scalars[key] !== value) {
-        conflicts.push(key);
-      }
+    const isCollection = key === 'refs' || key === 'options' || key === 'components';
+    if (!isCollection && scalars[key] !== undefined && scalars[key] !== value) {
+      conflicts.push(key);
     }
   }
-  for (const key of ['options', 'components'] as const) {
-    const own = base[key];
-    const incoming = extra[key];
-    if (!own || !incoming) {
-      continue;
-    }
-    for (const [entry, value] of Object.entries(incoming)) {
-      if (own[entry] !== undefined && own[entry] !== value) {
-        conflicts.push(`${key}.${entry}`);
-      }
+  return conflicts;
+}
+
+/** Entries of one collection both declare with different values. */
+function conflictingEntries(
+  key: 'options' | 'components',
+  base: BaseConfig,
+  extra: BaseConfig,
+): string[] {
+  const own = base[key];
+  const incoming = extra[key];
+  if (!own || !incoming) {
+    return [];
+  }
+  const conflicts: string[] = [];
+  for (const [entry, value] of Object.entries(incoming)) {
+    if (own[entry] !== undefined && own[entry] !== value) {
+      conflicts.push(`${key}.${entry}`);
     }
   }
   return conflicts;

--- a/packages/v4/src/diagnostics.ts
+++ b/packages/v4/src/diagnostics.ts
@@ -57,6 +57,25 @@ export function reportDiagnostic(
   return dispatchDiagnostic(detail, target);
 }
 
+/**
+ * Run a callback the framework does not own, and report a throw instead of
+ * letting it out: one failing subscriber must not stop delivery to the others,
+ * nor turn a subscription into a failure for the caller.
+ *
+ * @internal
+ */
+export function isolateCallbackFailure(
+  code: ToolkitDiagnosticCode,
+  message: string,
+  run: () => void,
+): void {
+  try {
+    run();
+  } catch (error) {
+    reportDiagnostic(code, message, error);
+  }
+}
+
 /** @internal */
 export function warn(
   code: ToolkitDiagnosticCode,

--- a/packages/v4/src/registry.ts
+++ b/packages/v4/src/registry.ts
@@ -659,8 +659,14 @@ function destroyWithin(node: Node, snapshot?: readonly Element[]): void {
   }
 }
 
-function processMutations(records: readonly DOMMutationRecord[]): void {
-  // Teardown must finish before a moved node mounts under its new ancestor.
+/** The attribute mutations of one batch, sorted by what they affect. */
+interface AttributeChanges {
+  declarations: Set<HTMLElement>;
+  strategies: Set<HTMLElement>;
+  options: Map<HTMLElement, Map<string, string | null>>;
+}
+
+function destroyRemovedSubtrees(records: readonly DOMMutationRecord[]): void {
   for (const { record, removedSubtrees } of records) {
     if (record.type === 'childList') {
       for (const node of record.removedNodes) {
@@ -668,7 +674,9 @@ function processMutations(records: readonly DOMMutationRecord[]): void {
       }
     }
   }
+}
 
+function collectAttributeChanges(records: readonly DOMMutationRecord[]): AttributeChanges {
   const declarations = new Set<HTMLElement>();
   const strategies = new Set<HTMLElement>();
   const options = new Map<HTMLElement, Map<string, string | null>>();
@@ -690,13 +698,17 @@ function processMutations(records: readonly DOMMutationRecord[]): void {
         options.set(record.target, changes);
       }
       // Mutation records carry each preceding value. Keeping the first one
-      // and reading the final DOM below coalesces same-task writes.
+      // and reading the final DOM when the batch is applied coalesces
+      // same-task writes.
       if (!changes.has(record.attributeName)) {
         changes.set(record.attributeName, record.oldValue);
       }
     }
   }
+  return { declarations, strategies, options };
+}
 
+function reconcileChangedElements({ declarations, strategies }: AttributeChanges): void {
   // Reconcile once from final DOM state even when a morph changed the same
   // attribute several times in this observer batch.
   for (const el of declarations) {
@@ -709,10 +721,9 @@ function processMutations(records: readonly DOMMutationRecord[]): void {
       reconcileElement(el);
     }
   }
+}
 
-  // Option effects only run on components which survived declaration
-  // reconciliation and are mounted in this cycle. A waiting strategy reads
-  // the final values when it eventually mounts.
+function applyOptionChanges({ options }: AttributeChanges): void {
   for (const [el, changes] of options) {
     if (!el.isConnected) {
       continue;
@@ -724,7 +735,9 @@ function processMutations(records: readonly DOMMutationRecord[]): void {
       }
     }
   }
+}
 
+function scanAddedNodes(records: readonly DOMMutationRecord[]): void {
   for (const { record } of records) {
     if (record.type === 'childList') {
       for (const node of record.addedNodes) {
@@ -734,4 +747,20 @@ function processMutations(records: readonly DOMMutationRecord[]): void {
       }
     }
   }
+}
+
+function processMutations(records: readonly DOMMutationRecord[]): void {
+  // Teardown must finish before a moved node mounts under its new ancestor.
+  destroyRemovedSubtrees(records);
+  // Every attribute of the batch is collected before any of them is applied,
+  // so an element touched several times reconciles once, from final DOM state.
+  const changes = collectAttributeChanges(records);
+  reconcileChangedElements(changes);
+  // Option effects only run on components which survived declaration
+  // reconciliation and are mounted in this cycle. A waiting strategy reads
+  // the final values when it eventually mounts.
+  applyOptionChanges(changes);
+  // Insertions come last: a node moved within this batch was torn down above
+  // and mounts here, under the ancestor it ended up in.
+  scanAddedNodes(records);
 }

--- a/packages/v4/src/services/service.ts
+++ b/packages/v4/src/services/service.ts
@@ -1,4 +1,4 @@
-import { reportDiagnostic } from '../diagnostics.js';
+import { isolateCallbackFailure } from '../diagnostics.js';
 
 /** Release one subscription. Services start with their first subscriber and stop with their last. */
 export type Unsubscribe = () => void;
@@ -71,12 +71,9 @@ export function createService<T, R = void>({
       if (!subscription.isActive) {
         continue;
       }
-      try {
-        subscription.callback(current);
-      } catch (error) {
-        // Isolate subscriber failures.
-        reportDiagnostic('callback.service-failed', 'A service subscriber failed.', error);
-      }
+      isolateCallbackFailure('callback.service-failed', 'A service subscriber failed.', () =>
+        subscription.callback(current),
+      );
     }
   }
 
@@ -104,16 +101,12 @@ export function createService<T, R = void>({
       }
       // Deliver after startup, when props are current, and only to the new subscriber.
       if (immediate && (hasProps?.() ?? true)) {
-        try {
-          callback(props());
-        } catch (error) {
-          // Keep `subscribe()` successful so the caller receives its unsubscribe.
-          reportDiagnostic(
-            'callback.service-failed',
-            'An immediate service subscriber failed.',
-            error,
-          );
-        }
+        // Keep `subscribe()` successful so the caller receives its unsubscribe.
+        isolateCallbackFailure(
+          'callback.service-failed',
+          'An immediate service subscriber failed.',
+          () => callback(props()),
+        );
       }
       return () => {
         // Unsubscribe is idempotent.


### PR DESCRIPTION
Six behavior-preserving refactors on `packages/v4/src`, each in its own commit, from a cyclomatic complexity analysis of the package.

## Why

Complexity in v4 is concentrated, not spread: before this PR, 8% of the functions held 31% of the total, and a single function held 30 of it. These commits take the top of that list. No public API changes, no behavior changes — every diagnostic code, message and ordering is preserved byte-for-byte, and the whole suite passes unchanged.

## Result

| Metric | Before | After |
| --- | --- | --- |
| Functions | 830 | 857 |
| Total complexity | 1890 | 1904 |
| Mean | 2.28 | 2.22 |
| **Max** | **30** | **18** |
| **Functions at CC ≥ 11** | **14** | **8** |

The total goes up by 14 because extraction adds function boundaries — expected, and not the metric that matters here. What matters is that the worst function drops from 30 to 3. Every remaining function at CC ≥ 11 is one this PR does not target.

## The commits

| Commit | Function | CC |
| --- | --- | --- |
| Split `processMutations` into its named phases | `registry.ts` | 30 → 3 |
| Route lifecycle failures through one guard helper | `Base.ts`, 10 call sites | −20 |
| Split `bindHandlers` into its three binding phases | `Base.ts` | 15 → 3 |
| Read option values from a per-type table | `Base.ts` | 12 → 1 |
| Split `conflictingKeys` into its two comparisons | `decorators.ts` | 13 → 1 |
| Isolate subscriber failures with one shared helper | `context.ts`, `services/service.ts` | −6 |

Two of them remove real duplication rather than only branches: ten copies of the same `try/catch` + `reportLifecycleFailure` block in `Base.ts`, and four copies of the subscriber-failure block across `context.ts` and `services/service.ts`.

## Cost

Bundled per export, minified and gzipped, against `main`:

| Export | main | This PR |
| :-- | --: | --: |
| `(barrel)` | 22.65 kB | +225 B (+1.0%) |
| `component` | 6.75 kB | +95 B (+1.4%) |
| `registerComponent` | 6.44 kB | +66 B (+1.0%) |
| `Base` | 8.05 kB | +128 B (+1.6%) |

## Not done, deliberately

- **A mount-strategy dispatch table.** It was written, measured and dropped: it replaced a short-circuiting if-chain with a `Map` lookup plus a per-call context object, on the path the registry runs for every element/component pair, and cost ~130 B on top. `applyMountStrategy` stays at CC 11.
- **`transform` (18), `createElement` (15), `reconcileElement` (14).** Above the rest of the distribution, but their complexity is breadth, not depth — splitting them would trade a flat table of cases for indirection.

## Notes for review

- `collectAttributeChanges` (`registry.ts`, CC 12) is the one function this PR creates above 11. It is a flat classification of attribute names into three buckets; splitting it further would add indirection without adding clarity.
- No `*.spec.ts` file was modified.

## Verification

- `npm run test:v4` — 80 files, 1083 tests passing, unchanged from `main`.
- `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9
