### PR TITLE
feat(v4): three core primitives — scroll alignment, a counted scroll lock, and memo over resolveConfig

### DIFF
--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -783,6 +783,18 @@ Promoted from `migration/utils/` into `src/`:
 - The easing functions, on `utils/easings.ts`.
 - `spring()` and `smoothTo()`.
 
+### Locking the page scroll
+
+```js
+lockScroll(target = document.documentElement): () => void
+```
+
+- **It counts.** A modal surface is not alone on a page: a dialog opened from inside a drawer is two holders, and the one which closes first must not put the scroll back under the one still open. The first lock saves the inline value it found, the last release puts exactly that value back, and the ones between only move the count.
+- **The count is shared across evaluated copies of the package**, through the runtime slot `focus` already uses for the same reason: there is one scroll per document.
+- **The release is idempotent**, so a surface calls it on close and again on destroy without counting twice — and a component destroyed while open owes the page its scroll, which is what the second call is for.
+- **It is `overflow: hidden` and nothing else.** No `paddingRight` compensation: `scrollbar-gutter: stable` is the page's own answer and it does not mis-handle fixed children. iOS Safari remains unreliable, which is the argument for having one function rather than a copy per component.
+- `<dialog>`'s `showModal()` gives the top layer, the backdrop, a focus trap and Escape — it does **not** stop the page behind it scrolling, so a native dialog needs this too.
+
 ### Scrolling to a target
 
 ```js

--- a/packages/v4/DESIGN.md
+++ b/packages/v4/DESIGN.md
@@ -783,6 +783,18 @@ Promoted from `migration/utils/` into `src/`:
 - The easing functions, on `utils/easings.ts`.
 - `spring()` and `smoothTo()`.
 
+### Scrolling to a target
+
+```js
+scrollPosition(target, { rootElement, axis, offset, align }): ScrollPosition
+scrollTo(target, { …the same, behavior }): ScrollPosition
+```
+
+- **The two halves are separate because callers need them separately.** `scrollPosition()` measures and returns; `scrollTo()` calls it and moves. A carousel asks which slide is nearest three times for every time it travels, and asking used to mean scrolling.
+- **`align` is `'start' | 'center' | 'end'`, or one per axis**, and it applies to an **element** target only: a number or a position names its own destination. The names are physical, like `axis` — `x` and `y`, not the platform's `inline` and `block` — because nothing here maps a writing mode, and borrowing that vocabulary without the mapping would promise what `compute-scroll-into-view` promises and does not deliver.
+- **The viewport is the client box**, so a scrollbar gutter is out of the arithmetic without a special case, and the destination is clamped to the scroll range: centring the first slide asks for a negative offset and gets `0`.
+- **A dependency was measured and refused.** `compute-scroll-into-view` is 1.4 kB and walks every scrolling ancestor — which is what v4's single `rootElement` contract declines, and what `@studiometa/ui` already cancels with `boundary`. Its own source leaves writing modes unimplemented and reads no `scroll-padding`, so the real delta over core was ~20 lines.
+
 The keyframes interpolator and its `cubicBezier` stay in `migration/ScrollAnimation/`, beside the only family that calls them, so they leave with it in one deletion.
 
 Out of core, in a separate `ui-animation` package: time-based playback, stagger, sequencing, morphing and text splitting. Two entry points over one package — Motion as declarative components (`data-component="Motion"`, its props as `data-option-*`), and GSAP as a lifecycle and scoping decorator (`gsap.context()` bound to the mount cycle) with thin `Gsap` and `GsapTimeline` components. Both keep the vocabulary of their engine.

--- a/packages/v4/migration/Carousel/Carousel.spec.ts
+++ b/packages/v4/migration/Carousel/Carousel.spec.ts
@@ -6,7 +6,7 @@ import { CarouselBtn } from './CarouselBtn.js';
 import { CarouselDrag } from './CarouselDrag.js';
 import { CarouselItem } from './CarouselItem.js';
 import { CarouselWrapper } from './CarouselWrapper.js';
-import { getClosestIndex, centeredScrollPosition } from './utils.js';
+import { getClosestIndex } from './utils.js';
 
 registerComponents(Carousel, CarouselBtn, CarouselDrag, CarouselItem, CarouselWrapper);
 
@@ -80,15 +80,14 @@ describe('getClosestIndex', () => {
   });
 });
 
-describe('centeredScrollPosition', () => {
-  it('centres the element in its scroller, clamped to the scroll range', async () => {
-    const { el, wrapper } = await render({ count: 3 });
-    const [first, second, third] = itemElements(el);
+describe('slide positions', () => {
+  it('centres each slide in its scroller, clamped to the scroll range', async () => {
+    const { el } = await render({ count: 3 });
+    const carousel = getInstance<Carousel>(el, 'Carousel');
 
-    // Each slide fills the scroller, so centring is the same as aligning.
-    expect(centeredScrollPosition(first, wrapper).left).toBe(0);
-    expect(centeredScrollPosition(second, wrapper).left).toBe(200);
-    expect(centeredScrollPosition(third, wrapper).left).toBe(400);
+    // Each slide fills the scroller, so centring is the same as aligning —
+    // and the arithmetic is core's now, through `scrollPosition({ align })`.
+    expect(carousel.positions.map((position) => position.left)).toEqual([0, 200, 400]);
   });
 });
 

--- a/packages/v4/migration/Carousel/Carousel.ts
+++ b/packages/v4/migration/Carousel/Carousel.ts
@@ -10,13 +10,14 @@ import {
   type MountedReturn,
   type RafRender,
 } from '../../src/index.js';
+import { SCROLL_ALIGNMENTS, SCROLL_AXES, scrollPosition } from '../../src/utils/scrollTo.js';
 import { CarouselBtn } from './CarouselBtn.js';
 import { CarouselDrag } from './CarouselDrag.js';
 import { CarouselItem } from './CarouselItem.js';
 import { CarouselWrapper } from './CarouselWrapper.js';
 import { CarouselContext, type CarouselApi, type CarouselState } from './context.js';
 import { Indexable, type IndexableInstruction, type IndexableProps } from './Indexable.js';
-import { centeredScrollPosition, type ScrollPosition } from './utils.js';
+import { type ScrollPosition } from './utils.js';
 
 export type CarouselProps = IndexableProps & {
   $options: IndexableProps['$options'] & {
@@ -128,7 +129,13 @@ export class Carousel extends withResize(withRaf(Indexable, { manual: true }))<C
       return [];
     }
 
-    this.#positions ??= this.items.items.map((item) => centeredScrollPosition(item.$el, scroller));
+    this.#positions ??= this.items.items.map((item) =>
+      scrollPosition(item.$el, {
+        rootElement: scroller,
+        axis: SCROLL_AXES.both,
+        align: SCROLL_ALIGNMENTS.center,
+      }),
+    );
 
     return this.#positions;
   }

--- a/packages/v4/migration/Carousel/index.ts
+++ b/packages/v4/migration/Carousel/index.ts
@@ -14,8 +14,4 @@ export {
   type IndexableInstruction,
   type IndexableProps,
 } from './Indexable.js';
-export {
-  centeredScrollPosition,
-  getClosestIndex,
-  type ScrollPosition as CarouselScrollPosition,
-} from './utils.js';
+export { getClosestIndex, type ScrollPosition as CarouselScrollPosition } from './utils.js';

--- a/packages/v4/migration/Carousel/utils.ts
+++ b/packages/v4/migration/Carousel/utils.ts
@@ -1,10 +1,4 @@
-import { clamp } from '../../src/utils/maths.js';
-
-/** A scroll offset pair, the shape both the wrapper and the drag track work in. */
-export interface ScrollPosition {
-  left: number;
-  top: number;
-}
+export type { ScrollPosition } from '../../src/utils/scrollTo.js';
 
 /** The index of the number closest to the target. */
 export function getClosestIndex(numbers: number[], target: number): number {
@@ -24,32 +18,4 @@ export function getClosestIndex(numbers: number[], target: number): number {
   }
 
   return closestIndex;
-}
-
-/**
- * The scroll offsets that centre `element` inside `scroller`.
- *
- * v3 gets this from the `compute-scroll-into-view` package, called with
- * `block: 'center', inline: 'center'`. Core's own `scrollTo()` aligns a target
- * to the **start** of its scroller and takes no alignment option, so a carousel
- * that centres its slides cannot use it (gap 36) and this is the arithmetic
- * that replaces the dependency.
- */
-export function centeredScrollPosition(element: Element, scroller: Element): ScrollPosition {
-  const elementRect = element.getBoundingClientRect();
-  const scrollerRect = scroller.getBoundingClientRect();
-
-  const left =
-    scroller.scrollLeft +
-    (elementRect.left - scrollerRect.left) -
-    (scrollerRect.width - elementRect.width) / 2;
-  const top =
-    scroller.scrollTop +
-    (elementRect.top - scrollerRect.top) -
-    (scrollerRect.height - elementRect.height) / 2;
-
-  return {
-    left: clamp(left, 0, scroller.scrollWidth - scroller.clientWidth),
-    top: clamp(top, 0, scroller.scrollHeight - scroller.clientHeight),
-  };
 }

--- a/packages/v4/migration/Dialog/Dialog.spec.ts
+++ b/packages/v4/migration/Dialog/Dialog.spec.ts
@@ -141,3 +141,35 @@ describe('Dialog', () => {
     expect(document.activeElement).toBe(last);
   });
 });
+
+describe('Dialog — the page scroll', () => {
+  it('keeps the page locked while a second dialog is still open', async () => {
+    const first = render({ withTransition: false });
+    const second = render({ withTransition: false });
+    await settle();
+
+    await getInstance<Dialog>(first, 'Dialog').open();
+    await getInstance<Dialog>(second, 'Dialog').open();
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    await getInstance<Dialog>(second, 'Dialog').close();
+
+    // The first one is still open: the page is not its to give back.
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    await getInstance<Dialog>(first, 'Dialog').close();
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('gives the scroll back when a dialog is destroyed while open', async () => {
+    const el = render({ withTransition: false });
+    await settle();
+    await getInstance<Dialog>(el, 'Dialog').open();
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    el.remove();
+    await settle();
+
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+});

--- a/packages/v4/migration/Dialog/Dialog.ts
+++ b/packages/v4/migration/Dialog/Dialog.ts
@@ -2,6 +2,7 @@ import { Base, withKey, type ChildrenCollection, type KeyProps } from '../../src
 import { Transition, type Transitionable } from '../Transition/Transition.js';
 import { ViewTransition } from '../Transition/ViewTransition.js';
 import { saveActiveElement, trapFocus, untrapFocus } from '../../src/utils/focus.js';
+import { lockScroll } from '../../src/utils/scroll-lock.js';
 
 export interface DialogProps {
   $el: HTMLDialogElement;
@@ -33,6 +34,17 @@ export class Dialog extends withKey(Base)<DialogProps> {
       scrollLock: { type: Boolean, default: true },
     },
   };
+
+  /**
+   * Releases this dialog's hold on the page scroll.
+   *
+   * A field rather than a style write, because the page scroll is shared: a
+   * dialog opened from inside a drawer must not put the scroll back when it
+   * closes while the drawer is still open. It is released on close and again
+   * on destroy — the release is idempotent, and a dialog destroyed while open
+   * used to leak its lock for the life of the page.
+   */
+  #releaseScroll: (() => void) | null = null;
 
   transitionChildren: ChildrenCollection<Transition> =
     this.$watchChildren<Transition>('Transition');
@@ -77,7 +89,7 @@ export class Dialog extends withKey(Base)<DialogProps> {
     }
 
     if (this.$options.scrollLock) {
-      document.documentElement.style.overflow = 'hidden';
+      this.#releaseScroll = lockScroll();
     }
 
     this.$emit('open');
@@ -98,9 +110,14 @@ export class Dialog extends withKey(Base)<DialogProps> {
       untrapFocus();
     }
 
-    if (this.$options.scrollLock) {
-      document.documentElement.style.overflow = '';
-    }
+    this.#releaseScroll?.();
+    this.#releaseScroll = null;
+  }
+
+  /** A dialog destroyed while open still owes the page its scroll. */
+  destroyed(): void {
+    this.#releaseScroll?.();
+    this.#releaseScroll = null;
   }
 
   toggle(): Promise<void> {

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -640,6 +640,10 @@
       "types": "./dist/subpaths/utils/scrollTo.d.ts",
       "import": "./dist/subpaths/utils/scrollTo.js"
     },
+    "./utils/lockScroll": {
+      "types": "./dist/subpaths/utils/lockScroll.d.ts",
+      "import": "./dist/subpaths/utils/lockScroll.js"
+    },
     "./utils/selectorFor": {
       "types": "./dist/subpaths/utils/selectorFor.d.ts",
       "import": "./dist/subpaths/utils/selectorFor.js"

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -624,9 +624,17 @@
       "types": "./dist/subpaths/utils/randomItem.d.ts",
       "import": "./dist/subpaths/utils/randomItem.js"
     },
+    "./utils/SCROLL_ALIGNMENTS": {
+      "types": "./dist/subpaths/utils/SCROLL_ALIGNMENTS.d.ts",
+      "import": "./dist/subpaths/utils/SCROLL_ALIGNMENTS.js"
+    },
     "./utils/SCROLL_AXES": {
       "types": "./dist/subpaths/utils/SCROLL_AXES.d.ts",
       "import": "./dist/subpaths/utils/SCROLL_AXES.js"
+    },
+    "./utils/scrollPosition": {
+      "types": "./dist/subpaths/utils/scrollPosition.d.ts",
+      "import": "./dist/subpaths/utils/scrollPosition.js"
     },
     "./utils/scrollTo": {
       "types": "./dist/subpaths/utils/scrollTo.d.ts",

--- a/packages/v4/src/Base.ts
+++ b/packages/v4/src/Base.ts
@@ -484,8 +484,6 @@ interface OptionReader {
   read(raw: string | null): unknown;
 }
 
-const optionReaders = new WeakMap<Base, Map<string, OptionReader>>();
-
 /** The method name an option's effect is declared under. */
 function optionChangedMethod(name: string): string {
   return `option${capitalize(name)}Changed`;
@@ -618,10 +616,16 @@ export function declaresBoolean(definition: OptionDefinition): boolean {
   return isOptionTypes(type) ? type.includes(Boolean) : type === Boolean;
 }
 
-function buildOptions(instance: Base): Record<string, unknown> {
+/**
+ * The `$options` view and the readers behind it, built in one pass: the getters
+ * and the readers are the same closures seen from two sides.
+ */
+function buildOptions(instance: Base): {
+  options: Record<string, unknown>;
+  readers: Map<string, OptionReader>;
+} {
   const options: Record<string, unknown> = {};
   const readers = new Map<string, OptionReader>();
-  optionReaders.set(instance, readers);
   const el = instance.$el;
   for (const [name, definition] of Object.entries(instance.$config.options ?? {})) {
     const shorthand = isOptionShorthand(definition);
@@ -691,22 +695,17 @@ function buildOptions(instance: Base): Record<string, unknown> {
       get: () => read(rawValue()),
     });
   }
-  return options;
+  return { options, readers };
 }
-
-const resolvedConfigs = new WeakMap<BaseConstructor, BaseConfig>();
 
 /**
  * Merge inherited config. Collections merge; declared scalar values override parent values.
  *
- * The registry uses this before an instance exists.
+ * The registry uses this before an instance exists. Memoised per class: a
+ * config is a pure function of the prototype chain, and `$config` reads it on
+ * every access.
  */
-export function resolveConfig(ctor: BaseConstructor): BaseConfig {
-  const cached = resolvedConfigs.get(ctor);
-  if (cached) {
-    return cached;
-  }
-
+export const resolveConfig = /* @__PURE__ */ memo((ctor: BaseConstructor): BaseConfig => {
   const chain: BaseConfig[] = [];
   let current: BaseConstructor | null = ctor;
   while (current?.config) {
@@ -727,9 +726,8 @@ export function resolveConfig(ctor: BaseConstructor): BaseConfig {
     { name: ctor.name },
   );
 
-  resolvedConfigs.set(ctor, config);
   return config;
-}
+});
 
 /** Reserved handler prefixes for global targets. They take precedence over child and ref names. */
 const GLOBAL_PREFIXES = ['Window', 'Document'] as const;
@@ -908,6 +906,15 @@ export class Base<T extends BaseProps = BaseProps> {
   /** Per-mount-cycle cleanups (service unsubscriptions, `mounted()` return values). */
   #destroyCallbacks: Array<() => void> = [];
 
+  /**
+   * The reader behind each declared option, built with the `$options` view.
+   *
+   * A side table rather than a cache: it holds no computed value, it holds the
+   * other half of what `buildOptions()` produced, so it lives with the
+   * instance like every other piece of its state.
+   */
+  #optionReaders: Map<string, OptionReader>;
+
   /** Cleanup returned by each active `option<Name>Changed()` effect. */
   #optionCleanups = new Map<string, () => void>();
 
@@ -943,7 +950,9 @@ export class Base<T extends BaseProps = BaseProps> {
     el[INSTANCES].set(name, this);
     // Both views resolve on access, so they are built once and stay correct
     // for the instance's whole life.
-    this.$options = buildOptions(this);
+    const built = buildOptions(this);
+    this.$options = built.options;
+    this.#optionReaders = built.readers;
     this.$refs = buildRefs(this);
   }
 
@@ -1216,7 +1225,7 @@ export class Base<T extends BaseProps = BaseProps> {
         ? (changes.get(attributeName) ?? null)
         : this.$el.getAttribute(attributeName);
 
-    for (const [name, reader] of optionReaders.get(this) ?? []) {
+    for (const [name, reader] of this.#optionReaders) {
       // The base attribute is one lookup; any of the scoped spellings may be
       // the one the cascade was selecting, so a miss asks about every changed
       // name before giving up.
@@ -1276,7 +1285,7 @@ export class Base<T extends BaseProps = BaseProps> {
   }
 
   #initializeOptionEffects(cycle: number): void {
-    for (const [name, reader] of optionReaders.get(this) ?? []) {
+    for (const [name, reader] of this.#optionReaders) {
       if (!this.#isActiveMountCycle(cycle)) {
         return;
       }
@@ -1286,7 +1295,7 @@ export class Base<T extends BaseProps = BaseProps> {
 
   /** Subscribe to breakpoint changes for this mount cycle only when an option effect exists. */
   #initializeResponsiveOptions(cycle: number): void {
-    const readers = optionReaders.get(this);
+    const readers = this.#optionReaders;
     if (!readers || readers.size === 0) {
       return;
     }

--- a/packages/v4/src/subpaths/utils/SCROLL_ALIGNMENTS.ts
+++ b/packages/v4/src/subpaths/utils/SCROLL_ALIGNMENTS.ts
@@ -1,0 +1,1 @@
+export { SCROLL_ALIGNMENTS, SCROLL_ALIGNMENTS as default } from '../../utils/scrollTo.js';

--- a/packages/v4/src/subpaths/utils/lockScroll.ts
+++ b/packages/v4/src/subpaths/utils/lockScroll.ts
@@ -1,0 +1,1 @@
+export { lockScroll, lockScroll as default } from '../../utils/scroll-lock.js';

--- a/packages/v4/src/subpaths/utils/scrollPosition.ts
+++ b/packages/v4/src/subpaths/utils/scrollPosition.ts
@@ -1,0 +1,1 @@
+export { scrollPosition, scrollPosition as default } from '../../utils/scrollTo.js';

--- a/packages/v4/src/utils/index.spec.ts
+++ b/packages/v4/src/utils/index.spec.ts
@@ -11,6 +11,7 @@ import * as maths from './maths.js';
 import * as memoModule from './memo.js';
 import * as noopModule from './noop.js';
 import * as randomModule from './random.js';
+import * as scrollLockModule from './scroll-lock.js';
 import * as scrollToModule from './scrollTo.js';
 import * as selectors from './selectors.js';
 import * as smoothToModule from './smoothTo.js';
@@ -34,6 +35,7 @@ describe('the utils barrel', () => {
       ...Object.keys(memoModule),
       ...Object.keys(noopModule),
       ...Object.keys(randomModule),
+      ...Object.keys(scrollLockModule),
       ...Object.keys(scrollToModule),
       ...Object.keys(selectors),
       ...Object.keys(smoothToModule),

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -72,10 +72,14 @@ export { memo, type Memo } from './memo.js';
 export { noop, noopValue } from './noop.js';
 export { random, randomInt, randomItem } from './random.js';
 export {
+  SCROLL_ALIGNMENTS,
   SCROLL_AXES,
+  scrollPosition,
   scrollTo,
+  type ScrollAlign,
   type ScrollAxis,
   type ScrollPosition,
+  type ScrollPositionOptions,
   type ScrollToOptions,
   type ScrollToTarget,
 } from './scrollTo.js';

--- a/packages/v4/src/utils/index.ts
+++ b/packages/v4/src/utils/index.ts
@@ -83,6 +83,7 @@ export {
   type ScrollToOptions,
   type ScrollToTarget,
 } from './scrollTo.js';
+export { lockScroll } from './scroll-lock.js';
 export { selectorFor } from './selectors.js';
 export { smoothTo, type SmoothTo, type SmoothToOptions } from './smoothTo.js';
 export {

--- a/packages/v4/src/utils/scroll-lock.spec.ts
+++ b/packages/v4/src/utils/scroll-lock.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { lockScroll } from './scroll-lock.js';
+
+afterEach(() => {
+  document.documentElement.style.overflow = '';
+  document.body.innerHTML = '';
+});
+
+function scrollable(): HTMLElement {
+  const el = document.createElement('div');
+  el.style.cssText = 'width: 100px; height: 100px; overflow: auto;';
+  document.body.append(el);
+  return el;
+}
+
+describe('lockScroll', () => {
+  it('locks the document element by default and puts it back on release', () => {
+    const release = lockScroll();
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    release();
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('keeps the lock until the last holder releases it', () => {
+    const first = lockScroll();
+    const second = lockScroll();
+
+    // The drawer is still open behind the dialog that just closed.
+    second();
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    first();
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('restores the inline value it found, not an empty one', () => {
+    document.documentElement.style.overflow = 'clip';
+
+    const release = lockScroll();
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    release();
+    expect(document.documentElement.style.overflow).toBe('clip');
+  });
+
+  it('releases once, however many times it is called', () => {
+    const first = lockScroll();
+    const second = lockScroll();
+
+    second();
+    second();
+    second();
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    first();
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('counts each target on its own', () => {
+    const drawer = scrollable();
+    const page = lockScroll();
+    const inner = lockScroll(drawer);
+
+    expect(document.documentElement.style.overflow).toBe('hidden');
+    expect(drawer.style.overflow).toBe('hidden');
+
+    inner();
+    expect(drawer.style.overflow).toBe('auto');
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    page();
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('locks again after the count reached zero', () => {
+    lockScroll()();
+    const release = lockScroll();
+
+    expect(document.documentElement.style.overflow).toBe('hidden');
+    release();
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+});

--- a/packages/v4/src/utils/scroll-lock.ts
+++ b/packages/v4/src/utils/scroll-lock.ts
@@ -1,0 +1,74 @@
+import { getSharedRuntimeSlot } from '../shared-runtime.js';
+
+/** What one target's lock knows: how many holders it has, and what to put back. */
+interface Lock {
+  holders: number;
+  restore: string;
+}
+
+/**
+ * One counter per locked element, shared across evaluated copies of the
+ * package: there is one scroll per document, so two copies must count the same
+ * holders or the second release puts the page back while a surface is still
+ * open.
+ */
+const state = /* @__PURE__ */ getSharedRuntimeSlot('scroll-lock', 1, () => ({
+  locks: new WeakMap<HTMLElement, Lock>(),
+}));
+
+/**
+ * Stop an element scrolling until every holder releases it.
+ *
+ * A modal surface is not alone on the page: a dialog opened from inside a
+ * drawer means two holders, and the one that closes first must not put the
+ * scroll back under the one still open. Counting is the whole point — the
+ * first lock saves the inline value it found, the last release puts exactly
+ * that value back, and the ones in between only move the count.
+ *
+ * The release is idempotent, so a surface may call it on close and again on
+ * destroy without counting twice.
+ *
+ * @param target What stops scrolling. Defaults to the document element.
+ * @returns Release this holder's lock.
+ *
+ * @example
+ * ```js
+ * const release = lockScroll();
+ * // …later, whichever comes first
+ * release();
+ * ```
+ */
+export function lockScroll(target: HTMLElement = document.documentElement): () => void {
+  const lock = state.locks.get(target);
+
+  if (lock) {
+    lock.holders += 1;
+  } else {
+    // Save the inline value rather than assuming it was empty: a page may set
+    // `overflow` for its own reasons, and it owns it again on the last release.
+    state.locks.set(target, { holders: 1, restore: target.style.overflow });
+    target.style.overflow = 'hidden';
+  }
+
+  let isReleased = false;
+
+  return () => {
+    if (isReleased) {
+      return;
+    }
+    isReleased = true;
+
+    const current = state.locks.get(target);
+    if (!current) {
+      return;
+    }
+
+    current.holders -= 1;
+    if (current.holders > 0) {
+      return;
+    }
+
+    state.locks.delete(target);
+    target.style.overflow = current.restore;
+  };
+}

--- a/packages/v4/src/utils/scrollTo.spec.ts
+++ b/packages/v4/src/utils/scrollTo.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cdp } from 'vitest/browser';
 import type {} from '@vitest/browser-playwright';
 import { createElement } from './dom.js';
-import { scrollTo, SCROLL_AXES } from './scrollTo.js';
+import { scrollPosition, scrollTo, SCROLL_AXES } from './scrollTo.js';
 
 /** A page taller and wider than the viewport, with a target inside it. */
 function givenAScrollablePage(): HTMLElement {
@@ -184,5 +184,116 @@ describe('scrollTo', () => {
 
     expect(spy).toHaveBeenCalledWith({ left: 0, top: 100, behavior: 'auto' });
     spy.mockRestore();
+  });
+});
+
+describe('scrollPosition', () => {
+  it('answers where a scroll would land without scrolling', () => {
+    givenAScrollablePage();
+
+    const destination = scrollPosition('#target', { axis: SCROLL_AXES.both });
+
+    expect(destination).toEqual({ left: 1500, top: 2000 });
+    // The measurement half moves nothing: that is the whole point of it.
+    expect(window.scrollY).toBe(0);
+    expect(window.scrollX).toBe(0);
+  });
+
+  it('gives the current position back for a target that is not there', () => {
+    givenAScrollablePage();
+    window.scrollTo({ left: 10, top: 20, behavior: 'instant' });
+
+    expect(scrollPosition('#nothing', { axis: SCROLL_AXES.both })).toEqual({ left: 10, top: 20 });
+  });
+
+  it('agrees with what `scrollTo()` does', () => {
+    const { root, target } = givenAScrollingElement();
+
+    const measured = scrollPosition(target, { rootElement: root, axis: SCROLL_AXES.both });
+    const moved = scrollTo(target, {
+      rootElement: root,
+      axis: SCROLL_AXES.both,
+      behavior: 'instant',
+    });
+
+    expect(measured).toEqual(moved);
+  });
+});
+
+describe('scrollTo — alignment', () => {
+  it('centres an element in its scroller', () => {
+    const { root, target } = givenAScrollingElement();
+
+    const destination = scrollTo(target, {
+      rootElement: root,
+      axis: SCROLL_AXES.both,
+      align: 'center',
+      behavior: 'instant',
+    });
+
+    // The target starts at 700/600 in the content, the scroller shows 200
+    // square — `clientWidth` is the content box, so the borders are already
+    // out — and the target is 50 square: centring backs off (200 - 50) / 2.
+    expect(destination).toEqual({ left: 625, top: 525 });
+  });
+
+  it('rests an element against the end of its scroller', () => {
+    const { root, target } = givenAScrollingElement();
+
+    const destination = scrollTo(target, {
+      rootElement: root,
+      axis: SCROLL_AXES.both,
+      align: 'end',
+      behavior: 'instant',
+    });
+
+    // The whole gap this time: 200 - 50.
+    expect(destination).toEqual({ left: 550, top: 450 });
+  });
+
+  it('takes one alignment per axis', () => {
+    const { root, target } = givenAScrollingElement();
+
+    const destination = scrollTo(target, {
+      rootElement: root,
+      axis: SCROLL_AXES.both,
+      align: { x: 'center' },
+      behavior: 'instant',
+    });
+
+    // `y` was left alone, so it keeps the start alignment.
+    expect(destination).toEqual({ left: 625, top: 600 });
+  });
+
+  it('clamps a centred element at the start of the scroller', () => {
+    const { root } = givenAScrollingElement();
+    const near = createElement('div');
+    near.style.cssText = 'width: 50px; height: 50px; position: absolute; top: 0; left: 0;';
+    root.firstElementChild?.append(near);
+
+    const destination = scrollTo(near, {
+      rootElement: root,
+      axis: SCROLL_AXES.both,
+      align: 'center',
+      behavior: 'instant',
+    });
+
+    // Centring the first item would ask for a negative offset.
+    expect(destination).toEqual({ left: 0, top: 0 });
+  });
+
+  it('leaves a position target alone, since it names its own destination', () => {
+    const { root } = givenAScrollingElement();
+
+    const destination = scrollTo(
+      { left: 100, top: 100 },
+      {
+        rootElement: root,
+        align: 'center',
+        behavior: 'instant',
+      },
+    );
+
+    expect(destination).toEqual({ left: 100, top: 100 });
   });
 });

--- a/packages/v4/src/utils/scrollTo.ts
+++ b/packages/v4/src/utils/scrollTo.ts
@@ -20,13 +20,34 @@ export const SCROLL_AXES = /* @__PURE__ */ Object.freeze({
 
 export type ScrollAxis = (typeof SCROLL_AXES)[keyof typeof SCROLL_AXES];
 
-export interface ScrollToOptions {
+/** Where an element comes to rest inside the scroller. */
+export const SCROLL_ALIGNMENTS = /* @__PURE__ */ Object.freeze({
+  start: 'start',
+  center: 'center',
+  end: 'end',
+} as const);
+
+export type ScrollAlign = (typeof SCROLL_ALIGNMENTS)[keyof typeof SCROLL_ALIGNMENTS];
+
+export interface ScrollPositionOptions {
   /** What scrolls. Defaults to the window. */
   rootElement?: Element | Window;
   /** Which axes a target that names none may move. Defaults to `'y'`. */
   axis?: ScrollAxis;
   /** Pixels to stop short of the target. Defaults to `0`. */
   offset?: number;
+  /**
+   * Where an **element** target comes to rest, per axis. Defaults to `'start'`.
+   *
+   * The names are physical, like `axis`: this is `x` and `y`, not the
+   * platform's `inline` and `block`, because nothing here maps a writing mode.
+   * A number or a position target names its own destination, so it has nothing
+   * to align.
+   */
+  align?: ScrollAlign | { x?: ScrollAlign; y?: ScrollAlign };
+}
+
+export interface ScrollToOptions extends ScrollPositionOptions {
   /** Defaults to `'smooth'`, or to `'instant'` when the reader asked for less motion. */
   behavior?: ScrollBehavior;
 }
@@ -56,6 +77,29 @@ function pixels(value: string): number {
   return Number.parseFloat(value) || 0;
 }
 
+/** What the scroller shows at once, scrollbars excluded on both axes. */
+function viewportOf(root: Element | Window): { width: number; height: number } {
+  return root instanceof Window
+    ? { width: root.innerWidth, height: root.innerHeight }
+    : { width: root.clientWidth, height: root.clientHeight };
+}
+
+/**
+ * How far past the start of the viewport the element rests.
+ *
+ * `start` is zero, which is why a caller that never asks for alignment pays
+ * nothing and reads the same numbers it always did.
+ */
+function alignmentShift(align: ScrollAlign | undefined, viewport: number, size: number): number {
+  if (align === SCROLL_ALIGNMENTS.center) {
+    return (viewport - size) / 2;
+  }
+  if (align === SCROLL_ALIGNMENTS.end) {
+    return viewport - size;
+  }
+  return 0;
+}
+
 /**
  * Where an element sits inside the root's scrolled content.
  *
@@ -66,11 +110,23 @@ function positionOfElement(
   element: Element,
   root: Element | Window,
   current: ScrollPosition,
+  align: ScrollPositionOptions['align'],
 ): ScrollPosition {
   const rect = element.getBoundingClientRect();
   const styles = getComputedStyle(element);
-  let left = rect.left + current.left - pixels(styles.scrollMarginLeft);
-  let top = rect.top + current.top - pixels(styles.scrollMarginTop);
+  const viewport = viewportOf(root);
+  const alignX = isString(align) ? align : align?.x;
+  const alignY = isString(align) ? align : align?.y;
+  let left =
+    rect.left +
+    current.left -
+    pixels(styles.scrollMarginLeft) -
+    alignmentShift(alignX, viewport.width, rect.width);
+  let top =
+    rect.top +
+    current.top -
+    pixels(styles.scrollMarginTop) -
+    alignmentShift(alignY, viewport.height, rect.height);
 
   if (!(root instanceof Window)) {
     // A viewport coordinate is not a content coordinate for a scrolling
@@ -90,6 +146,7 @@ function requestedPosition(
   root: Element | Window,
   current: ScrollPosition,
   axis: ScrollAxis,
+  align: ScrollPositionOptions['align'],
 ): Partial<ScrollPosition> | null {
   // A position object names its own axes, so `axis` has nothing left to pick.
   if (!isString(target) && !isNumber(target) && !(target instanceof Element)) {
@@ -105,7 +162,7 @@ function requestedPosition(
     if (!element) {
       return null;
     }
-    position = positionOfElement(element, root, current);
+    position = positionOfElement(element, root, current, align);
   }
 
   if (axis === SCROLL_AXES.x) {
@@ -115,6 +172,40 @@ function requestedPosition(
     return { top: position.top };
   }
   return position;
+}
+
+/**
+ * Where a scroll would land, without scrolling.
+ *
+ * The measurement half of {@link scrollTo}, split out because a caller often
+ * needs the number rather than the move: which slide is nearest, how far a
+ * control has to travel, whether the destination is where the scroller
+ * already stands. A target the document does not contain gives the current
+ * position back, so the answer is always a position.
+ *
+ * @example
+ * ```js
+ * const { left } = scrollPosition(slide, { rootElement: track, axis: 'x', align: 'center' });
+ * ```
+ */
+export function scrollPosition(
+  target: ScrollToTarget,
+  options: ScrollPositionOptions = {},
+): ScrollPosition {
+  const { rootElement = window, axis = SCROLL_AXES.y, offset = 0, align } = options;
+
+  const current = currentPositionOf(rootElement);
+  const requested = requestedPosition(target, rootElement, current, axis, align);
+
+  if (!requested) {
+    return current;
+  }
+
+  const max = maxPositionOf(rootElement);
+  return {
+    left: requested.left === undefined ? current.left : clamp(requested.left - offset, 0, max.left),
+    top: requested.top === undefined ? current.top : clamp(requested.top - offset, 0, max.top),
+  };
 }
 
 /**
@@ -129,23 +220,12 @@ function requestedPosition(
  * ```js
  * scrollTo('#section', { offset: 80 });
  * scrollTo({ left: 0 }, { rootElement: carousel });
