### PR TITLE
feat(v4): support multiple option types

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -180,6 +180,8 @@ options: {
 - **A literal object or array default is warned about, not repaired.** The type-level ban settles it for anyone with a build step; the no-build path never sees a type, so the same rule is said out loud — once per declaration, naming the component, the option and the fix — and the value is then handed over exactly as declared, shared between instances. Copying it was tried and removed: a shallow copy made an unsupported declaration appear to work one level deep, and a deep copy made core guess at how to rebuild a `Date`, a `Map` or a class instance. Neither is core's job when the contract already has an answer that works all the way down.
 - A mutation of a value **parsed from an attribute** is not kept, on the other hand: the attribute is re-read and re-parsed on the next access, which is what keeps options live.
 
+**An option can accept several types.** Declare the accepted constructors in order: `offset: [Number, Array]` reads `"10"` as a number and `"[10, 20]"` as an array. Each parser must produce a value of its declared type before the next parser is tried. An absent union option uses its declared default, or the empty value of its first type.
+
 ### Setup-sensitive options are live effects
 
 Reading an option on demand is enough for values used inside handlers and insufficient for an option which chooses a subscription, target, or other mount-scoped resource. A declared method named `option<Name>Changed()` turns that option into a live effect:

--- a/packages/v4/src/Base.spec.ts
+++ b/packages/v4/src/Base.spec.ts
@@ -160,6 +160,54 @@ describe('$options', () => {
     expect(instance.$options.count).toBe(9);
   });
 
+  it('reads the first matching type from a union option', () => {
+    class Offset extends Base<{ $options: { offset: number | unknown[] } }> {
+      static config = {
+        name: 'Offset',
+        options: {
+          offset: [Number, Array],
+        },
+      };
+    }
+
+    const number = document.createElement('div');
+    number.setAttribute('data-option-offset', '10');
+    expect(new Offset(number).$options.offset).toBe(10);
+
+    const array = document.createElement('div');
+    array.setAttribute('data-option-offset', '[10, 20]');
+    expect(new Offset(array).$options.offset).toEqual([10, 20]);
+
+    const fallback = new Offset(document.createElement('div'));
+    expect(fallback.$options.offset).toBe(0);
+
+    class Ordered extends Base<{ $options: { value: string | number } }> {
+      static config = {
+        name: 'Ordered',
+        options: {
+          value: { type: [String, Number], default: 1 },
+        },
+      };
+    }
+
+    const ordered = document.createElement('div');
+    ordered.setAttribute('data-option-value', '10');
+    expect(new Ordered(ordered).$options.value).toBe('10');
+
+    class Defaulted extends Base<{ $options: { value: number | unknown[] } }> {
+      static config = {
+        name: 'DefaultedUnion',
+        options: {
+          value: { type: [Number, Array], default: 3 },
+        },
+      };
+    }
+
+    const invalid = document.createElement('div');
+    invalid.setAttribute('data-option-value', 'invalid');
+    expect(new Defaulted(invalid).$options.value).toBe(3);
+  });
+
   it('gives each instance its own defaulted object, declared or not', () => {
     class Defaulted extends Base<{
       $options: { tween: Record<string, unknown>; list: unknown[]; bag: Record<string, unknown> };

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -30,27 +30,46 @@ export type OptionType =
   | typeof Array
   | typeof Object;
 
+/** An ordered list of types accepted by one option. */
+export type OptionTypes = readonly OptionType[];
+
+type OptionDefinitionType = OptionType | OptionTypes;
+
 /**
  * The value an option of a given type holds.
  */
-type OptionValue<T extends OptionType> = T extends typeof String
-  ? string
-  : T extends typeof Number
-    ? number
-    : T extends typeof Boolean
-      ? boolean
-      : T extends typeof Array
-        ? unknown[]
-        : Record<string, unknown>;
+type OptionValue<T extends OptionDefinitionType> = T extends OptionTypes
+  ? OptionValue<T[number]>
+  : T extends typeof String
+    ? string
+    : T extends typeof Number
+      ? number
+      : T extends typeof Boolean
+        ? boolean
+        : T extends typeof Array
+          ? unknown[]
+          : Record<string, unknown>;
+
+type PrimitiveOptionType = typeof String | typeof Number | typeof Boolean;
 
 /** `Array` and `Object` defaults must be per-instance factories. */
-type TypedOptionDefinition<T extends OptionType = OptionType> = T extends OptionType
-  ? T extends typeof Array | typeof Object
-    ? { type: T; default?: () => OptionValue<T> }
-    : { type: T; default?: OptionValue<T> | (() => OptionValue<T>) }
-  : never;
+type TypedOptionDefinition<T extends OptionDefinitionType = OptionDefinitionType> =
+  T extends OptionTypes
+    ? {
+        type: T;
+        default?:
+          | (() => OptionValue<T>)
+          | (Extract<T[number], PrimitiveOptionType> extends never
+              ? never
+              : OptionValue<Extract<T[number], PrimitiveOptionType>>);
+      }
+    : T extends OptionType
+      ? T extends typeof Array | typeof Object
+        ? { type: T; default?: () => OptionValue<T> }
+        : { type: T; default?: OptionValue<T> | (() => OptionValue<T>) }
+      : never;
 
-export type OptionDefinition = OptionType | TypedOptionDefinition;
+export type OptionDefinition = OptionDefinitionType | TypedOptionDefinition;
 
 export interface OptionChange<T = unknown> {
   name: string;
@@ -504,8 +523,24 @@ function readJSON(raw: string | null, defaultValue: () => unknown): unknown {
   }
 }
 
+function emptyValue(type: OptionType): unknown {
+  if (type === Boolean) return false;
+  if (type === Number) return 0;
+  if (type === String) return '';
+  if (type === Array) return [];
+  return {};
+}
+
+function isOptionValue(value: unknown, type: OptionType): boolean {
+  if (type === Boolean) return typeof value === 'boolean';
+  if (type === Number) return typeof value === 'number' && !Number.isNaN(value);
+  if (type === String) return typeof value === 'string';
+  if (type === Array) return Array.isArray(value);
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 /** What each supported option type makes of its attribute. */
-const OPTION_TYPE_RULES = new Map<unknown, OptionTypeRule>([
+const OPTION_TYPE_RULES = new Map<OptionType, OptionTypeRule>([
   // Presence is the value, so — unlike every other type — a declared `null`
   // default still reads as `false`.
   [Boolean, (raw, defaultValue) => (raw === null ? (defaultValue() ?? false) : raw !== 'false')],
@@ -515,17 +550,41 @@ const OPTION_TYPE_RULES = new Map<unknown, OptionTypeRule>([
   [Object, readJSON],
 ]);
 
+function readUnion(types: OptionTypes, raw: string | null, defaultValue: () => unknown): unknown {
+  if (raw === null) {
+    return absentValue(defaultValue, types[0] === undefined ? undefined : emptyValue(types[0]));
+  }
+
+  for (const type of types) {
+    const value = OPTION_TYPE_RULES.get(type)!(raw, () => undefined);
+    if (isOptionValue(value, type)) {
+      return value;
+    }
+  }
+
+  return defaultValue();
+}
+
+function isOptionTypes(value: unknown): value is OptionTypes {
+  return Array.isArray(value);
+}
+
+function isOptionShorthand(definition: OptionDefinition): definition is OptionType | OptionTypes {
+  return typeof definition === 'function' || isOptionTypes(definition);
+}
+
 function buildOptions(instance: Base): Record<string, unknown> {
   const options: Record<string, unknown> = {};
   const readers = new Map<string, OptionReader>();
   optionReaders.set(instance, readers);
   const el = instance.$el;
   for (const [name, definition] of Object.entries(instance.$config.options ?? {})) {
-    const type = typeof definition === 'function' ? definition : definition.type;
-    const declared = typeof definition === 'function' ? undefined : definition.default;
+    const shorthand = isOptionShorthand(definition);
+    const type = shorthand ? definition : definition.type;
+    const declared = shorthand ? undefined : definition.default;
     const attribute = optionAttributeFor(name);
 
-    if (typeof definition !== 'function' && declared !== null && typeof declared === 'object') {
+    if (!shorthand && declared !== null && typeof declared === 'object') {
       warnLiteralDefault(instance.$config.name, name, definition, declared, el);
     }
 
@@ -553,17 +612,18 @@ function buildOptions(instance: Base): Record<string, unknown> {
         return declared;
       }
       // An undeclared object or array default is still the instance's own.
-      if (type === Array) return [];
-      if (type === Object) return {};
+      const defaultType = isOptionTypes(type) ? type[0] : type;
+      if (defaultType === Array) return [];
+      if (defaultType === Object) return {};
       return undefined;
     };
 
-    // An unrecognised type has no rule of its own: it keeps the declared
-    // default when the attribute is absent, and the raw string otherwise.
-    const rule =
-      OPTION_TYPE_RULES.get(type) ??
-      ((raw, fallback) => (raw === null ? absentValue(fallback, undefined) : raw));
-    const read = (raw: string | null): unknown => rule(raw, defaultValue);
+    const read = (raw: string | null): unknown =>
+      isOptionTypes(type)
+        ? readUnion(type, raw, defaultValue)
+        : (OPTION_TYPE_RULES.get(type) ??
+            ((value, fallback) =>
+              value === null ? absentValue(fallback, undefined) : value))(raw, defaultValue);
 
     // Every option is responsive, and it is **derived on read**: the getter
     // consults the viewport as well as the element, and stores nothing. This

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -621,9 +621,10 @@ function buildOptions(instance: Base): Record<string, unknown> {
     const read = (raw: string | null): unknown =>
       isOptionTypes(type)
         ? readUnion(type, raw, defaultValue)
-        : (OPTION_TYPE_RULES.get(type) ??
-            ((value, fallback) =>
-              value === null ? absentValue(fallback, undefined) : value))(raw, defaultValue);
+        : (
+            OPTION_TYPE_RULES.get(type) ??
+            ((value, fallback) => (value === null ? absentValue(fallback, undefined) : value))
+          )(raw, defaultValue);
 
     // Every option is responsive, and it is **derived on read**: the getter
     // consults the viewport as well as the element, and stores nothing. This

--- a/packages/v4/src/index.ts
+++ b/packages/v4/src/index.ts
@@ -14,6 +14,7 @@ export {
   type OptionChangedReturn,
   type OptionDefinition,
   type OptionType,
+  type OptionTypes,
   type RefEvent,
   type WatchChildrenCallbacks,
 } from './Base.js';


### PR DESCRIPTION
## Summary
- support ordered option type unions such as `[Number, Array]`
- preserve defaults and parse values only when they match a declared type
- document union options and cover their parsing behavior

Closes #651

## Tests
- `npm run lint:types -w @studiometa/js-toolkit-v4`
- `npm run test -w @studiometa/js-toolkit-v4`
- `npm run build -w @studiometa/js-toolkit-v4`