### PR TITLE
refactor(v4): simplification pass over the core modules

### DIFF
--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -460,6 +460,22 @@ interface OptionReader {
 
 const optionReaders = new WeakMap<Base, Map<string, OptionReader>>();
 
+/** The method name an option's effect is declared under. */
+function optionChangedMethod(name: string): string {
+  return `option${capitalize(name)}Changed`;
+}
+
+/** The effect an option declares, or `undefined` when the component declares none. */
+function optionChangedHandler(
+  instance: Base,
+  name: string,
+): ((change: OptionChange) => OptionChangedReturn) | undefined {
+  const handler = (instance as unknown as Record<string, unknown>)[optionChangedMethod(name)];
+  return typeof handler === 'function'
+    ? (handler as (change: OptionChange) => OptionChangedReturn)
+    : undefined;
+}
+
 /** Warn once per declaration for literal object or array defaults. Values are not copied. */
 function warnLiteralDefault(
   componentName: string,
@@ -1210,9 +1226,7 @@ export class Base<T extends BaseProps = BaseProps> {
 
     let announces = false;
     for (const name of readers.keys()) {
-      announces ||=
-        typeof (this as unknown as Record<string, unknown>)[`option${capitalize(name)}Changed`] ===
-        'function';
+      announces ||= optionChangedHandler(this, name) !== undefined;
     }
     if (!announces) {
       return;
@@ -1249,14 +1263,13 @@ export class Base<T extends BaseProps = BaseProps> {
       return;
     }
 
-    const method = `option${capitalize(name)}Changed`;
-    const handler = (this as unknown as Record<string, unknown>)[method];
-    if (typeof handler !== 'function') {
+    const handler = optionChangedHandler(this, name);
+    if (!handler) {
       return;
     }
 
     const cycle = this.#mountCycle;
-    const cleanup = this.#guard(`\`${method}()\` failed.`, () => {
+    const cleanup = this.#guard(`\`${optionChangedMethod(name)}()\` failed.`, () => {
       const rawValue = reader.rawValue();
       const change: OptionChange = {
         name,
@@ -1266,7 +1279,7 @@ export class Base<T extends BaseProps = BaseProps> {
         previousRawValue,
         initial,
       };
-      return (handler as (change: OptionChange) => OptionChangedReturn).call(this, change);
+      return handler.call(this, change);
     });
     if (cleanup === GUARD_FAILED) {
       return;

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -3,6 +3,7 @@ import { BASE_BRAND } from './component-brand.js';
 import { componentTokens } from './component-declarations.js';
 import { injectContext, injectContextSync, provideContext, type ContextKey } from './context.js';
 import { reportDiagnostic, warnOnce } from './diagnostics.js';
+import { compareDocumentOrder } from './document-order.js';
 import { domVersion } from './dom-mutations.js';
 import { EVENTS } from './events.js';
 import { HANDLER_REGISTRATIONS, INSTANCES } from './protocol-symbols.js';
@@ -351,9 +352,7 @@ function queryRefs(root: HTMLElement, componentName: string, definition: string)
   }
   // One property, so one document order — an index handed to `on<Ref><Event>`
   // has to mean the same thing as an index into `$refs`.
-  return [...plain, ...owned].sort((a, b) =>
-    a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
-  );
+  return [...plain, ...owned].sort(compareDocumentOrder);
 }
 
 /** Warn once when a missing list ref has an unsuffixed markup candidate. */
@@ -1086,12 +1085,7 @@ export class Base<T extends BaseProps = BaseProps> {
         return instances.size;
       },
       get items() {
-        return [...instances].sort((a, b) => {
-          const position = a.$el.compareDocumentPosition(b.$el);
-          if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
-          if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
-          return 0;
-        });
+        return [...instances].sort((a, b) => compareDocumentOrder(a.$el, b.$el));
       },
       [Symbol.iterator]() {
         return this.items[Symbol.iterator]();

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -1224,10 +1224,9 @@ export class Base<T extends BaseProps = BaseProps> {
       [...readers.values()].map((reader) => reader.attribute),
     );
 
-    let announces = false;
-    for (const name of readers.keys()) {
-      announces ||= optionChangedHandler(this, name) !== undefined;
-    }
+    const announces = [...readers.keys()].some(
+      (name) => optionChangedHandler(this, name) !== undefined,
+    );
     if (!announces) {
       return;
     }

--- a/packages/v4/src/decorators.ts
+++ b/packages/v4/src/decorators.ts
@@ -176,6 +176,9 @@ export const read = inPhase('$read');
 /** Schedule the method body in the next write phase. Destruction cancels pending work. */
 export const write = inPhase('$write');
 
+/** Config keys that merge rather than override; the rest are compared as scalars. */
+const COLLECTION_KEYS = new Set(['refs', 'options', 'components']);
+
 /**
  * Merge the two config declarations one class can carry, by the rules
  * `resolveConfig()` applies to a chain: collections merge, declared values
@@ -215,8 +218,7 @@ function conflictingScalars(base: BaseConfig, extra: BaseConfig): string[] {
   const conflicts: string[] = [];
   const scalars = base as unknown as Record<string, unknown>;
   for (const [key, value] of Object.entries(extra)) {
-    const isCollection = key === 'refs' || key === 'options' || key === 'components';
-    if (!isCollection && scalars[key] !== undefined && scalars[key] !== value) {
+    if (!COLLECTION_KEYS.has(key) && scalars[key] !== undefined && scalars[key] !== value) {
       conflicts.push(key);
     }
   }

--- a/packages/v4/src/document-order.ts
+++ b/packages/v4/src/document-order.ts
@@ -1,0 +1,16 @@
+/**
+ * Document order, the only order DOM-anchored peers can agree on without
+ * either the coordinator or the mount sequence arbitrating it.
+ *
+ * Imports nothing, so ordering costs a consumer no component graph.
+ */
+export function compareDocumentOrder(a: Node, b: Node): number {
+  const position = a.compareDocumentPosition(b);
+  if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+    return -1;
+  }
+  if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+    return 1;
+  }
+  return 0;
+}

--- a/packages/v4/src/group.ts
+++ b/packages/v4/src/group.ts
@@ -1,4 +1,5 @@
 import { signal, type Signal } from './context.js';
+import { compareDocumentOrder } from './document-order.js';
 
 /**
  * What a group needs of a member: the element that decides its rank.
@@ -45,21 +46,6 @@ export interface Group<T extends GroupMember = GroupMember> {
 }
 
 /**
- * Document order, the only order DOM-anchored peers can agree on without
- * either the coordinator or the mount sequence arbitrating it.
- */
-function inDocumentOrder(a: GroupMember, b: GroupMember): number {
-  const position = a.$el.compareDocumentPosition(b.$el);
-  if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
-    return -1;
-  }
-  if (position & Node.DOCUMENT_POSITION_PRECEDING) {
-    return 1;
-  }
-  return 0;
-}
-
-/**
  * Create an empty group.
  *
  * A member leaves through the function `join()` returned; nothing sweeps
@@ -73,7 +59,7 @@ export function createGroup<T extends GroupMember = GroupMember>(): Group<T> {
   // Sorting on write keeps the published value ready to read and makes the
   // new array identity the notification.
   const publish = () => {
-    members.value = [...joined].sort(inDocumentOrder);
+    members.value = [...joined].sort((a, b) => compareDocumentOrder(a.$el, b.$el));
   };
 
   return {

--- a/packages/v4/src/registry.ts
+++ b/packages/v4/src/registry.ts
@@ -346,18 +346,14 @@ function resolveComponentClass(module: unknown, name: string): BaseConstructor |
 }
 
 function optionAttributes(ComponentClass: BaseConstructor): string[] {
-  const names = new Set<string>();
-  let current: BaseConstructor | null = ComponentClass;
-  while (current?.config) {
-    for (const name of Object.keys(current.config.options ?? {})) {
-      const attribute = optionAttributeFor(name);
-      names.add(attribute);
-      // Register each exact breakpoint-scoped spelling with the observer filter.
-      observeResponsiveAttribute(attribute);
-    }
-    current = Object.getPrototypeOf(current) as BaseConstructor | null;
+  const names: string[] = [];
+  for (const name of Object.keys(resolveConfig(ComponentClass).options ?? {})) {
+    const attribute = optionAttributeFor(name);
+    names.push(attribute);
+    // Register each exact breakpoint-scoped spelling with the observer filter.
+    observeResponsiveAttribute(attribute);
   }
-  return [...names];
+  return names;
 }
 
 /**


### PR DESCRIPTION
Five behavior-preserving simplifications over the v4 core modules.

- `registry.ts`: `optionAttributes()` reads the declared options from `resolveConfig()` instead of walking the prototype chain a second time.
- New internal `document-order.ts`: one `compareDocumentOrder()` comparator, used by `queryRefs()`, the `$watchChildren()` `items` getter, and `group.ts`. Not exported from `utils` and given no subpath — it is core's own use. It imports nothing, so `group.ts` stays free of `Base.js`.
- `Base.ts`: the `option<Name>Changed` naming rule gets one owner, `optionChangedMethod()` / `optionChangedHandler()`.
- `Base.ts`: the `announces` scan in `#initializeResponsiveOptions()` becomes a short-circuiting `.some()`.
- `decorators.ts`: the merging config keys are named once, as `COLLECTION_KEYS`, next to `mergeOwnConfigs()`.

Behavior is unchanged and no spec was modified. `npm run test:v4` is green: 82 test files, 1145 tests passed. `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9