+ * scrollTo(slide, { rootElement: track, axis: 'x', align: 'center' });
  * ```
  */
 export function scrollTo(target: ScrollToTarget, options: ScrollToOptions = {}): ScrollPosition {
-  const { rootElement = window, axis = SCROLL_AXES.y, offset = 0, behavior } = options;
-
-  const current = currentPositionOf(rootElement);
-  const requested = requestedPosition(target, rootElement, current, axis);
-
-  if (!requested) {
-    return current;
-  }
-
-  const max = maxPositionOf(rootElement);
-  const destination: ScrollPosition = {
-    left: requested.left === undefined ? current.left : clamp(requested.left - offset, 0, max.left),
-    top: requested.top === undefined ? current.top : clamp(requested.top - offset, 0, max.top),
-  };
+  const { rootElement = window, behavior } = options;
+  const destination = scrollPosition(target, options);
 
   rootElement.scrollTo({
     ...destination,


### PR DESCRIPTION
Item 3 of the investigation round: **K4**, **C10** and **F1**, one commit each. They are independent of one another; each has its written consumer in `migration/`.

## K4 — `scrollTo` gains an alignment, and a measuring half (gap 37)

`scrollTo()` aligned a target to the **start** of its scroller, so the ported `Carousel` carried twelve lines of centring arithmetic replacing the `compute-scroll-into-view` dependency v3 uses.

- **`align: 'start' | 'center' | 'end'`**, or one per axis, for an element target. The names are physical like `axis` — `x`/`y`, not the platform's `inline`/`block` — because nothing here maps a writing mode, and borrowing that vocabulary without the mapping would promise what the dependency promises and does not deliver: its own source leaves writing modes unimplemented and reads no `scroll-padding`.
- **`scrollPosition()` is the other half of the gap.** Measuring and moving were one function, so a carousel asking which slide is nearest had to scroll to find out. A spec pins that the two agree.
- The viewport is the client box, so a scrollbar gutter is out of the arithmetic with no special case, and the destination is still clamped — centring the first slide asks for a negative offset and gets `0`.

**The dependency was measured before being refused:** 1.4 kB, no runtime deps, 8.8M weekly downloads, but its headline feature is a walk of every scrolling ancestor — what v4's single `rootElement` contract declines and what ui already cancels with `boundary`. Real delta over core: ~20 lines.

`Carousel` deletes `centeredScrollPosition()` and its spec asserts the coordinator's own positions.

## C10 — `memo()` over `resolveConfig`, and a field for the option readers

The two halves wanted opposite treatments. `resolveConfig()` is exactly `memo()`'s shape and now uses it. **`optionReaders` is not a cache**: nothing computes it, `buildOptions()` writes it as a side effect while returning something else — so it becomes a private field, which is where the instance keeps its other state.

Not a performance change, and the measurement says so: over 5M hits the hand-rolled `get()` runs at ~24 ns and `memo()` at ~39 ns. Break-even would be ~66,000 calls per lost millisecond. This is consistency and five fewer lines.

## F1 — `lockScroll()` counts its holders

Two modal surfaces on one page fought over one style property: opening a dialog from inside a drawer and closing the dialog gave the page its scroll back **under the still-open drawer** — live in ui 1.10.0 today. Neither released on destroy, so a surface destroyed while open leaked the lock for the life of the page.

The first lock saves the inline value it found, the last release restores exactly that, and the release is idempotent so a surface calls it on close *and* on destroy. The count lives in the runtime slot for the reason `focus.ts` states about itself: there is one scroll per document. No `paddingRight` compensation — `scrollbar-gutter: stable` is the page's own answer.

`<dialog>`'s `showModal()` gives the top layer, backdrop, focus trap and Escape — it does **not** stop the page behind it scrolling, so this item is not obsolete.

## Verification

- `npm run test:v4` — 89 files, **1382 passed**, exit 0, no `Errors` line
- `npm run lint`, `lint:types`, `check:package`, `check:constant-subpaths` — clean
- `DESIGN.md` §9 documents both new utilities; subpaths regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nNdFD3aQhzfdm3EsCSbS9